### PR TITLE
"Open Map Scripts" button

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -20,6 +20,7 @@
 #include <QDialogButtonBox>
 #include <QProcess>
 #include <QSysInfo>
+#include <QDesktopServices>
 
 MainWindow::MainWindow(QWidget *parent) :
     QMainWindow(parent),
@@ -554,28 +555,8 @@ void MainWindow::redo() {
 
 // Open current map scripts in system default editor for .inc files
 void MainWindow::openInTextEditor() {
-    QProcess *process = new QProcess(this);
-    QSysInfo sysInfo;
-    process->setWorkingDirectory(editor->project->root);
-
-    #ifdef Q_OS_DARWIN
-        QString cmd = "open ";
-    #elif defined Q_OS_LINUX
-        QString cmd = "xdg-open ";
-    #elif defined Q_OS_WIN 
-        QString cmd = "cmd /c start \"";
-    #else
-        qDebug() << "Functionality is not available with this OS ("
-                 << sysInfo.productType() << ")";
-    #endif
-
-    cmd += "data/maps/" + editor->map->name + "/scripts.inc";
-
-    #ifdef Q_OS_WIN
-        cmd += "\"";
-    #endif
-
-    process->start(cmd);
+    QString path = QDir::cleanPath(editor->project->root + QDir::separator() + "data/maps/" + editor->map->name + "/scripts.inc");
+    QDesktopServices::openUrl(QUrl(path));
 }
 
 void MainWindow::on_action_Save_triggered() {

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -15,8 +15,11 @@
 #include <QSpacerItem>
 #include <QFont>
 #include <QScrollBar>
+#include <QPushButton>
 #include <QMessageBox>
 #include <QDialogButtonBox>
+#include <QProcess>
+#include <QSysInfo>
 
 MainWindow::MainWindow(QWidget *parent) :
     QMainWindow(parent),
@@ -549,6 +552,32 @@ void MainWindow::redo() {
     editor->redo();
 }
 
+// Open current map scripts in system default editor for .inc files
+void MainWindow::openInTextEditor() {
+    QProcess *process = new QProcess(this);
+    QSysInfo sysInfo;
+    process->setWorkingDirectory(editor->project->root);
+
+    #ifdef Q_OS_DARWIN
+        QString cmd = "open ";
+    #elif defined Q_OS_LINUX
+        QString cmd = "xdg-open ";
+    #elif defined Q_OS_WIN 
+        QString cmd = "cmd /c start \"";
+    #else
+        qDebug() << "Functionality is not available with this OS ("
+                 << sysInfo.productType() << ")";
+    #endif
+
+    cmd += "data/maps/" + editor->map->name + "/scripts.inc";
+
+    #ifdef Q_OS_WIN
+        cmd += "\"";
+    #endif
+
+    process->start(cmd);
+}
+
 void MainWindow::on_action_Save_triggered() {
     editor->save();
     updateMapList();
@@ -871,6 +900,11 @@ void MainWindow::on_toolButton_deleteObject_clicked()
             updateSelectedObjects();
         }
     }
+}
+
+void MainWindow::on_toolButton_Open_Scripts_clicked()
+{
+    openInTextEditor();
 }
 
 void MainWindow::on_toolButton_Paint_clicked()

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -555,7 +555,7 @@ void MainWindow::redo() {
 
 // Open current map scripts in system default editor for .inc files
 void MainWindow::openInTextEditor() {
-    QString path = QDir::cleanPath(editor->project->root + QDir::separator() + "data/maps/" + editor->map->name + "/scripts.inc");
+    QString path = QDir::cleanPath("file://" + editor->project->root + QDir::separator() + "data/maps/" + editor->map->name + "/scripts.inc");
     QDesktopServices::openUrl(QUrl(path));
 }
 

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -37,6 +37,8 @@ private slots:
     void undo();
     void redo();
 
+    void openInTextEditor();
+
     void onLoadMapRequested(QString, QString);
     void onMapChanged(Map *map);
     void onMapNeedsRedrawing(Map *map);
@@ -59,6 +61,7 @@ private slots:
     void on_actionRedo_triggered();
 
     void on_toolButton_deleteObject_clicked();
+    void on_toolButton_Open_Scripts_clicked();
 
     void addNewEvent(QString);
     void updateSelectedObjects();

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -334,8 +334,8 @@
                     <rect>
                      <x>0</x>
                      <y>0</y>
-                     <width>429</width>
-                     <height>620</height>
+                     <width>462</width>
+                     <height>599</height>
                     </rect>
                    </property>
                    <layout class="QGridLayout" name="gridLayout_8">
@@ -708,7 +708,7 @@
                         <rect>
                          <x>0</x>
                          <y>0</y>
-                         <width>315</width>
+                         <width>252</width>
                          <height>86</height>
                         </rect>
                        </property>
@@ -812,10 +812,10 @@
                     </property>
                     <property name="geometry">
                      <rect>
-                      <x>0</x>
+                      <x>8</x>
                       <y>0</y>
-                      <width>365</width>
-                      <height>405</height>
+                      <width>323</width>
+                      <height>368</height>
                      </rect>
                     </property>
                     <property name="sizePolicy">
@@ -1050,8 +1050,8 @@
               <rect>
                <x>0</x>
                <y>0</y>
-               <width>381</width>
-               <height>657</height>
+               <width>371</width>
+               <height>643</height>
               </rect>
              </property>
              <layout class="QGridLayout" name="gridLayout_7">
@@ -1216,8 +1216,8 @@
                        <rect>
                         <x>0</x>
                         <y>0</y>
-                        <width>420</width>
-                        <height>584</height>
+                        <width>410</width>
+                        <height>560</height>
                        </rect>
                       </property>
                       <property name="sizePolicy">
@@ -1325,6 +1325,29 @@
                   <property name="sizeHint" stdset="0">
                    <size>
                     <width>40</width>
+                    <height>20</height>
+                   </size>
+                  </property>
+                 </spacer>
+                </item>
+                <item>
+                 <widget class="QToolButton" name="toolButton_Open_Scripts">
+                  <property name="text">
+                   <string>Open Map Scripts</string>
+                  </property>
+                  <property name="autoRaise">
+                   <bool>false</bool>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <spacer name="horizontalSpacer_20">
+                  <property name="orientation">
+                   <enum>Qt::Horizontal</enum>
+                  </property>
+                  <property name="sizeHint" stdset="0">
+                   <size>
+                    <width>20</width>
                     <height>20</height>
                    </size>
                   </property>
@@ -1849,8 +1872,8 @@
                    <rect>
                     <x>0</x>
                     <y>0</y>
-                    <width>826</width>
-                    <height>557</height>
+                    <width>818</width>
+                    <height>539</height>
                    </rect>
                   </property>
                   <layout class="QGridLayout" name="gridLayout_14">
@@ -2022,7 +2045,7 @@
      <x>0</x>
      <y>0</y>
      <width>1117</width>
-     <height>21</height>
+     <height>22</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuFile">


### PR DESCRIPTION
(copy of [https://github.com/yenatch/pretmap/pull/70](https://github.com/yenatch/pretmap/pull/70))

Adds a button to open a map's scripts in a the system default text editor.

Should close Issue #4 

demo:
[![Alt text](https://img.youtube.com/vi/qFW7L9HFJNg/0.jpg)](https://www.youtube.com/watch?v=qFW7L9HFJNg)