### PR TITLE
Fix metatile selection not updating properly when changing tilesets

### DIFF
--- a/src/ui/metatileselector.cpp
+++ b/src/ui/metatileselector.cpp
@@ -65,8 +65,11 @@ bool MetatileSelector::selectFromMap(uint16_t metatileId, uint16_t collision, ui
 void MetatileSelector::setTilesets(Tileset *primaryTileset, Tileset *secondaryTileset) {
     this->primaryTileset = primaryTileset;
     this->secondaryTileset = secondaryTileset;
-    if (!this->selectionIsValid())
+    if (!this->selectionIsValid()) {
         this->select(Project::getNumMetatilesPrimary() + this->secondaryTileset->metatiles->length() - 1);
+    } else {
+        updateSelectedMetatiles();
+    }
     this->draw();
 }
 


### PR DESCRIPTION
Fixes an issue where the drawn metatile selection and what's shown on the metatile selector can disagree after changing tilesets.

Steps to reproduce:
1. Open Petalburg City map
2. Select the PokeCenter in the metatile selector (starts 0x048)
3. Change the primary tileset to gTileset_Building
4. The selection is now a different set of valid metatiles in the same region on the metatile selector (starting at 0x240), but the drawn selection still shows the PokeCenter metatile ids (which are now invalid)
