### PR TITLE
Disable invalid metatile selection in tileset editor

### DIFF
--- a/include/ui/tileseteditormetatileselector.h
+++ b/include/ui/tileseteditormetatileselector.h
@@ -33,7 +33,7 @@ private:
     void updateSelectedMetatile();
     uint16_t getMetatileId(int x, int y);
     QPoint getMetatileIdCoords(uint16_t);
-    uint16_t getValidMetatileId(uint16_t);
+    bool shouldAcceptEvent(QGraphicsSceneMouseEvent*);
 
 signals:
     void hoveredMetatileChanged(uint16_t);

--- a/include/ui/tileseteditormetatileselector.h
+++ b/include/ui/tileseteditormetatileselector.h
@@ -17,6 +17,7 @@ public:
     void select(uint16_t metatileId);
     void setTilesets(Tileset*, Tileset*);
     uint16_t getSelectedMetatile();
+    void updateSelectedMetatile();
 
 protected:
     void mousePressEvent(QGraphicsSceneMouseEvent*);
@@ -30,7 +31,6 @@ private:
     Tileset *secondaryTileset = nullptr;
     uint16_t selectedMetatile;
     int numMetatilesWide;
-    void updateSelectedMetatile();
     uint16_t getMetatileId(int x, int y);
     QPoint getMetatileIdCoords(uint16_t);
     bool shouldAcceptEvent(QGraphicsSceneMouseEvent*);

--- a/src/ui/tileseteditor.cpp
+++ b/src/ui/tileseteditor.cpp
@@ -650,6 +650,7 @@ void TilesetEditor::on_actionChange_Metatiles_Count_triggered()
             this->secondaryTileset->metatiles->append(metatile);
         }
 
+        this->metatileSelector->updateSelectedMetatile();
         this->refresh();
         this->hasUnsavedChanges = true;
     }

--- a/src/ui/tileseteditormetatileselector.cpp
+++ b/src/ui/tileseteditormetatileselector.cpp
@@ -54,6 +54,9 @@ void TilesetEditorMetatileSelector::updateSelectedMetatile() {
     uint16_t metatileId = this->getMetatileId(origin.x(), origin.y());
     if (Tileset::metatileIsValid(metatileId, this->primaryTileset, this->secondaryTileset))
         this->selectedMetatile = metatileId;
+    else
+        this->selectedMetatile = 0;
+    emit selectedMetatileChanged(this->selectedMetatile);
 }
 
 uint16_t TilesetEditorMetatileSelector::getSelectedMetatile() {
@@ -78,7 +81,6 @@ void TilesetEditorMetatileSelector::mousePressEvent(QGraphicsSceneMouseEvent *ev
     if (!shouldAcceptEvent(event)) return;
     SelectablePixmapItem::mousePressEvent(event);
     this->updateSelectedMetatile();
-    emit selectedMetatileChanged(this->selectedMetatile);
 }
 
 void TilesetEditorMetatileSelector::mouseMoveEvent(QGraphicsSceneMouseEvent *event) {
@@ -86,14 +88,12 @@ void TilesetEditorMetatileSelector::mouseMoveEvent(QGraphicsSceneMouseEvent *eve
     SelectablePixmapItem::mouseMoveEvent(event);
     this->updateSelectedMetatile();
     emit hoveredMetatileChanged(this->selectedMetatile);
-    emit selectedMetatileChanged(this->selectedMetatile);
 }
 
 void TilesetEditorMetatileSelector::mouseReleaseEvent(QGraphicsSceneMouseEvent *event) {
     if (!shouldAcceptEvent(event)) return;
     SelectablePixmapItem::mouseReleaseEvent(event);
     this->updateSelectedMetatile();
-    emit selectedMetatileChanged(this->selectedMetatile);
 }
 
 void TilesetEditorMetatileSelector::hoverMoveEvent(QGraphicsSceneHoverEvent *event) {


### PR DESCRIPTION
It's still possible to select invalid metatiles in the tileset editor. This replicates the fix done for the metatile selector in the main editor.
Also incidentally found and fixed a potential crash when the currently selected metatile becomes invalid by reducing the number of metatiles in the tileset