### PR TITLE
Fix a crash that occured when creating a new tileset using triple layer mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project somewhat adheres to [Semantic Versioning](https://semver.org/sp
 The **"Breaking Changes"** listed below are changes that have been made in the decompilation projects (e.g. pokeemerald), which porymap requires in order to work properly. If porymap is used on a project that is not up-to-date with the breaking changes, then porymap will likely break or behave improperly.
 
 ## [Unreleased]
-Nothing, yet.
+### Fixed
+- Fix a crash that occured when creating a new tileset using triple layer mode
 
 ## [4.3.0] - 2020-06-27
 ### Added

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1070,8 +1070,9 @@ void MainWindow::on_actionNew_Tileset_triggered() {
         editor->project->loadTilesetTiles(newSet, *tilesImage);
         newSet->metatiles = new QList<Metatile*>();
         for(int i = 0; i < numMetaTiles; ++i) {
+            int tilesPerMetatile = projectConfig.getTripleLayerMetatilesEnabled() ? 12 : 8;
             Metatile *mt = new Metatile();
-            for(int j = 0; j < 8; ++j){
+            for(int j = 0; j < tilesPerMetatile; ++j){
                 Tile *tile = new Tile();
                 //Create a checkerboard-style dummy tileset
                 if(((i / 8) % 2) == 0)


### PR DESCRIPTION
When creating a new tileset porymap did not respect that it has to create one additional metatile layer in triple layer mode.

fixes #254