### PR TITLE
Temporarily disable smart paths (closes #294)

### DIFF
--- a/docsrc/manual/editing-map-tiles.rst
+++ b/docsrc/manual/editing-map-tiles.rst
@@ -119,7 +119,7 @@ The Map Shift Tool |map-shift-tool| (*Tools -> Map Shift*, or ``S``) lets you sh
 Smart Paths
 -----------
 
-Smart Paths provide an easy way to paint pathways, ponds, and mountains.  If there is any formation of metatiles that have a basic outline and a "middle" tile, then smart paths can help save you time when painting.  **Smart Paths can only be used when you have a 3x3 metatile selection.**  Smart Paths is only available when using the Pencil Tool or the Bucket Fill Tool.  To enable Smart Paths, you must either check the Smart Paths checkbox above the map area, or you can hold down the ``Shift`` key.  Below are a few examples that illustrate the power of Smart Paths.
+Smart Paths provide an easy way to paint pathways, ponds, and mountains.  If there is any formation of metatiles that have a basic outline and a "middle" tile, then smart paths can help save you time when painting.  **Smart Paths can only be used when you have a 3x3 metatile selection.**  Smart Paths is only available when using the Pencil Tool or the Bucket Fill Tool.  To enable Smart Paths, you must either check the Smart Paths checkbox above the map area, or you can hold down the ``Shift`` key.  If you have the Smart Paths checkbox checked then you can temporarily disable smart paths by holding down the ``Shift`` key.  Below are a few examples that illustrate the power of Smart Paths.
 
 .. figure:: images/editing-map-tiles/smart-paths-1-painting.gif
     :alt: Regular vs. Smart Paths

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -1011,11 +1011,19 @@ void Editor::onMapEndPaint(QGraphicsSceneMouseEvent *, MapPixmapItem *item) {
 
 void Editor::setSmartPathCursorMode(QGraphicsSceneMouseEvent *event)
 {
-    bool smartPathsEnabled = event->modifiers() & Qt::ShiftModifier;
-    if (smartPathsEnabled || settings->smartPathsEnabled) {
-        this->cursorMapTileRect->setSmartPathMode();
+    bool shiftPressed = event->modifiers() & Qt::ShiftModifier;
+    if (settings->smartPathsEnabled) {
+        if (!shiftPressed) {
+            this->cursorMapTileRect->setSmartPathMode();
+        } else {
+            this->cursorMapTileRect->setNormalPathMode();
+        }
     } else {
-        this->cursorMapTileRect->setNormalPathMode();
+        if (shiftPressed) {
+            this->cursorMapTileRect->setSmartPathMode();
+        } else {
+            this->cursorMapTileRect->setNormalPathMode();
+        }
     }
 }
 

--- a/src/ui/mappixmapitem.cpp
+++ b/src/ui/mappixmapitem.cpp
@@ -15,12 +15,20 @@ void MapPixmapItem::paint(QGraphicsSceneMouseEvent *event) {
             int y = static_cast<int>(pos.y()) / 16;
 
             // Paint onto the map.
-            bool smartPathsEnabled = event->modifiers() & Qt::ShiftModifier;
+            bool shiftPressed = event->modifiers() & Qt::ShiftModifier;
             QPoint selectionDimensions = this->metatileSelector->getSelectionDimensions();
-            if ((this->settings->smartPathsEnabled || smartPathsEnabled) && selectionDimensions.x() == 3 && selectionDimensions.y() == 3) {
-                paintSmartPath(x, y);
+            if (settings->smartPathsEnabled) {
+                if (!shiftPressed && selectionDimensions.x() == 3 && selectionDimensions.y() == 3) {
+                    paintSmartPath(x, y);
+                } else {
+                    paintNormal(x, y);
+                }
             } else {
-                paintNormal(x, y);
+                if (shiftPressed && selectionDimensions.x() == 3 && selectionDimensions.y() == 3) {
+                    paintSmartPath(x, y);
+                } else {
+                    paintNormal(x, y);
+                }
             }
         }
     }


### PR DESCRIPTION
Temporarily disable smart paths when the checkbox is checked and the shift key is held down.