### PR TITLE
Misc fixes for tileset editor

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -2333,6 +2333,7 @@ void MainWindow::on_comboBox_PrimaryTileset_currentTextChanged(const QString &ti
         editor->updatePrimaryTileset(tilesetLabel);
         redrawMapScene();
         on_horizontalSlider_MetatileZoom_valueChanged(ui->horizontalSlider_MetatileZoom->value());
+        updateTilesetEditor();
     }
 }
 
@@ -2342,6 +2343,7 @@ void MainWindow::on_comboBox_SecondaryTileset_currentTextChanged(const QString &
         editor->updateSecondaryTileset(tilesetLabel);
         redrawMapScene();
         on_horizontalSlider_MetatileZoom_valueChanged(ui->horizontalSlider_MetatileZoom->value());
+        updateTilesetEditor();
     }
 }
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1156,6 +1156,8 @@ void MainWindow::currentMetatilesSelectionChanged()
         pos *= scale;
         ui->scrollArea_2->ensureVisible(pos.x(), pos.y(), 8 * scale, 8 * scale);
     }
+    if (this->tilesetEditor)
+        this->tilesetEditor->selectMetatile(editor->metatile_selector_item->getSelectedMetatiles()->at(0));
 }
 
 void MainWindow::on_mapList_activated(const QModelIndex &index)

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -2247,9 +2247,23 @@ void MainWindow::onMapCacheCleared() {
 }
 
 void MainWindow::onTilesetsSaved(QString primaryTilesetLabel, QString secondaryTilesetLabel) {
-    this->editor->updatePrimaryTileset(primaryTilesetLabel, true);
-    this->editor->updateSecondaryTileset(secondaryTilesetLabel, true);
-    redrawMapScene();
+    // If saved tilesets are currently in-use, update them and redraw
+    // Otherwise overwrite the cache for the saved tileset
+    bool updated = false;
+    if (primaryTilesetLabel == this->editor->map->layout->tileset_primary_label) {
+        this->editor->updatePrimaryTileset(primaryTilesetLabel, true);
+        updated = true;
+    } else {
+        this->editor->project->getTileset(primaryTilesetLabel, true);
+    }
+    if (secondaryTilesetLabel == this->editor->map->layout->tileset_secondary_label)  {
+        this->editor->updateSecondaryTileset(secondaryTilesetLabel, true);
+        updated = true;
+    } else {
+        this->editor->project->getTileset(secondaryTilesetLabel, true);
+    }
+    if (updated)
+        redrawMapScene();
 }
 
 void MainWindow::onWildMonDataChanged() {

--- a/src/ui/tileseteditor.cpp
+++ b/src/ui/tileseteditor.cpp
@@ -376,6 +376,7 @@ void TilesetEditor::on_comboBox_metatileBehaviors_activated(const QString &metat
         this->metatile->behavior = static_cast<uint8_t>(project->metatileBehaviorMap[metatileBehavior]);
         MetatileHistoryItem *commit = new MetatileHistoryItem(metatileSelector->getSelectedMetatile(), prevMetatile, this->metatile->copy());
         metatileHistory.push(commit);
+        this->hasUnsavedChanges = true;
     }
 }
 
@@ -392,6 +393,7 @@ void TilesetEditor::saveMetatileLabel()
         this->metatile->label = this->ui->lineEdit_metatileLabel->text();
         MetatileHistoryItem *commit = new MetatileHistoryItem(metatileSelector->getSelectedMetatile(), prevMetatile, this->metatile->copy());
         metatileHistory.push(commit);
+        this->hasUnsavedChanges = true;
     }
 }
 
@@ -402,6 +404,7 @@ void TilesetEditor::on_comboBox_layerType_activated(int layerType)
         this->metatile->layerType = static_cast<uint8_t>(layerType);
         MetatileHistoryItem *commit = new MetatileHistoryItem(metatileSelector->getSelectedMetatile(), prevMetatile, this->metatile->copy());
         metatileHistory.push(commit);
+        this->hasUnsavedChanges = true;
     }
 }
 
@@ -412,6 +415,7 @@ void TilesetEditor::on_comboBox_encounterType_activated(int encounterType)
         this->metatile->encounterType = static_cast<uint8_t>(encounterType);
         MetatileHistoryItem *commit = new MetatileHistoryItem(metatileSelector->getSelectedMetatile(), prevMetatile, this->metatile->copy());
         metatileHistory.push(commit);
+        this->hasUnsavedChanges = true;
     }
 }
 
@@ -422,6 +426,7 @@ void TilesetEditor::on_comboBox_terrainType_activated(int terrainType)
         this->metatile->terrainType = static_cast<uint8_t>(terrainType);
         MetatileHistoryItem *commit = new MetatileHistoryItem(metatileSelector->getSelectedMetatile(), prevMetatile, this->metatile->copy());
         metatileHistory.push(commit);
+        this->hasUnsavedChanges = true;
     }
 }
 

--- a/src/ui/tileseteditor.cpp
+++ b/src/ui/tileseteditor.cpp
@@ -112,6 +112,17 @@ void TilesetEditor::selectMetatile(uint16_t metatileId) {
 }
 
 void TilesetEditor::setTilesets(QString primaryTilesetLabel, QString secondaryTilesetLabel) {
+    if (this->hasUnsavedChanges) {
+        QMessageBox::StandardButton result = QMessageBox::question(
+            this,
+            "porymap",
+            "Tileset has been modified, save changes?",
+            QMessageBox::No | QMessageBox::Yes,
+            QMessageBox::Yes);
+        if (result == QMessageBox::Yes)
+            this->on_actionSave_Tileset_triggered();
+    }
+    this->hasUnsavedChanges = false;
     delete this->primaryTileset;
     delete this->secondaryTileset;
     Tileset *primaryTileset = project->getTileset(primaryTilesetLabel);


### PR DESCRIPTION
- Sync selected metatile in tileset editor to map(#257)
- Sync tilesets in tileset editor to map 
- Metatile attributes and labels included in unsaved changes
- Prompt for unsaved changes when changing tileset/map

There's definitely a better way to clear the tileset cache in `onTilesetsSaved`, feel free to change that