### PR TITLE
Read MAX_MAP_DATA_SIZE

### DIFF
--- a/include/mainwindow.h
+++ b/include/mainwindow.h
@@ -277,7 +277,7 @@ private:
     QString getDefaultMap();
     void setRecentMap(QString map_name);
     QStandardItem* createMapItem(QString mapName, int groupNum, int inGroupNum);
-    static bool mapDimensionsValid(int width, int height);
+    bool mapDimensionsValid(int width, int height);
 
     void drawMapListIcons(QAbstractItemModel *model);
     void updateMapList();

--- a/include/mainwindow.h
+++ b/include/mainwindow.h
@@ -277,7 +277,6 @@ private:
     QString getDefaultMap();
     void setRecentMap(QString map_name);
     QStandardItem* createMapItem(QString mapName, int groupNum, int inGroupNum);
-    bool mapDimensionsValid(int width, int height);
 
     void drawMapListIcons(QAbstractItemModel *model);
     void updateMapList();

--- a/include/project.h
+++ b/include/project.h
@@ -184,6 +184,13 @@ public:
     static int getNumMetatilesTotal();
     static int getNumPalettesPrimary();
     static int getNumPalettesTotal();
+    static int getMaxMapDataSize();
+    static int getDefaultMapSize();
+    static int getMaxMapWidth();
+    static int getMaxMapHeight();
+
+    int getMapDataSize(int width, int height);
+    bool calculateDefaultMapSize();
 
 private:
     void updateMapLayout(Map*);
@@ -203,6 +210,8 @@ private:
     static int num_metatiles_total;
     static int num_pals_primary;
     static int num_pals_total;
+    static int max_map_data_size;
+    static int default_map_size;
 
     QWidget *parent;
 

--- a/include/project.h
+++ b/include/project.h
@@ -149,6 +149,7 @@ public:
     QStringList getVisibilities();
     QMap<QString, QStringList> getTilesetLabels();
     bool readTilesetProperties();
+    bool readMaxMapDataSize();
     bool readRegionMapSections();
     bool readItemNames();
     bool readFlagNames();
@@ -188,8 +189,8 @@ public:
     static int getDefaultMapSize();
     static int getMaxMapWidth();
     static int getMaxMapHeight();
-
-    int getMapDataSize(int width, int height);
+    static int getMapDataSize(int width, int height);
+    static bool mapDimensionsValid(int width, int height);
     bool calculateDefaultMapSize();
 
 private:

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -701,6 +701,7 @@ bool MainWindow::loadDataStructures() {
                 && project->readTrainerTypes()
                 && project->readMetatileBehaviors()
                 && project->readTilesetProperties()
+                && project->readMaxMapDataSize()
                 && project->readHealLocations()
                 && project->readMiscellaneousConstants()
                 && project->readSpeciesIconPaths()
@@ -2349,10 +2350,6 @@ void MainWindow::on_pushButton_ChangeDimensions_clicked()
         editor->map->commit();
         onMapNeedsRedrawing();
     }
-}
-
-bool MainWindow::mapDimensionsValid(int width, int height) {
-    return editor->project->getMapDataSize(width, height) <= editor->project->getMaxMapDataSize();
 }
 
 void MainWindow::on_checkBox_smartPaths_stateChanged(int selected)

--- a/src/mainwindow_scriptapi.cpp
+++ b/src/mainwindow_scriptapi.cpp
@@ -176,7 +176,7 @@ int MainWindow::getHeight() {
 void MainWindow::setDimensions(int width, int height) {
     if (!this->editor || !this->editor->map)
         return;
-    if (!MainWindow::mapDimensionsValid(width, height))
+    if (!Project::mapDimensionsValid(width, height))
         return;
     this->editor->map->setDimensions(width, height);
     this->editor->map->commit();
@@ -186,7 +186,7 @@ void MainWindow::setDimensions(int width, int height) {
 void MainWindow::setWidth(int width) {
     if (!this->editor || !this->editor->map)
         return;
-    if (!MainWindow::mapDimensionsValid(width, this->editor->map->getHeight()))
+    if (!Project::mapDimensionsValid(width, this->editor->map->getHeight()))
         return;
     this->editor->map->setDimensions(width, this->editor->map->getHeight());
     this->editor->map->commit();
@@ -196,7 +196,7 @@ void MainWindow::setWidth(int width) {
 void MainWindow::setHeight(int height) {
     if (!this->editor || !this->editor->map)
         return;
-    if (!MainWindow::mapDimensionsValid(this->editor->map->getWidth(), height))
+    if (!Project::mapDimensionsValid(this->editor->map->getWidth(), height))
         return;
     this->editor->map->setDimensions(this->editor->map->getWidth(), height);
     this->editor->map->commit();

--- a/src/project.cpp
+++ b/src/project.cpp
@@ -2609,7 +2609,7 @@ bool Project::calculateDefaultMapSize(){
         default_map_size = 20;
     } else if (max >= getMapDataSize(1, 1)) {
         // Below equation derived from max >= (x + 15) * (x + 14)
-        // x^2 + 29x + (10 - max), then complete the square and simplify
+        // x^2 + 29x + (210 - max), then complete the square and simplify
         default_map_size = qFloor((qSqrt(4 * getMaxMapDataSize() + 1) - 29) / 2);
     } else {
         logError(QString("'MAX_MAP_DATA_SIZE' of %1 is too small to support a 1x1 map. Must be at least %2.")

--- a/src/project.cpp
+++ b/src/project.cpp
@@ -2046,7 +2046,7 @@ QMap<QString, QStringList> Project::getTilesetLabels() {
 
 bool Project::readTilesetProperties() {
     QStringList definePrefixes;
-    definePrefixes << "NUM_" << "MAX_";
+    definePrefixes << "NUM_";
     QString filename = "include/fieldmap.h";
     fileWatcher.addPath(root + "/" + filename);
     QMap<QString, int> defines = parser.readCDefines(filename, definePrefixes);
@@ -2099,7 +2099,16 @@ bool Project::readTilesetProperties() {
         logWarn(QString("Value for tileset property 'NUM_PALS_TOTAL' not found. Using default (%1) instead.")
                 .arg(Project::num_pals_total));
     }
-    it = defines.find("MAX_MAP_DATA_SIZE");
+    return true;
+}
+
+bool Project::readMaxMapDataSize() {
+    QStringList definePrefixes;
+    definePrefixes << "MAX_";
+    QString filename = "include/fieldmap.h"; // already in fileWatcher from readTilesetProperties
+    QMap<QString, int> defines = parser.readCDefines(filename, definePrefixes);
+
+    auto it = defines.find("MAX_MAP_DATA_SIZE");
     if (it != defines.end()) {
         int min = getMapDataSize(1, 1);
         if (it.value() >= min) {
@@ -2586,6 +2595,10 @@ int Project::getMaxMapWidth()
 int Project::getMaxMapHeight()
 {
     return (getMaxMapDataSize() / (1 + 15)) - 14;
+}
+
+bool Project::mapDimensionsValid(int width, int height) {
+    return getMapDataSize(width, height) <= getMaxMapDataSize();
 }
 
 // Get largest possible square dimensions for a map up to maximum of 20x20 (arbitrary)

--- a/src/ui/newmappopup.cpp
+++ b/src/ui/newmappopup.cpp
@@ -67,8 +67,8 @@ void NewMapPopup::setDefaultValues(int groupNum, QString mapSec) {
         ui->comboBox_NewMap_Primary_Tileset->setDisabled(true);
         ui->comboBox_NewMap_Secondary_Tileset->setDisabled(true);
     } else {
-        ui->spinBox_NewMap_Width->setValue(20);
-        ui->spinBox_NewMap_Height->setValue(20);
+        ui->spinBox_NewMap_Width->setValue(project->getDefaultMapSize());
+        ui->spinBox_NewMap_Height->setValue(project->getDefaultMapSize());
         ui->spinBox_NewMap_BorderWidth->setValue(DEFAULT_BORDER_WIDTH);
         ui->spinBox_NewMap_BorderHeight->setValue(DEFAULT_BORDER_HEIGHT);
     }


### PR DESCRIPTION
Use `MAX_MAP_DATA_SIZE` in the repo for the map dimensions limit. Does not change the new map prompt's bad width/height limit