### PR TITLE
Add config options for project-specific features

### DIFF
--- a/docsrc/manual/settings-and-options.rst
+++ b/docsrc/manual/settings-and-options.rst
@@ -35,6 +35,13 @@ determined by this file.
    ``use_encounter_json``, 1, project, yes, Enables wild encounter table editing
    ``use_poryscript``, 0, project, yes, Whether to open .pory files for scripts
    ``use_custom_border_size``, 0, project, yes, Whether to allow variable border sizes
+   ``enable_event_weather_trigger``, 1 if not ``pokefirered``, project, yes, Allows adding Weather Trigger events
+   ``enable_event_secret_base``, 1 if not ``pokefirered``, project, yes, Allows adding Secret Base events
+   ``enable_hidden_item_quantity``, 1 if ``pokefirered``, project, yes, Adds ``Quantity`` to Hidden Item events
+   ``enable_hidden_item_requires_itemfinder``, 1 if ``pokefirered``, project, yes, Adds ``Requires Itemfinder`` to Hidden Item events
+   ``enable_heal_location_respawn_data``, 1 if ``pokefirered``, project, yes, Adds ``Respawn Map`` and ``Respawn NPC`` to Heal Location events
+   ``enable_object_event_in_connection``, 1 if ``pokefirered``, project, yes, Adds ``In Connection`` to Object events
+   ``enable_floor_number``, 1 if ``pokefirered``, project, yes, Adds ``Floor Number`` to map headers
    ``custom_scripts``, , project, yes, A list of script files to load into the scripting engine
 
 Some of these settings can be toggled manually in porymap via the *Options* menu.

--- a/include/config.h
+++ b/include/config.h
@@ -113,6 +113,13 @@ public:
         this->baseGameVersion = BaseGameVersion::pokeemerald;
         this->useEncounterJson = true;
         this->useCustomBorderSize = false;
+        this->enableEventWeatherTrigger = true;
+        this->enableEventSecretBase = true;
+        this->enableHiddenItemQuantity = false;
+        this->enableHiddenItemRequiresItemfinder = false;
+        this->enableHealLocationRespawnData = false;
+        this->enableObjectEventInConnection = false;
+        this->enableFloorNumber = false;
         this->customScripts.clear();
     }
     void setBaseGameVersion(BaseGameVersion baseGameVersion);
@@ -125,6 +132,20 @@ public:
     QString getProjectDir();
     void setUseCustomBorderSize(bool enable);
     bool getUseCustomBorderSize();
+    void setEventWeatherTriggerEnabled(bool enable);
+    bool getEventWeatherTriggerEnabled();
+    void setEventSecretBaseEnabled(bool enable);
+    bool getEventSecretBaseEnabled();
+    void setHiddenItemQuantityEnabled(bool enable);
+    bool getHiddenItemQuantityEnabled();
+    void setHiddenItemRequiresItemfinderEnabled(bool enable);
+    bool getHiddenItemRequiresItemfinderEnabled();
+    void setHealLocationRespawnDataEnabled(bool enable);
+    bool getHealLocationRespawnDataEnabled();
+    void setObjectEventInConnectionEnabled(bool enable);
+    bool getObjectEventInConnectionEnabled();
+    void setFloorNumberEnabled(bool enable);
+    bool getFloorNumberEnabled();
     void setCustomScripts(QList<QString> scripts);
     QList<QString> getCustomScripts();
 protected:
@@ -138,6 +159,13 @@ private:
     bool useEncounterJson;
     bool usePoryScript;
     bool useCustomBorderSize;
+    bool enableEventWeatherTrigger;
+    bool enableEventSecretBase;
+    bool enableHiddenItemQuantity;
+    bool enableHiddenItemRequiresItemfinder;
+    bool enableHealLocationRespawnData;
+    bool enableObjectEventInConnection;
+    bool enableFloorNumber;
     QList<QString> customScripts;
 };
 

--- a/include/config.h
+++ b/include/config.h
@@ -24,6 +24,7 @@ protected:
     virtual void parseConfigKeyValue(QString key, QString value) = 0;
     virtual QMap<QString, QString> getKeyValueMap() = 0;
     virtual void onNewConfigFileCreated() = 0;
+    virtual void setUnreadKeys() = 0;
 };
 
 class PorymapConfig: public KeyValueConfigBase
@@ -73,7 +74,8 @@ protected:
     virtual QString getConfigFilepath() override;
     virtual void parseConfigKeyValue(QString key, QString value) override;
     virtual QMap<QString, QString> getKeyValueMap() override;
-    virtual void onNewConfigFileCreated() override {}
+    virtual void onNewConfigFileCreated() override {};
+    virtual void setUnreadKeys() override {};
 private:
     QString recentProject;
     QString recentMap;
@@ -121,6 +123,7 @@ public:
         this->enableObjectEventInConnection = false;
         this->enableFloorNumber = false;
         this->customScripts.clear();
+        this->readKeys.clear();
     }
     void setBaseGameVersion(BaseGameVersion baseGameVersion);
     BaseGameVersion getBaseGameVersion();
@@ -153,6 +156,7 @@ protected:
     virtual void parseConfigKeyValue(QString key, QString value) override;
     virtual QMap<QString, QString> getKeyValueMap() override;
     virtual void onNewConfigFileCreated() override;
+    virtual void setUnreadKeys() override;
 private:
     BaseGameVersion baseGameVersion;
     QString projectDir;
@@ -167,6 +171,7 @@ private:
     bool enableObjectEventInConnection;
     bool enableFloorNumber;
     QList<QString> customScripts;
+    QStringList readKeys;
 };
 
 extern ProjectConfig projectConfig;

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -380,6 +380,48 @@ void ProjectConfig::parseConfigKeyValue(QString key, QString value) {
         if (!ok) {
             logWarn(QString("Invalid config value for use_custom_border_size: '%1'. Must be 0 or 1.").arg(value));
         }
+    } else if (key == "enable_event_weather_trigger") {
+        bool ok;
+        this->enableEventWeatherTrigger = value.toInt(&ok);
+        if (!ok) {
+            logWarn(QString("Invalid config value for enable_event_weather_trigger: '%1'. Must be 0 or 1.").arg(value));
+        }
+    } else if (key == "enable_event_secret_base") {
+        bool ok;
+        this->enableEventSecretBase = value.toInt(&ok);
+        if (!ok) {
+            logWarn(QString("Invalid config value for enable_event_secret_base: '%1'. Must be 0 or 1.").arg(value));
+        }
+    } else if (key == "enable_hidden_item_quantity") {
+        bool ok;
+        this->enableHiddenItemQuantity = value.toInt(&ok);
+        if (!ok) {
+            logWarn(QString("Invalid config value for enable_hidden_item_quantity: '%1'. Must be 0 or 1.").arg(value));
+        }
+    } else if (key == "enable_hidden_item_requires_itemfinder") {
+        bool ok;
+        this->enableHiddenItemRequiresItemfinder = value.toInt(&ok);
+        if (!ok) {
+            logWarn(QString("Invalid config value for enable_hidden_item_requires_itemfinder: '%1'. Must be 0 or 1.").arg(value));
+        }
+    } else if (key == "enable_heal_location_respawn_data") {
+        bool ok;
+        this->enableHealLocationRespawnData = value.toInt(&ok);
+        if (!ok) {
+            logWarn(QString("Invalid config value for enable_heal_location_respawn_data: '%1'. Must be 0 or 1.").arg(value));
+        }
+    } else if (key == "enable_object_event_in_connection") {
+        bool ok;
+        this->enableObjectEventInConnection = value.toInt(&ok);
+        if (!ok) {
+            logWarn(QString("Invalid config value for enable_object_event_in_connection: '%1'. Must be 0 or 1.").arg(value));
+        }
+    } else if (key == "enable_floor_number") {
+        bool ok;
+        this->enableFloorNumber = value.toInt(&ok);
+        if (!ok) {
+            logWarn(QString("Invalid config value for enable_floor_number: '%1'. Must be 0 or 1.").arg(value));
+        }
     } else if (key == "custom_scripts") {
         this->customScripts.clear();
         QList<QString> paths = value.split(",");
@@ -400,6 +442,13 @@ QMap<QString, QString> ProjectConfig::getKeyValueMap() {
     map.insert("use_encounter_json", QString::number(this->useEncounterJson));
     map.insert("use_poryscript", QString::number(this->usePoryScript));
     map.insert("use_custom_border_size", QString::number(this->useCustomBorderSize));
+    map.insert("enable_event_weather_trigger", QString::number(this->enableEventWeatherTrigger));
+    map.insert("enable_event_secret_base", QString::number(this->enableEventSecretBase));
+    map.insert("enable_hidden_item_quantity", QString::number(this->enableHiddenItemQuantity));
+    map.insert("enable_hidden_item_requires_itemfinder", QString::number(this->enableHiddenItemRequiresItemfinder));
+    map.insert("enable_heal_location_respawn_data", QString::number(this->enableHealLocationRespawnData));
+    map.insert("enable_object_event_in_connection", QString::number(this->enableObjectEventInConnection));
+    map.insert("enable_floor_number", QString::number(this->enableFloorNumber));
     map.insert("custom_scripts", this->customScripts.join(","));
     return map;
 }
@@ -430,7 +479,15 @@ void ProjectConfig::onNewConfigFileCreated() {
             this->baseGameVersion = static_cast<BaseGameVersion>(baseGameVersionComboBox->currentData().toInt());
         }
     }
-    this->useCustomBorderSize = this->baseGameVersion == BaseGameVersion::pokefirered;
+    bool isPokefirered = this->baseGameVersion == BaseGameVersion::pokefirered;
+    this->useCustomBorderSize = isPokefirered;
+    this->enableEventWeatherTrigger = !isPokefirered;
+    this->enableEventSecretBase = !isPokefirered;
+    this->enableHiddenItemQuantity = isPokefirered;
+    this->enableHiddenItemRequiresItemfinder = isPokefirered;
+    this->enableHealLocationRespawnData = isPokefirered;
+    this->enableObjectEventInConnection = isPokefirered;
+    this->enableFloorNumber = isPokefirered;
     this->useEncounterJson = true;
     this->usePoryScript = false;
     this->customScripts.clear();
@@ -478,6 +535,69 @@ void ProjectConfig::setUseCustomBorderSize(bool enable) {
 
 bool ProjectConfig::getUseCustomBorderSize() {
     return this->useCustomBorderSize;
+}
+
+void ProjectConfig::setEventWeatherTriggerEnabled(bool enable) {
+    this->enableEventWeatherTrigger = enable;
+    this->save();
+}
+
+bool ProjectConfig::getEventWeatherTriggerEnabled() {
+    return this->enableEventWeatherTrigger;
+}
+
+void ProjectConfig::setEventSecretBaseEnabled(bool enable) {
+    this->enableEventSecretBase = enable;
+    this->save();
+}
+
+bool ProjectConfig::getEventSecretBaseEnabled() {
+    return this->enableEventSecretBase;
+}
+
+void ProjectConfig::setHiddenItemQuantityEnabled(bool enable) {
+    this->enableHiddenItemQuantity = enable;
+    this->save();
+}
+
+bool ProjectConfig::getHiddenItemQuantityEnabled() {
+    return this->enableHiddenItemQuantity;
+}
+
+void ProjectConfig::setHiddenItemRequiresItemfinderEnabled(bool enable) {
+    this->enableHiddenItemRequiresItemfinder = enable;
+    this->save();
+}
+
+bool ProjectConfig::getHiddenItemRequiresItemfinderEnabled() {
+    return this->enableHiddenItemRequiresItemfinder;
+}
+
+void ProjectConfig::setHealLocationRespawnDataEnabled(bool enable) {
+    this->enableHealLocationRespawnData = enable;
+    this->save();
+}
+
+bool ProjectConfig::getHealLocationRespawnDataEnabled() {
+    return this->enableHealLocationRespawnData;
+}
+
+void ProjectConfig::setObjectEventInConnectionEnabled(bool enable) {
+    this->enableObjectEventInConnection = enable;
+    this->save();
+}
+
+bool ProjectConfig::getObjectEventInConnectionEnabled() {
+    return this->enableObjectEventInConnection;
+}
+
+void ProjectConfig::setFloorNumberEnabled(bool enable) {
+    this->enableFloorNumber = enable;
+    this->save();
+}
+
+bool ProjectConfig::getFloorNumberEnabled() {
+    return this->enableFloorNumber;
 }
 
 void ProjectConfig::setCustomScripts(QList<QString> scripts) {

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -56,6 +56,7 @@ void KeyValueConfigBase::load() {
 
         this->parseConfigKeyValue(match.captured("key").toLower(), match.captured("value"));
     }
+    this->setUnreadKeys();
 
     file.close();
 }
@@ -434,6 +435,20 @@ void ProjectConfig::parseConfigKeyValue(QString key, QString value) {
     } else {
         logWarn(QString("Invalid config key found in config file %1: '%2'").arg(this->getConfigFilepath()).arg(key));
     }
+    readKeys.append(key);
+}
+
+void ProjectConfig::setUnreadKeys() {
+    // Set game-version specific defaults for any config field that wasn't read
+    bool isPokefirered = this->baseGameVersion == BaseGameVersion::pokefirered;
+    if (!readKeys.contains("use_custom_border_size")) this->useCustomBorderSize = isPokefirered;
+    if (!readKeys.contains("enable_event_weather_trigger")) this->enableEventWeatherTrigger = !isPokefirered;
+    if (!readKeys.contains("enable_event_secret_base")) this->enableEventSecretBase = !isPokefirered;
+    if (!readKeys.contains("enable_hidden_item_quantity")) this->enableHiddenItemQuantity = isPokefirered;
+    if (!readKeys.contains("enable_hidden_item_requires_itemfinder")) this->enableHiddenItemRequiresItemfinder = isPokefirered;
+    if (!readKeys.contains("enable_heal_location_respawn_data")) this->enableHealLocationRespawnData = isPokefirered;
+    if (!readKeys.contains("enable_object_event_in_connection")) this->enableObjectEventInConnection = isPokefirered;
+    if (!readKeys.contains("enable_floor_number")) this->enableFloorNumber = isPokefirered;
 }
 
 QMap<QString, QString> ProjectConfig::getKeyValueMap() {

--- a/src/core/heallocation.cpp
+++ b/src/core/heallocation.cpp
@@ -26,7 +26,7 @@ HealLocation HealLocation::fromEvent(Event *event)
     }
     hl.x     = event->getU16("x");
     hl.y     = event->getU16("y");
-    if (projectConfig.getBaseGameVersion() == BaseGameVersion::pokefirered) {
+    if (projectConfig.getHealLocationRespawnDataEnabled()) {
         hl.respawnNPC = event->getU16("respawn_npc");
         hl.respawnMap = Map::mapConstantFromName(event->get("respawn_map")).remove(0,4);
     }

--- a/src/ui/newmappopup.cpp
+++ b/src/ui/newmappopup.cpp
@@ -122,31 +122,25 @@ void NewMapPopup::setDefaultValues(int groupNum, QString mapSec) {
         ui->checkBox_NewMap_Allow_Running->setVisible(false);
         ui->checkBox_NewMap_Allow_Biking->setVisible(false);
         ui->checkBox_NewMap_Allow_Escape_Rope->setVisible(false);
-        ui->spinBox_NewMap_Floor_Number->setVisible(false);
         ui->label_NewMap_Allow_Running->setVisible(false);
         ui->label_NewMap_Allow_Biking->setVisible(false);
         ui->label_NewMap_Allow_Escape_Rope->setVisible(false);
-        ui->label_NewMap_Floor_Number->setVisible(false);
         break;
     case BaseGameVersion::pokeemerald:
         ui->checkBox_NewMap_Allow_Running->setVisible(true);
         ui->checkBox_NewMap_Allow_Biking->setVisible(true);
         ui->checkBox_NewMap_Allow_Escape_Rope->setVisible(true);
-        ui->spinBox_NewMap_Floor_Number->setVisible(false);
         ui->label_NewMap_Allow_Running->setVisible(true);
         ui->label_NewMap_Allow_Biking->setVisible(true);
         ui->label_NewMap_Allow_Escape_Rope->setVisible(true);
-        ui->label_NewMap_Floor_Number->setVisible(false);
         break;
     case BaseGameVersion::pokefirered:
         ui->checkBox_NewMap_Allow_Running->setVisible(true);
         ui->checkBox_NewMap_Allow_Biking->setVisible(true);
         ui->checkBox_NewMap_Allow_Escape_Rope->setVisible(true);
-        ui->spinBox_NewMap_Floor_Number->setVisible(true);
         ui->label_NewMap_Allow_Running->setVisible(true);
         ui->label_NewMap_Allow_Biking->setVisible(true);
         ui->label_NewMap_Allow_Escape_Rope->setVisible(true);
-        ui->label_NewMap_Floor_Number->setVisible(true);
         break;
     }
     if (projectConfig.getUseCustomBorderSize()) {
@@ -159,6 +153,13 @@ void NewMapPopup::setDefaultValues(int groupNum, QString mapSec) {
         ui->spinBox_NewMap_BorderHeight->setVisible(false);
         ui->label_NewMap_BorderWidth->setVisible(false);
         ui->label_NewMap_BorderHeight->setVisible(false);
+    }
+    if (projectConfig.getFloorNumberEnabled()) {
+        ui->spinBox_NewMap_Floor_Number->setVisible(true);
+        ui->label_NewMap_Floor_Number->setVisible(true);
+    } else {
+        ui->spinBox_NewMap_Floor_Number->setVisible(false);
+        ui->label_NewMap_Floor_Number->setVisible(false);
     }
 }
 
@@ -223,14 +224,12 @@ void NewMapPopup::on_pushButton_NewMap_Accept_clicked() {
         newMap->isFlyable = "TRUE";
     }
 
-    if (projectConfig.getBaseGameVersion() == BaseGameVersion::pokeemerald) {
+    if (projectConfig.getBaseGameVersion() != BaseGameVersion::pokeruby) {
         newMap->allowRunning = this->ui->checkBox_NewMap_Allow_Running->isChecked() ? "1" : "0";
         newMap->allowBiking = this->ui->checkBox_NewMap_Allow_Biking->isChecked() ? "1" : "0";
         newMap->allowEscapeRope = this->ui->checkBox_NewMap_Allow_Escape_Rope->isChecked() ? "1" : "0";
-    } else if (projectConfig.getBaseGameVersion() == BaseGameVersion::pokefirered) {
-        newMap->allowRunning = this->ui->checkBox_NewMap_Allow_Running->isChecked() ? "1" : "0";
-        newMap->allowBiking = this->ui->checkBox_NewMap_Allow_Biking->isChecked() ? "1" : "0";
-        newMap->allowEscapeRope = this->ui->checkBox_NewMap_Allow_Escape_Rope->isChecked() ? "1" : "0";
+    }
+    if (projectConfig.getFloorNumberEnabled()) {
         newMap->floorNumber = this->ui->spinBox_NewMap_Floor_Number->value();
     }
 


### PR DESCRIPTION
Closes #231 

Adds config fields for the features listed in #231. Also fixes issue with config defaults not being project-specific. At the moment this would only affect pokefirered projects that are missing `use_custom_border_size` in the config