### PR TITLE
Toggle menuFile actions and menuHelp when no project is open

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -66,11 +66,21 @@ void MainWindow::setWindowDisabled(bool disabled) {
     for (auto *child : findChildren<QWidget *>(QString(), Qt::FindDirectChildrenOnly)) {
         bool disableThis = disabled;
         if (child->objectName() == "menuBar") {
-            // disable all but the menuFile
+            // disable all but the menuFile and menuHelp
             for (auto *menu : child->findChildren<QWidget *>(QString(), Qt::FindDirectChildrenOnly)) {
-                menu->setDisabled(disabled);
+                disableThis = disabled;
+                if (menu->objectName() == "menuFile") {
+                    // disable all but the action_Open_Project and action_Exit
+                    for (auto *action : menu->actions()) {
+                        action->setDisabled(disabled);
+                    }
+                    ui->action_Open_Project->setDisabled(false);
+                    ui->action_Exit->setDisabled(false);
+                    disableThis = false;
+                }
+                menu->setDisabled(disableThis);
             }
-            child->findChild<QWidget *>("menuFile")->setDisabled(false);
+            child->findChild<QWidget *>("menuHelp")->setDisabled(false);
             disableThis = false;
         }
         child->setDisabled(disableThis);


### PR DESCRIPTION
This continues to fix #281 

Trying to reload the project with no project open still caused a crash, so I disabled all actions in menuFile except for action_Open_Project and action_Exit. I also enabled menuHelp when no project is open to make sure that the user can always get help even if they have no project to load (such as those who are confused between rom hacking and the disassembly projects).