### PR TITLE
Add switch for using PoryScript

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -106,6 +106,8 @@ public:
     BaseGameVersion getBaseGameVersion();
     void setEncounterJsonActive(bool active);
     bool getEncounterJsonActive();
+    void setUsePoryScript(bool usePoryScript);
+    bool getUsePoryScript();
     void setProjectDir(QString projectDir);
 protected:
     QString getConfigFilepath();
@@ -116,6 +118,7 @@ private:
     BaseGameVersion baseGameVersion;
     QString projectDir;
     bool useEncounterJson;
+    bool usePoryScript;
 };
 
 extern ProjectConfig projectConfig;

--- a/include/project.h
+++ b/include/project.h
@@ -151,6 +151,9 @@ public:
     QString fixPalettePath(QString path);
     QString fixGraphicPath(QString path);
 
+    QString getScriptFileExtension(bool usePoryScript);
+    QString getScriptDefaultString(bool usePoryScript, QString mapName);
+
     void loadMapBorder(Map *map);
 
     void saveMapHealEvents(Map *map);

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -354,6 +354,12 @@ void ProjectConfig::parseConfigKeyValue(QString key, QString value) {
         if (!ok) {
             logWarn(QString("Invalid config value for use_encounter_json: '%1'. Must be 0 or 1.").arg(value));
         }
+    } else if(key == "use_poryscript") {
+        bool ok;
+        this->usePoryScript = value.toInt(&ok);
+        if(!ok) {
+            logWarn(QString("Invalid config value for use_poryscript: '%1'. Must be 0 or 1.").arg(value));
+        }
     } else {
         logWarn(QString("Invalid config key found in config file %1: '%2'").arg(this->getConfigFilepath()).arg(key));
     }
@@ -363,6 +369,7 @@ QMap<QString, QString> ProjectConfig::getKeyValueMap() {
     QMap<QString, QString> map;
     map.insert("base_game_version", baseGameVersionMap.value(this->baseGameVersion));
     map.insert("use_encounter_json", QString::number(this->useEncounterJson));
+    map.insert("use_poryscript", QString::number(this->usePoryScript));
     return map;
 }
 
@@ -392,6 +399,7 @@ void ProjectConfig::onNewConfigFileCreated() {
         }
     }
     this->useEncounterJson = true;
+    this->usePoryScript = false;
 }
 
 void ProjectConfig::setProjectDir(QString projectDir) {
@@ -414,4 +422,13 @@ void ProjectConfig::setEncounterJsonActive(bool active) {
 
 bool ProjectConfig::getEncounterJsonActive() {
     return this->useEncounterJson;
+}
+
+void ProjectConfig::setUsePoryScript(bool usePoryScript) {
+    this->usePoryScript = usePoryScript;
+    this->save();
+}
+
+bool ProjectConfig::getUsePoryScript() {
+    return this->usePoryScript;
 }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1062,7 +1062,7 @@ void MainWindow::redo() {
 
 // Open current map scripts in system default editor for .inc files
 void MainWindow::openInTextEditor() {
-    QString path = QDir::cleanPath("file://" + editor->project->root + QDir::separator() + "data/maps/" + editor->map->name + "/scripts.inc");
+    QString path = QDir::cleanPath("file://" + editor->project->root + QDir::separator() + "data/maps/" + editor->map->name + "/scripts" + editor->project->getScriptFileExtension(projectConfig.getUsePoryScript()));
     QDesktopServices::openUrl(QUrl(path));
 }
 

--- a/src/project.cpp
+++ b/src/project.cpp
@@ -962,12 +962,12 @@ void Project::saveMap(Map *map) {
         }
 
         // Create file data/maps/<map_name>/scripts.inc
-        QString text = QString("%1_MapScripts::\n\t.byte 0\n").arg(map->name);
-        saveTextFile(root + "/data/maps/" + map->name + "/scripts.inc", text);
+        QString text = this->getScriptDefaultString(projectConfig.getUsePoryScript(), map->name);
+        saveTextFile(root + "/data/maps/" + map->name + "/scripts" + this->getScriptFileExtension(projectConfig.getUsePoryScript()), text);
 
         if (projectConfig.getBaseGameVersion() == BaseGameVersion::pokeruby) {
             // Create file data/maps/<map_name>/text.inc
-            saveTextFile(root + "/data/maps/" + map->name + "/text.inc", "\n");
+            saveTextFile(root + "/data/maps/" + map->name + "/text" + this->getScriptFileExtension(projectConfig.getUsePoryScript()), "\n");
         }
 
         // Simply append to data/event_scripts.s.
@@ -1796,6 +1796,21 @@ QString Project::fixGraphicPath(QString path) {
     path = path.replace(QRegExp("\\.lz$"), "");
     path = path.replace(QRegExp("\\.[1248]bpp$"), ".png");
     return path;
+}
+
+QString Project::getScriptFileExtension(bool usePoryScript) {
+    if(usePoryScript) {
+        return ".pory";
+    } else {
+        return ".inc";
+    }
+}
+
+QString Project::getScriptDefaultString(bool usePoryScript, QString mapName) {
+    if(usePoryScript)
+        return QString("mapscripts %1_MapScripts {}").arg(mapName);
+    else
+        return QString("%1_MapScripts::\n\t.byte 0\n").arg(mapName);
 }
 
 void Project::loadEventPixmaps(QList<Event*> objects) {


### PR DESCRIPTION
Defines the key `use_poryscript` (0/1) which can be toggled in the config file to open `scripts.pory` files per default, and create them when a new map is saved with a default map script:

```
mapscripts {MapName}_MapScripts {}