### PR TITLE
Add installation instructions and fix compile issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@ porymap.pro.user
 moc_*
 qrc_*
 porymap.app*
+porymap
 Makefile
-ui_mainwindow.h
-ui_objectpropertiesframe.h
+
+# Generated UI header
+ui_*.h
+

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,0 +1,15 @@
+# Installation
+
+porymap requires Qt 5 & C++11.
+
+## Ubuntu
+
+You need to install Qt 5. Qt 5.5 should be enough. You can check you Qt version
+with `qtdiag`.
+
+```
+sudo apt-get install qt5-default
+qmake
+make
+./porymap
+```

--- a/porymap.pro
+++ b/porymap.pro
@@ -12,7 +12,7 @@ TARGET = porymap
 TEMPLATE = app
 RC_ICONS = resources/icons/porymap-icon-1.ico
 ICON = resources/icons/porymap-icon-1.ico
-
+QMAKE_CXXFLAGS += -std=c++11
 
 SOURCES += src/core/block.cpp \
     src/core/blockdata.cpp \

--- a/src/core/parseutil.cpp
+++ b/src/core/parseutil.cpp
@@ -77,7 +77,7 @@ QList<HealLocation>* ParseUtil::parseHealLocs(QString text) {
     int i = 1;
     for (auto line : lines){
         if (line.contains("MAP_GROUP")){
-            QList<QString> li = line.replace(" ","").chopped(2).remove('{').split(',');
+            QList<QString> li = line.remove(QRegExp("[{|} ]")).split(",");
             HealLocation hloc = HealLocation(li[1].remove("MAP_NUM(").remove(")"), i, li[2].toUShort(), li[3].toUShort());
             parsed->append(hloc);
             i++;

--- a/src/ui/tileseteditor.cpp
+++ b/src/ui/tileseteditor.cpp
@@ -5,6 +5,7 @@
 #include <QDebug>
 #include <QMessageBox>
 #include <QDialogButtonBox>
+#include <QCloseEvent>
 
 TilesetEditor::TilesetEditor(Project *project, QString primaryTilesetLabel, QString secondaryTilesetLabel, QWidget *parent) :
     QMainWindow(parent),


### PR DESCRIPTION
By changing the call to QString#chopped to QString#left, we remove the
Qt 10 dependency.

I also changed the C++ version to C++11 as that's what the code is
using my compiler (and others) didn't default to it.

Ref #2