### PR TITLE
Add a way to name metatiles, for use in c code

### DIFF
--- a/forms/tileseteditor.ui
+++ b/forms/tileseteditor.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>700</width>
-    <height>600</height>
+    <height>700</height>
    </rect>
   </property>
   <property name="focusPolicy">
@@ -198,6 +198,16 @@
              <bool>false</bool>
             </property>
             <layout class="QGridLayout" name="gridLayout_3">
+             <item row="4" column="0" colspan="3">
+              <widget class="QLabel" name="label_8">
+               <property name="text">
+                <string>Metatile Label (Optional)</string>
+               </property>
+              </widget>
+             </item>
+             <item row="5" column="0" colspan="3">
+              <widget class="QLineEdit" name="lineEdit_metatileLabel"/>
+             </item>
              <item row="2" column="0" colspan="3">
               <widget class="QLabel" name="label_5">
                <property name="text">

--- a/include/core/metatile.h
+++ b/include/core/metatile.h
@@ -3,6 +3,7 @@
 
 #include "tile.h"
 #include <QImage>
+#include <QString>
 
 class Metatile
 {
@@ -12,6 +13,7 @@ public:
     QList<Tile> *tiles = nullptr;
     uint8_t behavior;
     uint8_t layerType;
+    QString label;
 
     Metatile *copy();
     void copyInPlace(Metatile*);

--- a/include/project.h
+++ b/include/project.h
@@ -78,6 +78,7 @@ public:
     void loadTilesetAssets(Tileset*);
     void loadTilesetTiles(Tileset*, QImage);
     void loadTilesetMetatiles(Tileset*);
+    void loadTilesetMetatileLabels(Tileset*);
 
     void saveLayoutBlockdata(Map*);
     void saveLayoutBorder(Map*);
@@ -90,6 +91,7 @@ public:
     void saveMapConstantsHeader();
     void saveHealLocationStruct(Map*);
     void saveTilesets(Tileset*, Tileset*);
+    void saveTilesetMetatileLabels(Tileset*, Tileset*);
     void saveTilesetMetatileAttributes(Tileset*);
     void saveTilesetMetatiles(Tileset*);
     void saveTilesetTilesImage(Tileset*);

--- a/include/ui/tileseteditor.h
+++ b/include/ui/tileseteditor.h
@@ -95,6 +95,7 @@ private:
     void importTilesetTiles(Tileset*, bool);
     void importTilesetMetatiles(Tileset*, bool);
     void refresh();
+    void saveMetatileLabel();
     Ui::TilesetEditor *ui;
     History<MetatileHistoryItem*> metatileHistory;
     TilesetEditorMetatileSelector *metatileSelector = nullptr;

--- a/include/ui/tileseteditor.h
+++ b/include/ui/tileseteditor.h
@@ -73,6 +73,8 @@ private slots:
 
     void on_comboBox_metatileBehaviors_activated(const QString &arg1);
 
+    void on_lineEdit_metatileLabel_editingFinished();
+
     void on_comboBox_layerType_activated(int arg1);
 
     void on_actionExport_Primary_Tiles_Image_triggered();

--- a/src/core/metatile.cpp
+++ b/src/core/metatile.cpp
@@ -12,6 +12,7 @@ Metatile* Metatile::copy() {
     copy->behavior = this->behavior;
     copy->layerType = this->layerType;
     copy->tiles = new QList<Tile>;
+    copy->label = this->label;
     for (Tile tile : *this->tiles) {
         copy->tiles->append(tile);
     }
@@ -21,6 +22,7 @@ Metatile* Metatile::copy() {
 void Metatile::copyInPlace(Metatile *other) {
     this->behavior = other->behavior;
     this->layerType = other->layerType;
+    this->label = other->label;
     for (int i = 0; i < this->tiles->length(); i++) {
         (*this->tiles)[i] = other->tiles->at(i);
     }

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -348,8 +348,14 @@ void Editor::onHoveredMovementPermissionCleared() {
 }
 
 void Editor::onHoveredMetatileSelectionChanged(uint16_t metatileId) {
-    QString message = QString("Metatile: 0x%1")
-                        .arg(QString("%1").arg(metatileId, 3, 16, QChar('0')).toUpper());
+    Metatile *metatile = Tileset::getMetatile(metatileId, map->layout->tileset_primary, map->layout->tileset_secondary);
+    QString message;
+    QString hexString = QString("%1").arg(metatileId, 3, 16, QChar('0')).toUpper();
+    if (metatile && metatile->label.size() != 0) {
+        message = QString("Metatile: 0x%1 \"%2\"").arg(hexString, metatile->label);
+    } else {
+        message = QString("Metatile: 0x%1").arg(hexString);
+    }
     this->ui->statusBar->showMessage(message);
 }
 

--- a/src/project.cpp
+++ b/src/project.cpp
@@ -670,6 +670,7 @@ void Project::saveHealLocationStruct(Map *map) {
 }
 
 void Project::saveTilesets(Tileset *primaryTileset, Tileset *secondaryTileset) {
+    saveTilesetMetatileLabels(primaryTileset, secondaryTileset);
     saveTilesetMetatileAttributes(primaryTileset);
     saveTilesetMetatileAttributes(secondaryTileset);
     saveTilesetMetatiles(primaryTileset);
@@ -678,6 +679,77 @@ void Project::saveTilesets(Tileset *primaryTileset, Tileset *secondaryTileset) {
     saveTilesetTilesImage(secondaryTileset);
     saveTilesetPalettes(primaryTileset, true);
     saveTilesetPalettes(secondaryTileset, false);
+}
+
+void Project::saveTilesetMetatileLabels(Tileset *primaryTileset, Tileset *secondaryTileset) {
+    QString filepath = root + "/include/constants/metatile_labels.h";
+    QString originalText = readTextFile(filepath);
+
+    QString primaryPrefix = QString("METATILE_%1_").arg(QString(primaryTileset->name).replace("gTileset_", ""));
+    QString secondaryPrefix = QString("METATILE_%1_").arg(QString(secondaryTileset->name).replace("gTileset_", ""));
+
+    QMap<QString, int> defines;
+    bool definesFileModified = false;
+    if (!originalText.isNull()) {
+        defines = readCDefines(originalText, (QStringList() << "METATILE_"));
+
+        // Purge old entries from the file.
+        QStringList definesToRemove;
+        for (QString defineName : defines.keys()) {
+            if (defineName.startsWith(primaryPrefix) || defineName.startsWith(secondaryPrefix)) {
+                definesToRemove << defineName;
+            }
+        }
+        for (QString defineName : definesToRemove) {
+            defines.remove(defineName);
+            definesFileModified = true;
+        }
+    }
+
+    // Add the new labels.
+    for (int i = 0; i < primaryTileset->metatiles->size(); i++) {
+        Metatile *metatile = primaryTileset->metatiles->at(i);
+        if (metatile->label.size() != 0) {
+            QString defineName = QString("%1%2").arg(primaryPrefix, metatile->label);
+            defines.insert(defineName, i);
+            definesFileModified = true;
+        }
+    }
+    for (int i = 0; i < secondaryTileset->metatiles->size(); i++) {
+        Metatile *metatile = secondaryTileset->metatiles->at(i);
+        if (metatile->label.size() != 0) {
+            QString defineName = QString("%1%2").arg(secondaryPrefix, metatile->label);
+            defines.insert(defineName, i);
+            definesFileModified = true;
+        }
+    }
+
+    if (!definesFileModified) {
+        return;
+    }
+
+    // Setup pretty formatting.
+    int longestDefineNameLength = 0;
+    for (QString defineName : defines.keys()) {
+        if (defineName.size() > longestDefineNameLength) {
+            longestDefineNameLength = defineName.size();
+        }
+    }
+
+    // Write the file.
+    QString outputText = "#ifndef GUARD_METATILE_LABELS_H\n";
+    outputText += "#define GUARD_METATILE_LABELS_H\n\n";
+
+    for (QString defineName : defines.keys()) {
+        int value = defines[defineName];
+        QString line = QString("#define %1  0x%2\n")
+            .arg(defineName, -1 * longestDefineNameLength)
+            .arg(QString("%1").arg(value, 3, 16, QChar('0')).toUpper());
+        outputText += line;
+    }
+
+    outputText += "\n#endif // GUARD_METATILE_LABELS_H\n";
+    saveTextFile(filepath, outputText);
 }
 
 void Project::saveTilesetMetatileAttributes(Tileset *tileset) {
@@ -1098,6 +1170,7 @@ void Project::loadTilesetAssets(Tileset* tileset) {
     QImage image = QImage(tileset->tilesImagePath);
     this->loadTilesetTiles(tileset, image);
     this->loadTilesetMetatiles(tileset);
+    this->loadTilesetMetatileLabels(tileset);
 
     // palettes
     QList<QList<QRgb>> *palettes = new QList<QList<QRgb>>;
@@ -1197,6 +1270,29 @@ void Project::loadTilesetMetatiles(Tileset* tileset) {
         }
     } else {
         logError(QString("Could not open tileset metatile attributes file '%1'").arg(tileset->metatile_attrs_path));
+    }
+}
+
+void Project::loadTilesetMetatileLabels(Tileset* tileset) {
+    QString filepath = root + "/include/constants/metatile_labels.h";
+    QString text = readTextFile(filepath);
+
+    if (!text.isNull()) {
+        QString tilesetPrefix = QString("METATILE_%1_").arg(QString(tileset->name).replace("gTileset_", ""));
+        QMap<QString, int> labels = readCDefines(text, QStringList() << tilesetPrefix);
+
+        for (QString labelName : labels.keys()) {
+            int metatileId = labels[labelName];
+            Metatile *metatile = Tileset::getMetatile(metatileId, tileset, nullptr);
+            if (metatile) {
+                metatile->label = labelName.replace(tilesetPrefix, "");
+            } else {
+                QString hexString = QString("%1").arg(metatileId, 3, 16, QChar('0')).toUpper();
+                logError(QString("Metatile 0x%1 cannot be found in tileset '%2'").arg(hexString, tileset->name));
+            }
+        }
+    } else {
+        logError(QString("Failed to read C defines file: '%1'").arg(filepath));
     }
 }
 

--- a/src/ui/tileseteditor.cpp
+++ b/src/ui/tileseteditor.cpp
@@ -324,7 +324,8 @@ void TilesetEditor::on_lineEdit_metatileLabel_editingFinished()
 
 void TilesetEditor::saveMetatileLabel()
 {
-    if (this->metatile) {
+    // Only commit if the field has changed.
+    if (this->metatile && this->metatile->label != this->ui->lineEdit_metatileLabel->text()) {
         Metatile *prevMetatile = this->metatile->copy();
         this->metatile->label = this->ui->lineEdit_metatileLabel->text();
         MetatileHistoryItem *commit = new MetatileHistoryItem(metatileSelector->getSelectedMetatile(), prevMetatile, this->metatile->copy());
@@ -344,11 +345,7 @@ void TilesetEditor::on_comboBox_layerType_activated(int layerType)
 
 void TilesetEditor::on_actionSave_Tileset_triggered()
 {
-    if (this->metatile) {
-        if (this->metatile->label != this->ui->lineEdit_metatileLabel->text()) {
-            saveMetatileLabel();
-        }
-    }
+    saveMetatileLabel();
 
     this->project->saveTilesets(this->primaryTileset, this->secondaryTileset);
     emit this->tilesetsSaved(this->primaryTileset->name, this->secondaryTileset->name);

--- a/src/ui/tileseteditor.cpp
+++ b/src/ui/tileseteditor.cpp
@@ -319,6 +319,11 @@ void TilesetEditor::on_comboBox_metatileBehaviors_activated(const QString &metat
 
 void TilesetEditor::on_lineEdit_metatileLabel_editingFinished()
 {
+    saveMetatileLabel();
+}
+
+void TilesetEditor::saveMetatileLabel()
+{
     if (this->metatile) {
         Metatile *prevMetatile = this->metatile->copy();
         this->metatile->label = this->ui->lineEdit_metatileLabel->text();
@@ -339,6 +344,12 @@ void TilesetEditor::on_comboBox_layerType_activated(int layerType)
 
 void TilesetEditor::on_actionSave_Tileset_triggered()
 {
+    if (this->metatile) {
+        if (this->metatile->label != this->ui->lineEdit_metatileLabel->text()) {
+            saveMetatileLabel();
+        }
+    }
+
     this->project->saveTilesets(this->primaryTileset, this->secondaryTileset);
     emit this->tilesetsSaved(this->primaryTileset->name, this->secondaryTileset->name);
     if (this->paletteEditor) {

--- a/src/ui/tileseteditor.cpp
+++ b/src/ui/tileseteditor.cpp
@@ -61,6 +61,11 @@ void TilesetEditor::init(Project *project, QString primaryTilesetLabel, QString 
     this->ui->spinBox_paletteSelector->setMinimum(0);
     this->ui->spinBox_paletteSelector->setMaximum(Project::getNumPalettesTotal() - 1);
 
+    //only allow characters valid for a symbol
+    QRegExp expression("[-_.A-Za-z0-9]+$");
+    QRegExpValidator *validator = new QRegExpValidator(expression);
+    this->ui->lineEdit_metatileLabel->setValidator(validator);
+
     this->initMetatileSelector();
     this->initMetatileLayersItem();
     this->initTileSelector();
@@ -179,8 +184,14 @@ void TilesetEditor::initMetatileLayersItem() {
 }
 
 void TilesetEditor::onHoveredMetatileChanged(uint16_t metatileId) {
-    QString message = QString("Metatile: 0x%1")
-                        .arg(QString("%1").arg(metatileId, 3, 16, QChar('0')).toUpper());
+    Metatile *metatile = Tileset::getMetatile(metatileId, this->primaryTileset, this->secondaryTileset);
+    QString message;
+    QString hexString = QString("%1").arg(metatileId, 3, 16, QChar('0')).toUpper();
+    if (metatile && metatile->label.size() != 0) {
+        message = QString("Metatile: 0x%1 \"%2\"").arg(hexString, metatile->label);
+    } else {
+        message = QString("Metatile: 0x%1").arg(hexString);
+    }
     this->ui->statusbar->showMessage(message);
 }
 
@@ -193,6 +204,7 @@ void TilesetEditor::onSelectedMetatileChanged(uint16_t metatileId) {
     this->metatileLayersItem->setMetatile(metatile);
     this->metatileLayersItem->draw();
     this->ui->comboBox_metatileBehaviors->setCurrentIndex(this->ui->comboBox_metatileBehaviors->findData(this->metatile->behavior));
+    this->ui->lineEdit_metatileLabel->setText(this->metatile->label);
     this->ui->comboBox_layerType->setCurrentIndex(this->ui->comboBox_layerType->findData(this->metatile->layerType));
 }
 
@@ -300,6 +312,16 @@ void TilesetEditor::on_comboBox_metatileBehaviors_activated(const QString &metat
     if (this->metatile) {
         Metatile *prevMetatile = this->metatile->copy();
         this->metatile->behavior = static_cast<uint8_t>(project->metatileBehaviorMap[metatileBehavior]);
+        MetatileHistoryItem *commit = new MetatileHistoryItem(metatileSelector->getSelectedMetatile(), prevMetatile, this->metatile->copy());
+        metatileHistory.push(commit);
+    }
+}
+
+void TilesetEditor::on_lineEdit_metatileLabel_editingFinished()
+{
+    if (this->metatile) {
+        Metatile *prevMetatile = this->metatile->copy();
+        this->metatile->label = this->ui->lineEdit_metatileLabel->text();
         MetatileHistoryItem *commit = new MetatileHistoryItem(metatileSelector->getSelectedMetatile(), prevMetatile, this->metatile->copy());
         metatileHistory.push(commit);
     }
@@ -668,7 +690,7 @@ void TilesetEditor::importTilesetMetatiles(Tileset *tileset, bool primary)
         msgBox.exec();
         return;
     }
-\
+
     // TODO: This is crude because it makes a history entry for every newly-imported metatile.
     //       Revisit this when tiles and num metatiles are added to tileset editory history.
     int metatileIdBase = primary ? 0 : Project::getNumMetatilesPrimary();

--- a/src/ui/tileseteditor.cpp
+++ b/src/ui/tileseteditor.cpp
@@ -62,7 +62,7 @@ void TilesetEditor::init(Project *project, QString primaryTilesetLabel, QString 
     this->ui->spinBox_paletteSelector->setMaximum(Project::getNumPalettesTotal() - 1);
 
     //only allow characters valid for a symbol
-    QRegExp expression("[-_.A-Za-z0-9]+$");
+    QRegExp expression("[_A-Za-z0-9]*$");
     QRegExpValidator *validator = new QRegExpValidator(expression);
     this->ui->lineEdit_metatileLabel->setValidator(validator);
 


### PR DESCRIPTION
Metatiles can be given a name. The name becomes a constant in
includes/contstants/metatile_labels.h.

The plan is to be able to reference metatiles in code using a macro
like `METATILE(Building, TV_ON, Primary)`, which will evaluate to the
value 0x003, or `METATILE(BrendansMaysHouse, MOVING_BOX_OPEN, Secondary)`,
which will evaluate to the value 0x270.

I'm open to suggestions on this PR, but I think there should definitely be a way to make a constant for a metatile. There are a lot of raw metatile values in C code. This implementation lets us pick and choose which ones need constants, and to do so in a way that's modder-friendly and not fragile.