### PR TITLE
Fix metatile selection rect disappearing during map selection

### DIFF
--- a/src/ui/metatileselector.cpp
+++ b/src/ui/metatileselector.cpp
@@ -41,7 +41,7 @@ void MetatileSelector::draw() {
     painter.end();
     this->setPixmap(QPixmap::fromImage(image));
 
-    if (!this->externalSelection) {
+    if (!this->externalSelection || (this->externalSelectionWidth == 1 && this->externalSelectionHeight == 1)) {
         this->drawSelection();
     }
 }


### PR DESCRIPTION
Moving the mouse within a single metatile during a right-click is considered an external selection and hides the metatile selector rectangle. This can happen quite often if the mouse is moved while right-clicking single metatiles to eyedrop them. This fixes it so the selector rectangle is only hidden when multiple map metatiles are selected.