### PR TITLE
Fix more methods of selecting invalid metatiles

### DIFF
--- a/include/ui/metatileselector.h
+++ b/include/ui/metatileselector.h
@@ -52,6 +52,7 @@ private:
     uint16_t getMetatileId(int x, int y);
     QPoint getMetatileIdCoords(uint16_t);
     bool shouldAcceptEvent(QGraphicsSceneMouseEvent*);
+    bool selectionIsValid();
 
 signals:
     void hoveredMetatileSelectionChanged(uint16_t);

--- a/include/ui/metatileselector.h
+++ b/include/ui/metatileselector.h
@@ -23,8 +23,8 @@ public:
     }
     QPoint getSelectionDimensions();
     void draw();
-    void select(uint16_t metatile);
-    void selectFromMap(uint16_t metatileId, uint16_t collision, uint16_t elevation);
+    bool select(uint16_t metatile);
+    bool selectFromMap(uint16_t metatileId, uint16_t collision, uint16_t elevation);
     void setTilesets(Tileset*, Tileset*);
     QList<uint16_t>* getSelectedMetatiles();
     QList<QPair<uint16_t, uint16_t>>* getSelectedCollisions();

--- a/include/ui/tileseteditor.h
+++ b/include/ui/tileseteditor.h
@@ -39,7 +39,7 @@ public:
     ~TilesetEditor();
     void setMap(Map*);
     void setTilesets(QString, QString);
-    void selectMetatile(uint16_t metatileId);
+    bool selectMetatile(uint16_t metatileId);
 
 private slots:
     void onHoveredMetatileChanged(uint16_t);

--- a/include/ui/tileseteditormetatileselector.h
+++ b/include/ui/tileseteditormetatileselector.h
@@ -17,7 +17,7 @@ public:
     }
     Map *map = nullptr;
     void draw();
-    void select(uint16_t metatileId);
+    bool select(uint16_t metatileId);
     void setTilesets(Tileset*, Tileset*);
     uint16_t getSelectedMetatile();
     void updateSelectedMetatile();

--- a/src/core/tileset.cpp
+++ b/src/core/tileset.cpp
@@ -82,7 +82,7 @@ bool Tileset::metatileIsValid(uint16_t metatileId, Tileset *primaryTileset, Tile
     if (metatileId < Project::getNumMetatilesPrimary() && metatileId >= primaryTileset->metatiles->length())
         return false;
 
-    if (metatileId < Project::getNumMetatilesTotal() && metatileId >= Project::getNumMetatilesPrimary() + secondaryTileset->metatiles->length())
+    if (metatileId >= Project::getNumMetatilesPrimary() + secondaryTileset->metatiles->length())
         return false;
 
     return true;

--- a/src/ui/metatileselector.cpp
+++ b/src/ui/metatileselector.cpp
@@ -51,7 +51,6 @@ void MetatileSelector::select(uint16_t metatileId) {
     QPoint coords = this->getMetatileIdCoords(metatileId);
     SelectablePixmapItem::select(coords.x(), coords.y(), 0, 0);
     this->updateSelectedMetatiles();
-    emit selectedMetatilesChanged();
 }
 
 void MetatileSelector::selectFromMap(uint16_t metatileId, uint16_t collision, uint16_t elevation) {
@@ -62,6 +61,8 @@ void MetatileSelector::selectFromMap(uint16_t metatileId, uint16_t collision, ui
 void MetatileSelector::setTilesets(Tileset *primaryTileset, Tileset *secondaryTileset) {
     this->primaryTileset = primaryTileset;
     this->secondaryTileset = secondaryTileset;
+    if (!this->selectionIsValid())
+        this->select(Project::getNumMetatilesPrimary() + this->secondaryTileset->metatiles->length() - 1);
     this->draw();
 }
 
@@ -101,7 +102,6 @@ void MetatileSelector::mousePressEvent(QGraphicsSceneMouseEvent *event) {
     if (!shouldAcceptEvent(event)) return;
     SelectablePixmapItem::mousePressEvent(event);
     this->updateSelectedMetatiles();
-    emit selectedMetatilesChanged();
 }
 
 void MetatileSelector::mouseMoveEvent(QGraphicsSceneMouseEvent *event) {
@@ -112,14 +112,12 @@ void MetatileSelector::mouseMoveEvent(QGraphicsSceneMouseEvent *event) {
     QPoint pos = this->getCellPos(event->pos());
     uint16_t metatileId = this->getMetatileId(pos.x(), pos.y());
     emit this->hoveredMetatileSelectionChanged(metatileId);
-    emit selectedMetatilesChanged();
 }
 
 void MetatileSelector::mouseReleaseEvent(QGraphicsSceneMouseEvent *event) {
     if (!shouldAcceptEvent(event)) return;
     SelectablePixmapItem::mouseReleaseEvent(event);
     this->updateSelectedMetatiles();
-    emit selectedMetatilesChanged();
 }
 
 void MetatileSelector::hoverMoveEvent(QGraphicsSceneHoverEvent *event) {
@@ -144,6 +142,19 @@ void MetatileSelector::updateSelectedMetatiles() {
             this->selectedMetatiles->append(metatileId);
         }
     }
+    emit selectedMetatilesChanged();
+}
+
+bool MetatileSelector::selectionIsValid() {
+    QPoint origin = this->getSelectionStart();
+    QPoint dimensions = this->getSelectionDimensions();
+    for (int j = 0; j < dimensions.y(); j++) {
+        for (int i = 0; i < dimensions.x(); i++) {
+            if (!Tileset::metatileIsValid(this->getMetatileId(origin.x() + i, origin.y() + j), this->primaryTileset, this->secondaryTileset))
+                return false;
+        }
+    }
+    return true;
 }
 
 uint16_t MetatileSelector::getMetatileId(int x, int y) {

--- a/src/ui/metatileselector.cpp
+++ b/src/ui/metatileselector.cpp
@@ -46,16 +46,20 @@ void MetatileSelector::draw() {
     }
 }
 
-void MetatileSelector::select(uint16_t metatileId) {
+bool MetatileSelector::select(uint16_t metatileId) {
+    if (!Tileset::metatileIsValid(metatileId, this->primaryTileset, this->secondaryTileset)) return false;
     this->externalSelection = false;
     QPoint coords = this->getMetatileIdCoords(metatileId);
     SelectablePixmapItem::select(coords.x(), coords.y(), 0, 0);
     this->updateSelectedMetatiles();
+    return true;
 }
 
-void MetatileSelector::selectFromMap(uint16_t metatileId, uint16_t collision, uint16_t elevation) {
+bool MetatileSelector::selectFromMap(uint16_t metatileId, uint16_t collision, uint16_t elevation) {
+    if (!Tileset::metatileIsValid(metatileId, this->primaryTileset, this->secondaryTileset)) return false;
     this->select(metatileId);
     this->selectedCollisions->append(QPair<uint16_t, uint16_t>(collision, elevation));
+    return true;
 }
 
 void MetatileSelector::setTilesets(Tileset *primaryTileset, Tileset *secondaryTileset) {

--- a/src/ui/tileseteditor.cpp
+++ b/src/ui/tileseteditor.cpp
@@ -105,12 +105,12 @@ void TilesetEditor::init(Project *project, Map *map) {
     metatileHistory.push(commit);
 }
 
-void TilesetEditor::selectMetatile(uint16_t metatileId) {
-    if (Tileset::metatileIsValid(metatileId, this->primaryTileset, this->secondaryTileset)) {
-        this->metatileSelector->select(metatileId);
-        QPoint pos = this->metatileSelector->getMetatileIdCoordsOnWidget(metatileId);
-        this->ui->scrollArea_Metatiles->ensureVisible(pos.x(), pos.y());
-    }
+bool TilesetEditor::selectMetatile(uint16_t metatileId) {
+    if (!Tileset::metatileIsValid(metatileId, this->primaryTileset, this->secondaryTileset)) return false;
+    this->metatileSelector->select(metatileId);
+    QPoint pos = this->metatileSelector->getMetatileIdCoordsOnWidget(metatileId);
+    this->ui->scrollArea_Metatiles->ensureVisible(pos.x(), pos.y());
+    return true;
 }
 
 void TilesetEditor::setMap(Map *map) {

--- a/src/ui/tileseteditor.cpp
+++ b/src/ui/tileseteditor.cpp
@@ -106,9 +106,11 @@ void TilesetEditor::init(Project *project, Map *map) {
 }
 
 void TilesetEditor::selectMetatile(uint16_t metatileId) {
-    this->metatileSelector->select(metatileId);
-    QPoint pos = this->metatileSelector->getMetatileIdCoordsOnWidget(metatileId);
-    this->ui->scrollArea_Metatiles->ensureVisible(pos.x(), pos.y());
+    if (Tileset::metatileIsValid(metatileId, this->primaryTileset, this->secondaryTileset)) {
+        this->metatileSelector->select(metatileId);
+        QPoint pos = this->metatileSelector->getMetatileIdCoordsOnWidget(metatileId);
+        this->ui->scrollArea_Metatiles->ensureVisible(pos.x(), pos.y());
+    }
 }
 
 void TilesetEditor::setMap(Map *map) {

--- a/src/ui/tileseteditormetatileselector.cpp
+++ b/src/ui/tileseteditormetatileselector.cpp
@@ -42,12 +42,13 @@ void TilesetEditorMetatileSelector::draw() {
     this->drawSelection();
 }
 
-void TilesetEditorMetatileSelector::select(uint16_t metatileId) {
-    if (!Tileset::metatileIsValid(metatileId, this->primaryTileset, this->secondaryTileset)) return;
+bool TilesetEditorMetatileSelector::select(uint16_t metatileId) {
+    if (!Tileset::metatileIsValid(metatileId, this->primaryTileset, this->secondaryTileset)) return false;
     QPoint coords = this->getMetatileIdCoords(metatileId);
     SelectablePixmapItem::select(coords.x(), coords.y(), 0, 0);
     this->selectedMetatile = metatileId;
     emit selectedMetatileChanged(metatileId);
+    return true;
 }
 
 void TilesetEditorMetatileSelector::setTilesets(Tileset *primaryTileset, Tileset *secondaryTileset) {

--- a/src/ui/tileseteditormetatileselector.cpp
+++ b/src/ui/tileseteditormetatileselector.cpp
@@ -62,7 +62,7 @@ void TilesetEditorMetatileSelector::updateSelectedMetatile() {
     if (Tileset::metatileIsValid(metatileId, this->primaryTileset, this->secondaryTileset))
         this->selectedMetatile = metatileId;
     else
-        this->selectedMetatile = 0;
+        this->selectedMetatile = Project::getNumMetatilesPrimary() + this->secondaryTileset->metatiles->length() - 1;
     emit selectedMetatileChanged(this->selectedMetatile);
 }
 


### PR DESCRIPTION
Fixes the following methods of selecting invalid metatiles
- By switching to a tileset where the current metatile selection is not valid
- By reducing the number of metatiles with the tileset editor, then selecting beyond the reduced tileset with the map metatile selector

Also changed: when the currently selected metatile is invalidated, the last valid metatile is now selected instead of metatile 0