### PR TITLE
Respect x/y flip and palette for external tileset editor tile selections

### DIFF
--- a/include/ui/tileseteditortileselector.h
+++ b/include/ui/tileseteditortileselector.h
@@ -39,7 +39,7 @@ private:
     bool externalSelection;
     int externalSelectionWidth;
     int externalSelectionHeight;
-    QList<uint16_t> externalSelectedTiles;
+    QList<Tile> externalSelectedTiles;
 
     Tileset *primaryTileset;
     Tileset *secondaryTileset;
@@ -52,7 +52,7 @@ private:
     uint16_t getTileId(int x, int y);
     QPoint getTileCoords(uint16_t);
     QList<QRgb> getCurPaletteTable();
-    QList<Tile> buildSelectedTiles(int, int, QList<uint16_t>);
+    QList<Tile> buildSelectedTiles(int, int, QList<Tile>);
 
 signals:
     void hoveredTileChanged(uint16_t);

--- a/include/ui/tileseteditortileselector.h
+++ b/include/ui/tileseteditortileselector.h
@@ -24,7 +24,7 @@ public:
     void setPaletteId(int);
     void setTileFlips(bool, bool);
     QList<Tile> getSelectedTiles();
-    void setExternalSelection(int, int, QList<Tile>);
+    void setExternalSelection(int, int, QList<Tile>, QList<int>);
     QPoint getTileCoordsOnWidget(uint16_t);
     QImage buildPrimaryTilesIndexedImage();
     QImage buildSecondaryTilesIndexedImage();
@@ -41,6 +41,7 @@ private:
     int externalSelectionWidth;
     int externalSelectionHeight;
     QList<Tile> externalSelectedTiles;
+    QList<int> externalSelectedPos;
 
     Tileset *primaryTileset;
     Tileset *secondaryTileset;

--- a/include/ui/tileseteditortileselector.h
+++ b/include/ui/tileseteditortileselector.h
@@ -14,6 +14,7 @@ public:
         this->paletteId = 0;
         this->xFlip = false;
         this->yFlip = false;
+        this->paletteChanged = false;
         setAcceptHoverEvents(true);
     }
     QPoint getSelectionDimensions();
@@ -48,6 +49,7 @@ private:
     int paletteId;
     bool xFlip;
     bool yFlip;
+    bool paletteChanged;
     void updateSelectedTiles();
     uint16_t getTileId(int x, int y);
     QPoint getTileCoords(uint16_t);

--- a/include/ui/tileseteditortileselector.h
+++ b/include/ui/tileseteditortileselector.h
@@ -39,7 +39,7 @@ private:
     bool externalSelection;
     int externalSelectionWidth;
     int externalSelectionHeight;
-    QList<Tile> externalSelectedTiles;
+    QList<uint16_t> externalSelectedTiles;
 
     Tileset *primaryTileset;
     Tileset *secondaryTileset;
@@ -52,6 +52,7 @@ private:
     uint16_t getTileId(int x, int y);
     QPoint getTileCoords(uint16_t);
     QList<QRgb> getCurPaletteTable();
+    QList<Tile> buildSelectedTiles(int, int, QList<uint16_t>);
 
 signals:
     void hoveredTileChanged(uint16_t);

--- a/src/ui/tileseteditor.cpp
+++ b/src/ui/tileseteditor.cpp
@@ -341,18 +341,9 @@ void TilesetEditor::onMetatileLayerSelectionChanged(QPoint selectionOrigin, int 
         }
     }
 
-    if (width == 1 && height == 1) {
-        this->tileSelector->select(static_cast<uint16_t>(tiles[0].tile));
+    if (width == 1 && height == 1)
         ui->spinBox_paletteSelector->setValue(tiles[0].palette);
-        ui->checkBox_xFlip->setChecked(tiles[0].xflip);
-        ui->checkBox_yFlip->setChecked(tiles[0].yflip);
-        QPoint pos = tileSelector->getTileCoordsOnWidget(static_cast<uint16_t>(tiles[0].tile));
-        ui->scrollArea_Tiles->ensureVisible(pos.x(), pos.y());
-    }
-    else {
-        this->tileSelector->setExternalSelection(width, height, tiles);
-    }
-
+    this->tileSelector->setExternalSelection(width, height, tiles);
     this->metatileLayersItem->clearLastModifiedCoords();
 }
 

--- a/src/ui/tileseteditor.cpp
+++ b/src/ui/tileseteditor.cpp
@@ -328,6 +328,7 @@ void TilesetEditor::onMetatileLayerTileChanged(int x, int y) {
 
 void TilesetEditor::onMetatileLayerSelectionChanged(QPoint selectionOrigin, int width, int height) {
     QList<Tile> tiles;
+    QList<int> tileIdxs;
     int x = selectionOrigin.x();
     int y = selectionOrigin.y();
     bool isTripleLayerMetatile = projectConfig.getTripleLayerMetatilesEnabled();
@@ -337,13 +338,14 @@ void TilesetEditor::onMetatileLayerSelectionChanged(QPoint selectionOrigin, int 
             int tileIndex = ((x + i) / 2 * 4) + ((y + j) * 2) + ((x + i) % 2);
             if (tileIndex < maxTileIndex) {
                 tiles.append(this->metatile->tiles->at(tileIndex));
+                tileIdxs.append(tileIndex);
             }
         }
     }
 
     if (width == 1 && height == 1)
         ui->spinBox_paletteSelector->setValue(tiles[0].palette);
-    this->tileSelector->setExternalSelection(width, height, tiles);
+    this->tileSelector->setExternalSelection(width, height, tiles, tileIdxs);
     this->metatileLayersItem->clearLastModifiedCoords();
 }
 

--- a/src/ui/tileseteditortileselector.cpp
+++ b/src/ui/tileseteditortileselector.cpp
@@ -112,16 +112,23 @@ QList<Tile> TilesetEditorTileSelector::buildSelectedTiles(int width, int height,
     QList<QList<Tile>> tileMatrix;
     for (int j = 0; j < height; j++) {
         QList<Tile> row;
+        QList<Tile> layerRow;
         for (int i = 0; i < width; i++) {
             int index = i + j * width;
             Tile tile = selected.at(index);
             tile.xflip ^= this->xFlip;
             tile.yflip ^= this->yFlip;
-            tile.palette = this->paletteId;
             if (this->xFlip)
-                row.prepend(tile);
+                layerRow.prepend(tile);
             else
-                row.append(tile);
+                layerRow.append(tile);
+
+            // If we've completed a layer row, or its the last tile of an incompletely
+            // selected layer, then append the layer row to the full row
+            if (layerRow.length() == 2 || (width % 2 && i == width - 1)) {
+                row.append(layerRow);
+                layerRow.clear();
+            }
         }
         if (this->yFlip)
             tileMatrix.prepend(row);

--- a/src/ui/tileseteditortileselector.cpp
+++ b/src/ui/tileseteditortileselector.cpp
@@ -128,7 +128,8 @@ QList<Tile> TilesetEditorTileSelector::buildSelectedTiles(int width, int height,
 
             // If we've completed a layer row, or its the last tile of an incompletely
             // selected layer, then append the layer row to the full row
-            if (layerRow.length() == 2 || (width % 2 && i == width - 1)) {
+            // If not an external selection, treat the whole row as 1 "layer"
+            if (i == width - 1 || (this->externalSelection && (this->externalSelectedPos.at(index) % 4) & 1)) {
                 row.append(layerRow);
                 layerRow.clear();
             }
@@ -146,16 +147,15 @@ QList<Tile> TilesetEditorTileSelector::buildSelectedTiles(int width, int height,
     return tiles;
 }
 
-void TilesetEditorTileSelector::setExternalSelection(int width, int height, QList<Tile> tiles) {
+void TilesetEditorTileSelector::setExternalSelection(int width, int height, QList<Tile> tiles, QList<int> tileIdxs) {
     this->externalSelection = true;
     this->paletteChanged = false;
     this->externalSelectionWidth = width;
     this->externalSelectionHeight = height;
     this->externalSelectedTiles.clear();
-    for (int i = 0; i < tiles.length(); i++) {
-        this->externalSelectedTiles.append(tiles.at(i));
-    }
-
+    this->externalSelectedTiles.append(tiles);
+    this->externalSelectedPos.clear();
+    this->externalSelectedPos.append(tileIdxs);
     this->draw();
     emit selectedTilesChanged();
 }

--- a/src/ui/tileseteditortileselector.cpp
+++ b/src/ui/tileseteditortileselector.cpp
@@ -95,36 +95,37 @@ void TilesetEditorTileSelector::updateSelectedTiles() {
 
 QList<Tile> TilesetEditorTileSelector::getSelectedTiles() {
     if (this->externalSelection) {
-        return this->externalSelectedTiles;
+        return buildSelectedTiles(this->externalSelectionWidth, this->externalSelectionHeight, this->externalSelectedTiles);
     } else {
-        QList<Tile> tiles;
-        QList<QList<Tile>> tileMatrix;
-        QList<uint16_t> selected = this->selectedTiles;
         QPoint dimensions = this->getSelectionDimensions();
-        int width = dimensions.x();
-        int height = dimensions.y();
-        for (int j = 0; j < height; j++) {
-            QList<Tile> row;
-            for (int i = 0; i < width; i++) {
-                int index = i + j * width;
-                uint16_t tile = selected.at(index);
-                if (this->xFlip)
-                    row.prepend(Tile(tile, this->xFlip, this->yFlip, this->paletteId));
-                else
-                    row.append(Tile(tile, this->xFlip, this->yFlip, this->paletteId));
-            }
-            if (this->yFlip)
-                tileMatrix.prepend(row);
-            else
-                tileMatrix.append(row);
-        }
-        for (int j = 0; j < height; j++) {
-            for (int i = 0; i < width; i++) {
-                tiles.append(tileMatrix.at(j).at(i));
-            }
-        }
-        return tiles;
+        return buildSelectedTiles(dimensions.x(), dimensions.y(), this->selectedTiles);
     }
+}
+
+QList<Tile> TilesetEditorTileSelector::buildSelectedTiles(int width, int height, QList<uint16_t> selected) {
+    QList<Tile> tiles;
+    QList<QList<Tile>> tileMatrix;
+    for (int j = 0; j < height; j++) {
+        QList<Tile> row;
+        for (int i = 0; i < width; i++) {
+            int index = i + j * width;
+            uint16_t tile = selected.at(index);
+            if (this->xFlip)
+                row.prepend(Tile(tile, this->xFlip, this->yFlip, this->paletteId));
+            else
+                row.append(Tile(tile, this->xFlip, this->yFlip, this->paletteId));
+        }
+        if (this->yFlip)
+            tileMatrix.prepend(row);
+        else
+            tileMatrix.append(row);
+    }
+    for (int j = 0; j < height; j++) {
+        for (int i = 0; i < width; i++) {
+            tiles.append(tileMatrix.at(j).at(i));
+        }
+    }
+    return tiles;
 }
 
 void TilesetEditorTileSelector::setExternalSelection(int width, int height, QList<Tile> tiles) {
@@ -133,7 +134,7 @@ void TilesetEditorTileSelector::setExternalSelection(int width, int height, QLis
     this->externalSelectionHeight = height;
     this->externalSelectedTiles.clear();
     for (int i = 0; i < tiles.length(); i++) {
-        this->externalSelectedTiles.append(tiles.at(i));
+        this->externalSelectedTiles.append(tiles.at(i).tile);
     }
 
     this->draw();

--- a/src/ui/tileseteditortileselector.cpp
+++ b/src/ui/tileseteditortileselector.cpp
@@ -71,6 +71,7 @@ void TilesetEditorTileSelector::setTilesets(Tileset *primaryTileset, Tileset *se
 
 void TilesetEditorTileSelector::setPaletteId(int paletteId) {
     this->paletteId = paletteId;
+    this->paletteChanged = true;
     this->draw();
 }
 
@@ -118,6 +119,8 @@ QList<Tile> TilesetEditorTileSelector::buildSelectedTiles(int width, int height,
             Tile tile = selected.at(index);
             tile.xflip ^= this->xFlip;
             tile.yflip ^= this->yFlip;
+            if (this->paletteChanged)
+                tile.palette = this->paletteId;
             if (this->xFlip)
                 layerRow.prepend(tile);
             else
@@ -145,6 +148,7 @@ QList<Tile> TilesetEditorTileSelector::buildSelectedTiles(int width, int height,
 
 void TilesetEditorTileSelector::setExternalSelection(int width, int height, QList<Tile> tiles) {
     this->externalSelection = true;
+    this->paletteChanged = false;
     this->externalSelectionWidth = width;
     this->externalSelectionHeight = height;
     this->externalSelectedTiles.clear();

--- a/src/ui/tileseteditortileselector.cpp
+++ b/src/ui/tileseteditortileselector.cpp
@@ -98,22 +98,30 @@ QList<Tile> TilesetEditorTileSelector::getSelectedTiles() {
         return buildSelectedTiles(this->externalSelectionWidth, this->externalSelectionHeight, this->externalSelectedTiles);
     } else {
         QPoint dimensions = this->getSelectionDimensions();
-        return buildSelectedTiles(dimensions.x(), dimensions.y(), this->selectedTiles);
+        QList<Tile> tiles;
+        for (int i = 0; i < this->selectedTiles.length(); i++) {
+            uint16_t tile = this->selectedTiles.at(i);
+            tiles.append(Tile(tile, false, false, this->paletteId));
+        }
+        return buildSelectedTiles(dimensions.x(), dimensions.y(), tiles);
     }
 }
 
-QList<Tile> TilesetEditorTileSelector::buildSelectedTiles(int width, int height, QList<uint16_t> selected) {
+QList<Tile> TilesetEditorTileSelector::buildSelectedTiles(int width, int height, QList<Tile> selected) {
     QList<Tile> tiles;
     QList<QList<Tile>> tileMatrix;
     for (int j = 0; j < height; j++) {
         QList<Tile> row;
         for (int i = 0; i < width; i++) {
             int index = i + j * width;
-            uint16_t tile = selected.at(index);
+            Tile tile = selected.at(index);
+            tile.xflip ^= this->xFlip;
+            tile.yflip ^= this->yFlip;
+            tile.palette = this->paletteId;
             if (this->xFlip)
-                row.prepend(Tile(tile, this->xFlip, this->yFlip, this->paletteId));
+                row.prepend(tile);
             else
-                row.append(Tile(tile, this->xFlip, this->yFlip, this->paletteId));
+                row.append(tile);
         }
         if (this->yFlip)
             tileMatrix.prepend(row);
@@ -134,7 +142,7 @@ void TilesetEditorTileSelector::setExternalSelection(int width, int height, QLis
     this->externalSelectionHeight = height;
     this->externalSelectedTiles.clear();
     for (int i = 0; i < tiles.length(); i++) {
-        this->externalSelectedTiles.append(tiles.at(i).tile);
+        this->externalSelectedTiles.append(tiles.at(i));
     }
 
     this->draw();


### PR DESCRIPTION
Fixes #263 

The X Flip/Y Flip checkboxes are now always relative to the selected tiles visually, i.e. if you select any tile with the X Flip checkbox on, it will appear in the selection flipped horizontally (regardless of whether it was selected from an existing layer or from the tileset). Tile selections from the layer view can now be manipulated the same as they would for tiles selected from the tileset.

Single tile selections from a layer will no longer highlight the corresponding tile in the tile selector, as the layer tile may be flipped differently than its original tile.