### PR TITLE
Fix flags being listed out of order

### DIFF
--- a/docsrc/manual/project-files.rst
+++ b/docsrc/manual/project-files.rst
@@ -28,6 +28,7 @@ to a file, it probably is not a good idea to edit yourself unless otherwise note
    src/data/region_map/region_map_entries.h, yes, yes, 
    include/constants/map_groups.h, no, yes, 
    include/constants/items.h, yes, no, 
+   include/constants/opponents.h, yes, no, reads max trainers constant
    include/constants/flags.h, yes, no, 
    include/constants/vars.h, yes, no, 
    include/constants/weather.h, yes, no, 

--- a/include/core/parseutil.h
+++ b/include/core/parseutil.h
@@ -47,8 +47,8 @@ public:
     QStringList readCArray(QString text, QString label);
     QMap<QString, QString> readNamedIndexCArray(QString text, QString label);
     QString readCIncbin(QString text, QString label);
-    QMap<QString, int> readCDefines(QString filename, QStringList prefixes);
-    void readCDefinesSorted(QString, QStringList, QStringList*);
+    QMap<QString, int> readCDefines(QString filename, QStringList prefixes, QMap<QString, int> = QMap<QString, int>());
+    void readCDefinesSorted(QString, QStringList, QStringList*, QMap<QString, int> = QMap<QString, int>());
     QList<QStringList>* getLabelMacros(QList<QStringList>*, QString);
     QStringList* getLabelValues(QList<QStringList>*, QString);
     bool tryParseJsonFile(QJsonDocument *out, QString filepath);

--- a/src/core/parseutil.cpp
+++ b/src/core/parseutil.cpp
@@ -252,8 +252,7 @@ QString ParseUtil::readCIncbin(QString filename, QString label) {
     return path;
 }
 
-QMap<QString, int> ParseUtil::readCDefines(QString filename, QStringList prefixes) {
-    QMap<QString, int> allDefines;
+QMap<QString, int> ParseUtil::readCDefines(QString filename, QStringList prefixes, QMap<QString, int> allDefines) {
     QMap<QString, int> filteredDefines;
 
     file = filename;
@@ -293,8 +292,8 @@ QMap<QString, int> ParseUtil::readCDefines(QString filename, QStringList prefixe
     return filteredDefines;
 }
 
-void ParseUtil::readCDefinesSorted(QString filename, QStringList prefixes, QStringList* definesToSet) {    
-    QMap<QString, int> defines = readCDefines(filename, prefixes);
+void ParseUtil::readCDefinesSorted(QString filename, QStringList prefixes, QStringList* definesToSet, QMap<QString, int> knownDefines) {
+    QMap<QString, int> defines = readCDefines(filename, prefixes, knownDefines);
 
     // The defines should to be sorted by their underlying value, not alphabetically.
     // Reverse the map and read out the resulting keys in order.

--- a/src/project.cpp
+++ b/src/project.cpp
@@ -2170,13 +2170,19 @@ bool Project::readItemNames() {
 }
 
 bool Project::readFlagNames() {
+    // First read MAX_TRAINERS_COUNT, used to skip over trainer flags
+    // If this fails flags may simply be out of order, no need to check for success
+    QString opponentsFilename = "include/constants/opponents.h";
+    fileWatcher.addPath(root + "/" + opponentsFilename);
+    QMap<QString, int> maxTrainers = parser.readCDefines(opponentsFilename, QStringList() << "MAX_");
+    // Parse flags
     flagNames->clear();
     QStringList prefixes = (QStringList() << "FLAG_");
-    QString filename = "include/constants/flags.h";
-    fileWatcher.addPath(root + "/" + filename);
-    parser.readCDefinesSorted(filename, prefixes, flagNames);
+    QString flagsFilename = "include/constants/flags.h";
+    fileWatcher.addPath(root + "/" + flagsFilename);
+    parser.readCDefinesSorted(flagsFilename, prefixes, flagNames, maxTrainers);
     if (flagNames->isEmpty()) {
-        logError(QString("Failed to read flag constants from %1").arg(filename));
+        logError(QString("Failed to read flag constants from %1").arg(flagsFilename));
         return false;
     }
     return true;


### PR DESCRIPTION
Because `MAX_TRAINERS_COUNT` isn't read by porymap all the `SYSTEM_FLAGS` (which use it as part of their definition) don't get their values evaluated. As a result all these flags are out of order in the dropdown. 

This updates `readCDefines` and `readCDefinesSorted` to accept an optional QMap containing known defines, which can be used to pass an evaluated `MAX_TRAINERS_COUNT` and properly sort the flags. At the moment pokeruby and pokefirered don't use this constant (so it isn't currently an issue there) but they will updated to use it at some point because it allows users to easily add trainers beyond the allocated flag block.