### PR TITLE
Show metatile label names in map editor

### DIFF
--- a/include/editor.h
+++ b/include/editor.h
@@ -168,6 +168,7 @@ private:
     Event* createNewHiddenItemEvent();
     Event* createNewSecretBaseEvent();
     QString getMovementPermissionText(uint16_t collision, uint16_t elevation);
+    QString getMetatileDisplayMessage(uint16_t metatileId);
 
 private slots:
     void onMapStartPaint(QGraphicsSceneMouseEvent *event, MapPixmapItem *item);

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -905,13 +905,19 @@ void Editor::onHoveredMapMetatileChanged(int x, int y) {
                               .arg(y)
                               .arg(getMetatileDisplayMessage(metatileId))
                               .arg(QString::number(pow(scale_base, scale_exp), 'g', 2)));
+    } else if (map_item->paintingMode == MapPixmapItem::PaintMode::EventObjects
+        && x >= 0 && x < map->getWidth() && y >= 0 && y < map->getHeight()) {
+        this->ui->statusBar->showMessage(QString("X: %1, Y: %2")
+                              .arg(x)
+                              .arg(y));
     }
 }
 
 void Editor::onHoveredMapMetatileCleared() {
     this->playerViewRect->setVisible(false);
     this->cursorMapTileRect->setVisible(false);
-    if (map_item->paintingMode == MapPixmapItem::PaintMode::Metatiles) {
+    if (map_item->paintingMode == MapPixmapItem::PaintMode::Metatiles
+     || map_item->paintingMode == MapPixmapItem::PaintMode::EventObjects) {
         this->ui->statusBar->clearMessage();
     }
 }

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -867,7 +867,7 @@ void Editor::onHoveredMovementPermissionCleared() {
     this->ui->statusBar->clearMessage();
 }
 
-void Editor::onHoveredMetatileSelectionChanged(uint16_t metatileId) {
+QString Editor::getMetatileDisplayMessage(uint16_t metatileId) {
     Metatile *metatile = Tileset::getMetatile(metatileId, map->layout->tileset_primary, map->layout->tileset_secondary);
     QString message;
     QString hexString = QString("%1").arg(metatileId, 3, 16, QChar('0')).toUpper();
@@ -876,7 +876,11 @@ void Editor::onHoveredMetatileSelectionChanged(uint16_t metatileId) {
     } else {
         message = QString("Metatile: 0x%1").arg(hexString);
     }
-    this->ui->statusBar->showMessage(message);
+    return message;
+}
+
+void Editor::onHoveredMetatileSelectionChanged(uint16_t metatileId) {
+    this->ui->statusBar->showMessage(getMetatileDisplayMessage(metatileId));
 }
 
 void Editor::onHoveredMetatileSelectionCleared() {
@@ -895,11 +899,11 @@ void Editor::onHoveredMapMetatileChanged(int x, int y) {
     if (map_item->paintingMode == MapPixmapItem::PaintMode::Metatiles
      && x >= 0 && x < map->getWidth() && y >= 0 && y < map->getHeight()) {
         int blockIndex = y * map->getWidth() + x;
-        int tile = map->layout->blockdata->blocks->at(blockIndex).tile;
-        this->ui->statusBar->showMessage(QString("X: %1, Y: %2, Metatile: 0x%3, Scale = %4x")
+        int metatileId = map->layout->blockdata->blocks->at(blockIndex).tile;
+        this->ui->statusBar->showMessage(QString("X: %1, Y: %2, %3, Scale = %4x")
                               .arg(x)
                               .arg(y)
-                              .arg(QString("%1").arg(tile, 3, 16, QChar('0')).toUpper())
+                              .arg(getMetatileDisplayMessage(metatileId))
                               .arg(QString::number(pow(scale_base, scale_exp), 'g', 2)));
     }
 }


### PR DESCRIPTION
Mousing over metatiles in the map view will now show the metatile label name in the bottom left, as is already done in the metatile selector