### PR TITLE
Disallow drawing Heal Locations

### DIFF
--- a/include/project.h
+++ b/include/project.h
@@ -37,7 +37,7 @@ public:
     QList<QStringList> groupedMapNames;
     QStringList *mapNames = nullptr;
     QMap<QString, QVariant> miscConstants;
-    QList<HealLocation> flyableMaps;
+    QList<HealLocation> healLocations;
     QMap<QString, QString>* mapConstantsToMapNames;
     QMap<QString, QString>* mapNamesToMapConstants;
     QList<QString> mapLayoutsTable;

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -1067,10 +1067,14 @@ void Editor::mouseEvent_map(QGraphicsSceneMouseEvent *event, MapPixmapItem *item
             } else {
                 // Left-clicking while in paint mode will add a new event of the
                 // type of the first currently selected events.
-                DraggablePixmapItem * newEvent = addNewEvent(this->selected_events->first()->event->get("event_type"));
-                if (newEvent) {
-                    newEvent->move(x, y);
-                    selectMapEvent(newEvent, false);
+                // Disallow adding heal locations, deleting them is not possible yet
+                QString eventType = this->selected_events->first()->event->get("event_type");
+                if (eventType != "event_heal_location") {
+                    DraggablePixmapItem * newEvent = addNewEvent(eventType);
+                    if (newEvent) {
+                        newEvent->move(x, y);
+                        selectMapEvent(newEvent, false);
+                    }
                 }
             }
         } else if (map_edit_mode == "select") {

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -1845,8 +1845,8 @@ DraggablePixmapItem* Editor::addNewEvent(QString event_type) {
         event->put("map_name", map->name);
         if (event_type == "event_heal_location") {
             HealLocation hl = HealLocation::fromEvent(event);
-            project->flyableMaps.append(hl);
-            event->put("index", project->flyableMaps.length());
+            project->healLocations.append(hl);
+            event->put("index", project->healLocations.length());
         }
         map->addEvent(event);
         project->loadEventPixmaps(map->getAllEvents());


### PR DESCRIPTION
Fixes #213 
Deleting heal locations isn't allowed yet, so drawing them probably shouldn't be either. Adding new heal locations via the New Object button is already disallowed.