### PR TITLE
Fix increasing metatileset size in tileset editor crashing when triple layer is enabled

### DIFF
--- a/src/ui/tileseteditor.cpp
+++ b/src/ui/tileseteditor.cpp
@@ -638,6 +638,7 @@ void TilesetEditor::on_actionChange_Metatiles_Count_triggered()
     if (dialog.exec() == QDialog::Accepted) {
         int numPrimaryMetatiles = primarySpinBox->value();
         int numSecondaryMetatiles = secondarySpinBox->value();
+        int numTiles = projectConfig.getTripleLayerMetatilesEnabled() ? 12 : 8;
         while (this->primaryTileset->metatiles->length() > numPrimaryMetatiles) {
             Metatile *metatile = this->primaryTileset->metatiles->takeLast();
             delete metatile;
@@ -653,7 +654,7 @@ void TilesetEditor::on_actionChange_Metatiles_Count_triggered()
             metatile->layerType = 0;
             metatile->encounterType = 0;
             metatile->terrainType = 0;
-            for (int i = 0; i < 8; i++) {
+            for (int i = 0; i < numTiles; i++) {
                 metatile->tiles->append(tile);
             }
             this->primaryTileset->metatiles->append(metatile);
@@ -673,7 +674,7 @@ void TilesetEditor::on_actionChange_Metatiles_Count_triggered()
             metatile->layerType = 0;
             metatile->encounterType = 0;
             metatile->terrainType = 0;
-            for (int i = 0; i < 8; i++) {
+            for (int i = 0; i < numTiles; i++) {
                 metatile->tiles->append(tile);
             }
             this->secondaryTileset->metatiles->append(metatile);


### PR DESCRIPTION
Reported by dragonfly on Discord:

> 1. Use the Three Layer Block Feature
> 2. Create a new Tileset (secondary)
> 3. Change the number of Metatile to 1 and then to 512
> 4. Try to save the Tileset
> 5. See the Crash