### PR TITLE
Add duplicate shortcut for events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,17 @@ and this project somewhat adheres to [Semantic Versioning](https://semver.org/sp
 The **"Breaking Changes"** listed below are changes that have been made in the decompilation projects (e.g. pokeemerald), which porymap requires in order to work properly. If porymap is used on a project that is not up-to-date with the breaking changes, then porymap will likely break or behave improperly.
 
 ## [Unreleased]
+### Added
+- Add keyboard shortcut `Ctrl + D` for duplicating map events.
+
+### Changed
+- The tileset editor now syncs its metatile selection with the map's metatile selector.
+
 ### Fixed
-- Fix a crash that occured when creating a new tileset using triple layer mode
+- Fix a crash that occured when creating a new tileset using triple layer mode.
+- Fix crash when reducing number of metatiles past current selection.
+- Fix various methods of selecting invalid metatiles.
+- Fix sprite transparency not updating when changing object event graphics.
 
 ## [4.3.0] - 2020-06-27
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The **"Breaking Changes"** listed below are changes that have been made in the d
 
 ### Changed
 - The tileset editor now syncs its metatile selection with the map's metatile selector.
+- The number of object events per map is now limited to OBJECT_EVENT_TEMPLATES_COUNT
 
 ### Fixed
 - Fix a crash that occured when creating a new tileset using triple layer mode.

--- a/docsrc/manual/editing-map-events.rst
+++ b/docsrc/manual/editing-map-events.rst
@@ -19,6 +19,19 @@ All of the events are visible on the map.  The Event Details window on the right
 .. warning::
     There is currently no undo/redo functionality when editing events!  Use Git version control!
 
+Adding & Deleting Events
+------------------------
+
+To add a new event, press the green plus button. |add-event-button|  You can choose between the different types of events by clicking the small arrow on the right. You can also duplicate any currently selected events with ``Ctrl+D``.
+
+.. |add-event-button|
+   image:: images/editing-map-events/add-event-button.png
+
+To delete the selected event, press the delete button. |delete-event-button|
+
+.. |delete-event-button|
+   image:: images/editing-map-events/delete-event-button.png
+
 Event Positions
 ----------------
 
@@ -208,19 +221,6 @@ Respawn Map
 
 Respawn NPC
     Exclusive to pokefirered. The local id of the NPC the player will interact with when they white out.
-
-Adding & Deleting Events
-------------------------
-
-To add a new event, press the green plus button. |add-event-button|  You can choose between the different types of events by clicking the small arrow on the right.
-
-.. |add-event-button|
-   image:: images/editing-map-events/add-event-button.png
-
-To delete the selected event, press the delete button. |delete-event-button|
-
-.. |delete-event-button|
-   image:: images/editing-map-events/delete-event-button.png
 
 Open Map Scripts
 ----------------

--- a/docsrc/manual/project-files.rst
+++ b/docsrc/manual/project-files.rst
@@ -26,6 +26,7 @@ to a file, it probably is not a good idea to edit yourself unless otherwise note
    src/data/graphics/pokemon.h, yes, no, for pokemon sprite icons
    src/data/heal_locations.h, yes, yes, 
    src/data/region_map/region_map_entries.h, yes, yes, 
+   include/constants/global.h, yes, no, 
    include/constants/map_groups.h, no, yes, 
    include/constants/items.h, yes, no, 
    include/constants/flags.h, yes, no, 

--- a/include/core/event.h
+++ b/include/core/event.h
@@ -27,6 +27,7 @@ class Event
 {
 public:
     Event();
+    Event(const Event&);
     Event(QJsonObject, QString);
 public:
     int x() {

--- a/include/editor.h
+++ b/include/editor.h
@@ -100,6 +100,7 @@ public:
     Event* createNewEvent(QString event_type);
     void deleteEvent(Event *);
     void updateSelectedEvents();
+    void duplicateSelectedEvents();
     void redrawObject(DraggablePixmapItem *item);
     QList<DraggablePixmapItem *> *getObjects();
 

--- a/include/editor.h
+++ b/include/editor.h
@@ -170,6 +170,7 @@ private:
     Event* createNewSecretBaseEvent();
     QString getMovementPermissionText(uint16_t collision, uint16_t elevation);
     QString getMetatileDisplayMessage(uint16_t metatileId);
+    bool eventLimitReached(Map *, QString);
 
 private slots:
     void onMapStartPaint(QGraphicsSceneMouseEvent *event, MapPixmapItem *item);

--- a/include/mainwindow.h
+++ b/include/mainwindow.h
@@ -123,6 +123,7 @@ private slots:
 
     void undo();
     void redo();
+    void duplicate();
 
     void openInTextEditor();
 

--- a/include/project.h
+++ b/include/project.h
@@ -192,6 +192,7 @@ public:
     static int getMapDataSize(int width, int height);
     static bool mapDimensionsValid(int width, int height);
     bool calculateDefaultMapSize();
+    static int getMaxObjectEvents();
 
 private:
     void updateMapLayout(Map*);
@@ -213,6 +214,7 @@ private:
     static int num_pals_total;
     static int max_map_data_size;
     static int default_map_size;
+    static int max_object_events;
 
     QWidget *parent;
 

--- a/src/core/event.cpp
+++ b/src/core/event.cpp
@@ -19,6 +19,19 @@ Event::Event()
     this->usingSprite = false;
 }
 
+Event::Event(const Event& toCopy)
+{
+    Event();
+    this->values = toCopy.values;
+    this->customValues = toCopy.customValues;
+    this->pixmap = toCopy.pixmap;
+    this->spriteWidth = toCopy.spriteWidth;
+    this->spriteHeight = toCopy.spriteHeight;
+    this->frame = toCopy.frame;
+    this->hFlip = toCopy.hFlip;
+    this->usingSprite = toCopy.usingSprite;
+}
+
 Event::Event(QJsonObject obj, QString type)
 {
     Event();

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -1893,6 +1893,7 @@ void Editor::duplicateSelectedEvents() {
             logWarn(QString("Skipping duplication, the map limit for events of type '%1' has been reached.").arg(eventType));
             continue;
         }
+        if (eventType == EventType::HealLocation) continue;
         Event *duplicate = new Event(*original);
         map->addEvent(duplicate);
         DraggablePixmapItem *object = addMapEvent(duplicate);

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -1881,6 +1881,22 @@ void Editor::selectMapEvent(DraggablePixmapItem *object, bool toggle) {
     }
 }
 
+void Editor::duplicateSelectedEvents() {
+    if (!selected_events || !selected_events->length() || !map || !current_view || map_item->paintingMode != MapPixmapItem::PaintMode::EventObjects)
+        return;
+
+    QList<DraggablePixmapItem*> *duplicates = new QList<DraggablePixmapItem*>;
+    for (int i = 0; i < selected_events->length(); i++) {
+        Event *duplicate = new Event(*selected_events->at(i)->event);
+        map->addEvent(duplicate);
+        DraggablePixmapItem *object = addMapEvent(duplicate);
+        duplicates->append(object);
+    }
+    selected_events->clear();
+    selected_events = duplicates;
+    updateSelectedEvents();
+}
+
 DraggablePixmapItem* Editor::addNewEvent(QString event_type) {
     if (project && map && !event_type.isEmpty()) {
         Event *event = Event::createNewEvent(event_type, map->name, project);

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -980,7 +980,7 @@ void MainWindow::onNewMapCreated() {
     setMap(newMapName, true);
 
     if (newMap->isFlyable == "TRUE") {
-        addNewEvent("event_heal_location");
+        addNewEvent(EventType::HealLocation);
         editor->project->saveHealLocationStruct(newMap);
         editor->save();// required
     }
@@ -1413,11 +1413,22 @@ void MainWindow::resetMapViewScale() {
 
 void MainWindow::addNewEvent(QString event_type)
 {
-    if (editor) {
+    if (editor && editor->project) {
         DraggablePixmapItem *object = editor->addNewEvent(event_type);
-        updateObjects();
         if (object) {
+            updateObjects();
             editor->selectMapEvent(object, false);
+        } else {
+            QMessageBox msgBox(this);
+            msgBox.setText("Failed to add new event");
+            if (event_type == EventType::Object) {
+                msgBox.setInformativeText(QString("The limit for object events (%1) has been reached.\n\n"
+                                                  "This limit can be adjusted with OBJECT_EVENT_TEMPLATES_COUNT in 'include/constants/global.h'.")
+                                          .arg(editor->project->getMaxObjectEvents()));
+            }
+            msgBox.setDefaultButton(QMessageBox::Ok);
+            msgBox.setIcon(QMessageBox::Icon::Warning);
+            msgBox.exec();
         }
     }
 }
@@ -1534,7 +1545,7 @@ void MainWindow::updateSelectedObjects() {
         QString event_group_type = item->event->get("event_group_type");
         QString map_name = item->event->get("map_name");
         int event_offs;
-        if (event_type == "event_warp") { event_offs = 0; }
+        if (event_type == EventType::Warp) { event_offs = 0; }
         else { event_offs = 1; }
         frame->ui->label_name->setText(QString("%1 Id").arg(event_type));
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -77,6 +77,7 @@ void MainWindow::initExtraShortcuts() {
     new QShortcut(QKeySequence("Ctrl+Shift+Z"), this, SLOT(redo()));
     new QShortcut(QKeySequence("Ctrl+0"), this, SLOT(resetMapViewScale()));
     new QShortcut(QKeySequence("Ctrl+G"), ui->checkBox_ToggleGrid, SLOT(toggle()));
+    new QShortcut(QKeySequence("Ctrl+D"), this, SLOT(duplicate()));
     ui->actionZoom_In->setShortcuts({QKeySequence("Ctrl++"), QKeySequence("Ctrl+=")});
 }
 
@@ -1228,6 +1229,10 @@ void MainWindow::undo() {
 
 void MainWindow::redo() {
     editor->redo();
+}
+
+void MainWindow::duplicate() {
+    editor->duplicateSelectedEvents();
 }
 
 // Open current map scripts in system default editor for .inc files

--- a/src/project.cpp
+++ b/src/project.cpp
@@ -35,6 +35,7 @@ int Project::num_pals_primary = 6;
 int Project::num_pals_total = 13;
 int Project::max_map_data_size = 10240; // 0x2800
 int Project::default_map_size = 20;
+int Project::max_object_events = 64;
 
 Project::Project(QWidget *parent) : parent(parent)
 {
@@ -2365,6 +2366,28 @@ bool Project::readMiscellaneousConstants() {
         miscConstants.insert("max_level_define", pokemonDefines.value("MAX_LEVEL") > pokemonDefines.value("MIN_LEVEL") ? pokemonDefines.value("MAX_LEVEL") : 100);
         miscConstants.insert("min_level_define", pokemonDefines.value("MIN_LEVEL") < pokemonDefines.value("MAX_LEVEL") ? pokemonDefines.value("MIN_LEVEL") : 1);
     }
+
+    QString filename = "include/constants/global.h";
+    fileWatcher.addPath(root + "/" + filename);
+    QStringList definePrefixes;
+    definePrefixes << "OBJECT_";
+    QMap<QString, int> defines = parser.readCDefines(filename, definePrefixes);
+
+    auto it = defines.find("OBJECT_EVENT_TEMPLATES_COUNT");
+    if (it != defines.end()) {
+        if (it.value() > 0) {
+            Project::max_object_events = it.value();
+        } else {
+            logWarn(QString("Value for 'OBJECT_EVENT_TEMPLATES_COUNT' is %1, must be greater than 0. Using default (%2) instead.")
+                    .arg(it.value())
+                    .arg(Project::max_object_events));
+        }
+    }
+    else {
+        logWarn(QString("Value for 'OBJECT_EVENT_TEMPLATES_COUNT' not found. Using default (%1) instead.")
+                .arg(Project::max_object_events));
+    }
+
     return true;
 }
 
@@ -2582,4 +2605,9 @@ bool Project::calculateDefaultMapSize(){
         return false;
     }
     return true;
+}
+
+int Project::getMaxObjectEvents()
+{
+    return Project::max_object_events;
 }


### PR DESCRIPTION
Adds Ctrl/Cmd+D as a shortcut to duplicate events. Incidentally this makes it much easier to expose the fact that there's no enforced limit on creating events
Closes #269 