### PR TITLE
Don't Crash When Reading Bad Defines

### DIFF
--- a/include/core/parseutil.h
+++ b/include/core/parseutil.h
@@ -7,34 +7,12 @@
 #include <QString>
 #include <QList>
 #include <QMap>
+#include <QRegularExpression>
 
 enum TokenType {
     Number,
     Operator,
     Error,
-};
-
-class DebugInfo {
-public:
-    DebugInfo(QString file, QStringList lines) {
-        this->file = file;
-        this->lines = lines;
-    };
-    QString file;
-    int     line;
-    bool    err;
-    QStringList lines;
-    void error(QString expression, QString token) {
-        int lineNo = 0;
-        for (QString line_ : lines) {
-            lineNo++;
-            if (line_.contains(expression)) {
-                this->line = lineNo;
-                break;
-            }
-        }
-        logError(QString("%1:%2: unknown identifier found in expression: '%3'.").arg(file).arg(line).arg(token));
-    }
 };
 
 class Token {
@@ -60,15 +38,29 @@ public:
 class ParseUtil
 {
 public:
-    ParseUtil(QString, QString);
+    ParseUtil();
+    void set_root(QString);
+    QString readTextFile(QString);
     void strip_comment(QString*);
     QList<QStringList>* parseAsm(QString);
     int evaluateDefine(QString, QMap<QString, int>*);
-    DebugInfo *debug;
+    QStringList readCArray(QString text, QString label);
+    QMap<QString, QString> readNamedIndexCArray(QString text, QString label);
+    QString readCIncbin(QString text, QString label);
+    QMap<QString, int> readCDefines(QString filename, QStringList prefixes);
+    void readCDefinesSorted(QString, QStringList, QStringList*);
+    QList<QStringList>* getLabelMacros(QList<QStringList>*, QString);
+    QStringList* getLabelValues(QList<QStringList>*, QString);
+    bool tryParseJsonFile(QJsonDocument *out, QString filepath);
+
 private:
+    QString root;
+    QString text;
+    QString file;
     QList<Token> tokenizeExpression(QString expression, QMap<QString, int>* knownIdentifiers);
     QList<Token> generatePostfix(QList<Token> tokens);
     int evaluatePostfix(QList<Token> postfix);
+    void error(QString message, QString expression);
 };
 
 #endif // PARSEUTIL_H

--- a/include/core/parseutil.h
+++ b/include/core/parseutil.h
@@ -2,6 +2,7 @@
 #define PARSEUTIL_H
 
 #include "heallocation.h"
+#include "log.h"
 
 #include <QString>
 #include <QList>
@@ -10,6 +11,30 @@
 enum TokenType {
     Number,
     Operator,
+    Error,
+};
+
+class DebugInfo {
+public:
+    DebugInfo(QString file, QStringList lines) {
+        this->file = file;
+        this->lines = lines;
+    };
+    QString file;
+    int     line;
+    bool    err;
+    QStringList lines;
+    void error(QString expression, QString token) {
+        int lineNo = 0;
+        for (QString line_ : lines) {
+            lineNo++;
+            if (line_.contains(expression)) {
+                this->line = lineNo;
+                break;
+            }
+        }
+        logError(QString("%1:%2: unknown identifier found in expression: '%3'.").arg(file).arg(line).arg(token));
+    }
 };
 
 class Token {
@@ -22,6 +47,8 @@ public:
             this->operatorPrecedence = -1;
         } else if (type == "operator") {
             this->operatorPrecedence = precedenceMap[value];
+        } else if (type == "error") {
+            this->type = TokenType::Error;
         }
     }
     static QMap<QString, int> precedenceMap;
@@ -33,10 +60,11 @@ public:
 class ParseUtil
 {
 public:
-    ParseUtil();
+    ParseUtil(QString, QString);
     void strip_comment(QString*);
     QList<QStringList>* parseAsm(QString);
     int evaluateDefine(QString, QMap<QString, int>*);
+    DebugInfo *debug;
 private:
     QList<Token> tokenizeExpression(QString expression, QMap<QString, int>* knownIdentifiers);
     QList<Token> generatePostfix(QList<Token> tokens);

--- a/include/project.h
+++ b/include/project.h
@@ -5,6 +5,7 @@
 #include "blockdata.h"
 #include "heallocation.h"
 #include "event.h"
+#include "parseutil.h"
 
 #include <QStringList>
 #include <QList>
@@ -46,6 +47,9 @@ public:
     QMap<QString, int> metatileBehaviorMap;
     QMap<int, QString> metatileBehaviorMapInverse;
     QMap<QString, QString> facingDirections;
+    ParseUtil parser;
+
+    void set_root(QString);
 
     struct DataQualifiers
     {
@@ -66,7 +70,6 @@ public:
     Blockdata* readBlockdata(QString);
     void loadBlockdata(Map*);
 
-    QString readTextFile(QString path);
     void saveTextFile(QString path, QString text);
     void appendTextFile(QString path, QString text);
     void deleteFile(QString path);
@@ -80,8 +83,6 @@ public:
     QString readMapLayoutId(QString map_name);
     QString readMapLocation(QString map_name);
 
-    QList<QStringList>* getLabelMacros(QList<QStringList>*, QString);
-    QStringList* getLabelValues(QList<QStringList>*, QString);
     QMap<QString, bool> getTopLevelMapFields();
     bool loadMapData(Map*);
     void readMapLayouts();
@@ -107,7 +108,6 @@ public:
     void saveTilesetTilesImage(Tileset*);
     void saveTilesetPalettes(Tileset*, bool);
 
-    QList<QStringList>* parseAsm(QString text);
     QStringList getSongNames();
     QStringList getVisibilities();
     QMap<QString, QStringList> getTilesetLabels();
@@ -136,22 +136,15 @@ public:
 
     void saveMapHealEvents(Map *map);
 
-    QStringList readCArray(QString text, QString label);
-    QString readCIncbin(QString text, QString label);
-    QMap<QString, int> readCDefines(QString filename, QStringList prefixes);
-    QMap<QString, QString> readNamedIndexCArray(QString text, QString label);
-
     static int getNumTilesPrimary();
     static int getNumTilesTotal();
     static int getNumMetatilesPrimary();
     static int getNumMetatilesTotal();
     static int getNumPalettesPrimary();
     static int getNumPalettesTotal();
-    static bool tryParseJsonFile(QJsonDocument *out, QString filepath);
+
 private:
     void updateMapLayout(Map*);
-    void readCDefinesSorted(QString, QStringList, QStringList*);
-    void readCDefinesSorted(QString, QStringList, QStringList*, QString, int);
 
     void setNewMapHeader(Map* map, int mapIndex);
     void setNewMapLayout(Map* map);

--- a/include/project.h
+++ b/include/project.h
@@ -138,7 +138,7 @@ public:
 
     QStringList readCArray(QString text, QString label);
     QString readCIncbin(QString text, QString label);
-    QMap<QString, int> readCDefines(QString text, QStringList prefixes);
+    QMap<QString, int> readCDefines(QString filename, QStringList prefixes);
     QMap<QString, QString> readNamedIndexCArray(QString text, QString label);
 
     static int getNumTilesPrimary();

--- a/src/core/parseutil.cpp
+++ b/src/core/parseutil.cpp
@@ -4,8 +4,10 @@
 #include <QRegularExpression>
 #include <QStack>
 
-ParseUtil::ParseUtil()
+ParseUtil::ParseUtil(QString filename, QString text)
 {
+    QStringList lines = text.split(QRegularExpression("[\r\n]"));
+    debug = new DebugInfo(filename, lines);
 }
 
 void ParseUtil::strip_comment(QString *line) {
@@ -91,7 +93,8 @@ QList<Token> ParseUtil::tokenizeExpression(QString expression, QMap<QString, int
                         token = actualToken;
                         tokenType = "decimal";
                     } else {
-                        logError(QString("Unknown identifier found in expression: '%1'").arg(token));
+                        tokenType = "error";
+                        debug->error(expression, token);
                     }
                 }
 
@@ -190,9 +193,9 @@ int ParseUtil::evaluatePostfix(QList<Token> postfix) {
                 logError(QString("Unsupported postfix operator: '%1'").arg(token.value));
             }
             stack.push(Token(QString("%1").arg(result), "decimal"));
-        } else {
+        } else if (token.type != TokenType::Error) {
             stack.push(token);
-        }
+        } // else ignore errored tokens, we have already warned the user.
     }
 
     return stack.pop().value.toInt(nullptr, 0);

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -2,6 +2,21 @@
 #include <QDateTime>
 #include <QDir>
 #include <QStandardPaths>
+#include <QSysInfo>
+
+// Enabling this does not seem to be simple to color console output
+// on Windows for all CLIs without external libraries or extreme bloat.
+#ifdef Q_OS_WIN
+    #define ERROR_COLOR   ""
+    #define WARNING_COLOR ""
+    #define INFO_COLOR    ""
+    #define CLEAR_COLOR   ""
+#else
+    #define ERROR_COLOR   "\033[31;1m"
+    #define WARNING_COLOR "\033[1;33m"
+    #define INFO_COLOR    "\033[32m"
+    #define CLEAR_COLOR   "\033[0m"
+#endif
 
 void logInfo(QString message) {
     log(message, LogType::LOG_INFO);
@@ -13,6 +28,23 @@ void logWarn(QString message) {
 
 void logError(QString message) {
     log(message, LogType::LOG_ERROR);
+}
+
+QString colorizeMessage(QString message, LogType type) {
+    QString colorized = message;
+    switch (type)
+    {
+    case LogType::LOG_INFO:
+        colorized = colorized.replace("INFO", INFO_COLOR "INFO" CLEAR_COLOR);
+        break;
+    case LogType::LOG_WARN:
+        colorized = colorized.replace("WARN", WARNING_COLOR "WARN" CLEAR_COLOR);
+        break;
+    case LogType::LOG_ERROR:
+        colorized = colorized.replace("ERROR", ERROR_COLOR "ERROR" CLEAR_COLOR);
+        break;
+    }
+    return colorized;
 }
 
 void log(QString message, LogType type) {
@@ -40,7 +72,7 @@ void log(QString message, LogType type) {
 
     QString logPath = dir.absoluteFilePath("porymap.log");
 
-    qDebug() << message;
+    qDebug().noquote() << colorizeMessage(message, type);
     QFile outFile(logPath);
     outFile.open(QIODevice::WriteOnly | QIODevice::Append);
     QTextStream ts(&outFile);

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -255,7 +255,7 @@ bool MainWindow::openProject(QString dir) {
     bool already_open = isProjectOpen() && (editor->project->root == dir);
     if (!already_open) {
         editor->project = new Project;
-        editor->project->root = dir;
+        editor->project->set_root(dir);
         setWindowTitle(editor->project->getProjectTitle());
         loadDataStructures();
         populateMapList();


### PR DESCRIPTION
but warn the user (give a file name and line number) about bad expressions.

Reading tilesets now doesn't give warnings about the secret base tileset pointers.

Added colorful log output for Linux and macOS users (and probably this applies to WSL). Windows I can't reliably test and it would require a refactor that is probably not worth it.