### PR TITLE
improve way selected events are rendered on top

### DIFF
--- a/include/editor.h
+++ b/include/editor.h
@@ -204,7 +204,11 @@ public:
         int y = event->getPixelY();
         setX(x);
         setY(y);
-        setZValue(event->y());
+        if (editor->selected_events && editor->selected_events->contains(this)) {
+            setZValue(event->y() + 1);
+        } else {
+            setZValue(event->y());
+        }
     }
     void move(int x, int y);
     void emitPositionChanged() {

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -1243,7 +1243,6 @@ void Editor::selectMapEvent(DraggablePixmapItem *object, bool toggle) {
             selected_events->append(object);
         }
         updateSelectedEvents();
-        object->setZValue(object->y() + 1);
     }
 }
 


### PR DESCRIPTION
previous behavior didn't maintain object's z position when sprite was changed