### PR TITLE
Fix cursorMapTileRect toggling for Event tab view

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1377,7 +1377,7 @@ void MainWindow::on_actionCursor_Tile_Outline_triggered()
     porymapConfig.setShowCursorTile(enabled);
     this->editor->settings->cursorTileRectEnabled = enabled;
     if (this->editor->map_item->has_mouse) {
-        this->editor->cursorMapTileRect->setVisible(enabled);
+        this->editor->cursorMapTileRect->setVisibility(enabled);
     }
 }
 


### PR DESCRIPTION
If you're in the Events tab and enable the cursor tile outline using the shortcut (`C`), it will become visible until the mouse is moved, whereas normally it is always hidden.