### PR TITLE
Small Bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The **"Breaking Changes"** listed below are changes that have been made in the d
 ### Fixed
 - Fix bug where map group names were hardcoded when creating a new map.
 - Fix bug in Tileset Editor where multi-tile selections weren't properly painted when clicking on the bottom row of the metatile layers.
+- Fix bug where line breaks in C headers were not parsed properly.
 
 
 ## [1.2.2] - 2019-05-16

--- a/src/core/parseutil.cpp
+++ b/src/core/parseutil.cpp
@@ -272,6 +272,7 @@ QMap<QString, int> ParseUtil::readCDefines(QString filename, QStringList prefixe
     }
 
     text.replace(QRegularExpression("(//.*)|(\\/+\\*+[^*]*\\*+\\/+)"), "");
+    text.replace(QRegularExpression("(\\\\\\s+)"), "");
 
     QRegularExpression re("#define\\s+(?<defineName>\\w+)[^\\S\\n]+(?<defineValue>.+)");
     QRegularExpressionMatchIterator iter = re.globalMatch(text);

--- a/src/project.cpp
+++ b/src/project.cpp
@@ -1432,7 +1432,6 @@ void Project::readRegionMapSections() {
     for (QString defineName : this->mapSectionNameToValue.keys()) {
         this->mapSectionValueToName.insert(this->mapSectionNameToValue[defineName], defineName);
     }
-
 }
 
 void Project::readHealLocations() {
@@ -1444,6 +1443,7 @@ void Project::readHealLocations() {
     QRegularExpression regex("MAP_GROUP\\((?<map>[A-Za-z0-9_]*)\\),\\s+MAP_NUM\\((\\1)\\),\\s+(?<x>[0-9A-Fa-fx]*),\\s+(?<y>[0-9A-Fa-fx]*)");
     QRegularExpressionMatchIterator iter = regex.globalMatch(text);
 
+    flyableMaps.clear();
     for (int i = 1; iter.hasNext(); i++) {
         QRegularExpressionMatch match = iter.next();
         QString mapName = match.captured("map");


### PR DESCRIPTION
clear `flyableMaps` before reading heal locations,
fix line break parsing of C defines