### PR TITLE
Store & restore sub-editors' geometry & state from config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The **"Breaking Changes"** listed below are changes that have been made in the d
 - The New Map dialog now gives an option to specify the "Show Location Name" field.
 - Some new shortcuts were added in [porymap/#290](https://github.com/huderlem/porymap/pull/290).
 - All plain text boxes now have a clear button to delete the text.
+- The window sizes and positions of the tileset editor, palette editor, and region map editor are now stored in `porymap.cfg`.
 
 ### Changed
 - Holding `shift` now toggles "Smart Path" drawing; when the "Smart Paths" checkbox is checked, holding `shift` will temporarily disable it.
@@ -22,7 +23,7 @@ The **"Breaking Changes"** listed below are changes that have been made in the d
 ### Fixed
 - Fix a bug with the current metatile selection zoom.
 - Fix bug preventing the status bar from updating the current position while dragging events.
-- Fix porymap icon not showing on window or panel on Linux
+- Fix porymap icon not showing on window or panel on Linux.
 
 ## [4.3.1] - 2020-07-17
 ### Added

--- a/forms/paletteeditor.ui
+++ b/forms/paletteeditor.ui
@@ -14,7 +14,7 @@
    <enum>Qt::ClickFocus</enum>
   </property>
   <property name="windowTitle">
-   <string>MainWindow</string>
+   <string>Palette Editor</string>
   </property>
   <widget class="QWidget" name="centralwidget">
    <layout class="QVBoxLayout" name="verticalLayout">

--- a/include/config.h
+++ b/include/config.h
@@ -52,6 +52,7 @@ public:
     void setPrettyCursors(bool enabled);
     void setMainGeometry(QByteArray, QByteArray, QByteArray, QByteArray);
     void setTilesetEditorGeometry(QByteArray, QByteArray);
+    void setPaletteEditorGeometry(QByteArray, QByteArray);
     void setRegionMapEditorGeometry(QByteArray, QByteArray);
     void setCollisionOpacity(int opacity);
     void setMetatilesZoom(int zoom);
@@ -66,6 +67,7 @@ public:
     bool getPrettyCursors();
     QMap<QString, QByteArray> getMainGeometry();
     QMap<QString, QByteArray> getTilesetEditorGeometry();
+    QMap<QString, QByteArray> getPaletteEditorGeometry();
     QMap<QString, QByteArray> getRegionMapEditorGeometry();
     int getCollisionOpacity();
     int getMetatilesZoom();
@@ -94,6 +96,8 @@ private:
     QByteArray mainSplitterState;
     QByteArray tilesetEditorGeometry;
     QByteArray tilesetEditorState;
+    QByteArray paletteEditorGeometry;
+    QByteArray paletteEditorState;
     QByteArray regionMapEditorGeometry;
     QByteArray regionMapEditorState;
     int collisionOpacity;

--- a/include/config.h
+++ b/include/config.h
@@ -50,7 +50,8 @@ public:
     void setRecentMap(QString map);
     void setMapSortOrder(MapSortOrder order);
     void setPrettyCursors(bool enabled);
-    void setGeometry(QByteArray, QByteArray, QByteArray, QByteArray);
+    void setMainGeometry(QByteArray, QByteArray, QByteArray, QByteArray);
+    void setTilesetEditorGeometry(QByteArray, QByteArray);
     void setCollisionOpacity(int opacity);
     void setMetatilesZoom(int zoom);
     void setShowPlayerView(bool enabled);
@@ -62,7 +63,8 @@ public:
     QString getRecentMap();
     MapSortOrder getMapSortOrder();
     bool getPrettyCursors();
-    QMap<QString, QByteArray> getGeometry();
+    QMap<QString, QByteArray> getMainGeometry();
+    QMap<QString, QByteArray> getTilesetEditorGeometry();
     int getCollisionOpacity();
     int getMetatilesZoom();
     bool getShowPlayerView();
@@ -83,11 +85,13 @@ private:
     QByteArray bytesFromString(QString);
     MapSortOrder mapSortOrder;
     bool prettyCursors;
-    QByteArray windowGeometry;
-    QByteArray windowState;
+    QByteArray mainWindowGeometry;
+    QByteArray mainWindowState;
     QByteArray mapSplitterState;
     QByteArray eventsSlpitterState;
     QByteArray mainSplitterState;
+    QByteArray tilesetEditorGeometry;
+    QByteArray tilesetEditorState;
     int collisionOpacity;
     int metatilesZoom;
     bool showPlayerView;

--- a/include/config.h
+++ b/include/config.h
@@ -52,6 +52,7 @@ public:
     void setPrettyCursors(bool enabled);
     void setMainGeometry(QByteArray, QByteArray, QByteArray, QByteArray);
     void setTilesetEditorGeometry(QByteArray, QByteArray);
+    void setRegionMapEditorGeometry(QByteArray, QByteArray);
     void setCollisionOpacity(int opacity);
     void setMetatilesZoom(int zoom);
     void setShowPlayerView(bool enabled);
@@ -65,6 +66,7 @@ public:
     bool getPrettyCursors();
     QMap<QString, QByteArray> getMainGeometry();
     QMap<QString, QByteArray> getTilesetEditorGeometry();
+    QMap<QString, QByteArray> getRegionMapEditorGeometry();
     int getCollisionOpacity();
     int getMetatilesZoom();
     bool getShowPlayerView();
@@ -92,6 +94,8 @@ private:
     QByteArray mainSplitterState;
     QByteArray tilesetEditorGeometry;
     QByteArray tilesetEditorState;
+    QByteArray regionMapEditorGeometry;
+    QByteArray regionMapEditorState;
     int collisionOpacity;
     int metatilesZoom;
     bool showPlayerView;

--- a/include/ui/paletteeditor.h
+++ b/include/ui/paletteeditor.h
@@ -46,6 +46,7 @@ private:
     void setColor(int);
     void commitEditHistory(int paletteid);
     void setColorsFromHistory(PaletteHistoryItem*, int);
+    void closeEvent(QCloseEvent*);
 
 signals:
     void closed();

--- a/include/ui/paletteeditor.h
+++ b/include/ui/paletteeditor.h
@@ -45,6 +45,7 @@ private:
     void refreshColor(int);
     void setColor(int);
     void commitEditHistory(int paletteid);
+    void restoreWindowState();
     void setColorsFromHistory(PaletteHistoryItem*, int);
     void closeEvent(QCloseEvent*);
 

--- a/include/ui/regionmapeditor.h
+++ b/include/ui/regionmapeditor.h
@@ -97,6 +97,7 @@ private:
     bool createCityMap(QString name);
     bool tryInsertNewMapEntry(QString);
 
+    void restoreWindowState();
     void closeEvent(QCloseEvent* event);
 
 private slots:

--- a/include/ui/tileseteditor.h
+++ b/include/ui/tileseteditor.h
@@ -93,13 +93,17 @@ private slots:
     void on_actionImport_Secondary_Metatiles_triggered();
 
 private:
-    void init(Project*, Map*);
-    void closeEvent(QCloseEvent*);
-    void initMetatileSelector(Map*);
+    void initUi();
+    void setMetatileBehaviors();
+    void setMetatileLayersUi();
+    void setVersionSpecificUi();
+    void setMetatileLabelValidator();
+    void initMetatileSelector();
     void initTileSelector();
     void initSelectedTileItem();
     void initMetatileLayersItem();
     void restoreWindowState();
+    void initMetatileHistory();
     void setTilesets(QString primaryTilesetLabel, QString secondaryTilesetLabel);
     void reset();
     void drawSelectedTiles();
@@ -107,6 +111,7 @@ private:
     void importTilesetMetatiles(Tileset*, bool);
     void refresh();
     void saveMetatileLabel();
+    void closeEvent(QCloseEvent*);
     Ui::TilesetEditor *ui;
     History<MetatileHistoryItem*> metatileHistory;
     TilesetEditorMetatileSelector *metatileSelector = nullptr;

--- a/include/ui/tileseteditor.h
+++ b/include/ui/tileseteditor.h
@@ -37,8 +37,9 @@ class TilesetEditor : public QMainWindow
 public:
     explicit TilesetEditor(Project*, Map*, QWidget *parent = nullptr);
     ~TilesetEditor();
-    void setMap(Map*);
-    void setTilesets(QString, QString);
+    void update(Map *map, QString primaryTilsetLabel, QString secondaryTilesetLabel);
+    void updateMap(Map *map);
+    void updateTilesets(QString primaryTilsetLabel, QString secondaryTilesetLabel);
     bool selectMetatile(uint16_t metatileId);
 
 private slots:
@@ -98,6 +99,9 @@ private:
     void initTileSelector();
     void initSelectedTileItem();
     void initMetatileLayersItem();
+    void restoreWindowState();
+    void setTilesets(QString primaryTilesetLabel, QString secondaryTilesetLabel);
+    void reset();
     void drawSelectedTiles();
     void importTilesetTiles(Tileset*, bool);
     void importTilesetMetatiles(Tileset*, bool);
@@ -110,6 +114,7 @@ private:
     MetatileLayersItem *metatileLayersItem = nullptr;
     PaletteEditor *paletteEditor = nullptr;
     Project *project = nullptr;
+    Map *map = nullptr;
     Metatile *metatile = nullptr;
     int paletteId;
     bool tileXFlip;

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -141,6 +141,10 @@ void PorymapConfig::parseConfigKeyValue(QString key, QString value) {
         this->tilesetEditorGeometry = bytesFromString(value);
     } else if (key == "tileset_editor_state") {
         this->tilesetEditorState = bytesFromString(value);
+    } else if (key == "region_map_editor_geometry") {
+        this->regionMapEditorGeometry = bytesFromString(value);
+    } else if (key == "region_map_editor_state") {
+        this->regionMapEditorState = bytesFromString(value);
     } else if (key == "metatiles_zoom") {
         bool ok;
         this->metatilesZoom = qMax(10, qMin(100, value.toInt(&ok)));
@@ -196,6 +200,8 @@ QMap<QString, QString> PorymapConfig::getKeyValueMap() {
     map.insert("main_splitter_state", stringFromByteArray(this->mainSplitterState));
     map.insert("tileset_editor_geometry", stringFromByteArray(this->tilesetEditorGeometry));
     map.insert("tileset_editor_state", stringFromByteArray(this->tilesetEditorState));
+    map.insert("region_map_editor_geometry", stringFromByteArray(this->regionMapEditorGeometry));
+    map.insert("region_map_editor_state", stringFromByteArray(this->regionMapEditorState));
     map.insert("collision_opacity", QString("%1").arg(this->collisionOpacity));
     map.insert("metatiles_zoom", QString("%1").arg(this->metatilesZoom));
     map.insert("show_player_view", this->showPlayerView ? "1" : "0");
@@ -264,6 +270,12 @@ void PorymapConfig::setTilesetEditorGeometry(QByteArray tilesetEditorGeometry_, 
     this->save();
 }
 
+void PorymapConfig::setRegionMapEditorGeometry(QByteArray regionMapEditorGeometry_, QByteArray regionMapEditorState_) {
+    this->regionMapEditorGeometry = regionMapEditorGeometry_;
+    this->regionMapEditorState = regionMapEditorState_;
+    this->save();
+}
+
 void PorymapConfig::setCollisionOpacity(int opacity) {
     this->collisionOpacity = opacity;
     // don't auto-save here because this can be called very frequently.
@@ -324,6 +336,15 @@ QMap<QString, QByteArray> PorymapConfig::getTilesetEditorGeometry() {
 
     geometry.insert("tileset_editor_geometry", this->tilesetEditorGeometry);
     geometry.insert("tileset_editor_state", this->tilesetEditorState);
+
+    return geometry;
+}
+
+QMap<QString, QByteArray> PorymapConfig::getRegionMapEditorGeometry() {
+    QMap<QString, QByteArray> geometry;
+
+    geometry.insert("region_map_editor_geometry", this->regionMapEditorGeometry);
+    geometry.insert("region_map_editor_state", this->regionMapEditorState);
 
     return geometry;
 }

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -122,10 +122,10 @@ void PorymapConfig::parseConfigKeyValue(QString key, QString value) {
             this->mapSortOrder = MapSortOrder::Group;
             logWarn(QString("Invalid config value for map_sort_order: '%1'. Must be 'group', 'area', or 'layout'.").arg(value));
         }
-    } else if (key == "window_geometry") {
-        this->windowGeometry = bytesFromString(value);
-    } else if (key == "window_state") {
-        this->windowState = bytesFromString(value);
+    } else if (key == "main_window_geometry") {
+        this->mainWindowGeometry = bytesFromString(value);
+    } else if (key == "main_window_state") {
+        this->mainWindowState = bytesFromString(value);
     } else if (key == "map_splitter_state") {
         this->mapSplitterState = bytesFromString(value);
     } else if (key == "main_splitter_state") {
@@ -137,6 +137,10 @@ void PorymapConfig::parseConfigKeyValue(QString key, QString value) {
             logWarn(QString("Invalid config value for collision_opacity: '%1'. Must be an integer.").arg(value));
             this->collisionOpacity = 50;
         }
+    } else if (key == "tileset_editor_geometry") {
+        this->tilesetEditorGeometry = bytesFromString(value);
+    } else if (key == "tileset_editor_state") {
+        this->tilesetEditorState = bytesFromString(value);
     } else if (key == "metatiles_zoom") {
         bool ok;
         this->metatilesZoom = qMax(10, qMin(100, value.toInt(&ok)));
@@ -186,10 +190,12 @@ QMap<QString, QString> PorymapConfig::getKeyValueMap() {
     map.insert("recent_map", this->recentMap);
     map.insert("pretty_cursors", this->prettyCursors ? "1" : "0");
     map.insert("map_sort_order", mapSortOrderMap.value(this->mapSortOrder));
-    map.insert("window_geometry", stringFromByteArray(this->windowGeometry));
-    map.insert("window_state", stringFromByteArray(this->windowState));
+    map.insert("main_window_geometry", stringFromByteArray(this->mainWindowGeometry));
+    map.insert("main_window_state", stringFromByteArray(this->mainWindowState));
     map.insert("map_splitter_state", stringFromByteArray(this->mapSplitterState));
     map.insert("main_splitter_state", stringFromByteArray(this->mainSplitterState));
+    map.insert("tileset_editor_geometry", stringFromByteArray(this->tilesetEditorGeometry));
+    map.insert("tileset_editor_state", stringFromByteArray(this->tilesetEditorState));
     map.insert("collision_opacity", QString("%1").arg(this->collisionOpacity));
     map.insert("metatiles_zoom", QString("%1").arg(this->metatilesZoom));
     map.insert("show_player_view", this->showPlayerView ? "1" : "0");
@@ -243,12 +249,18 @@ void PorymapConfig::setMonitorFiles(bool monitor) {
     this->save();
 }
 
-void PorymapConfig::setGeometry(QByteArray windowGeometry_, QByteArray windowState_,
+void PorymapConfig::setMainGeometry(QByteArray mainWindowGeometry_, QByteArray mainWindowState_,
                                 QByteArray mapSplitterState_, QByteArray mainSplitterState_) {
-    this->windowGeometry = windowGeometry_;
-    this->windowState = windowState_;
+    this->mainWindowGeometry = mainWindowGeometry_;
+    this->mainWindowState = mainWindowState_;
     this->mapSplitterState = mapSplitterState_;
     this->mainSplitterState = mainSplitterState_;
+    this->save();
+}
+
+void PorymapConfig::setTilesetEditorGeometry(QByteArray tilesetEditorGeometry_, QByteArray tilesetEditorState_) {
+    this->tilesetEditorGeometry = tilesetEditorGeometry_;
+    this->tilesetEditorState = tilesetEditorState_;
     this->save();
 }
 
@@ -296,13 +308,22 @@ bool PorymapConfig::getPrettyCursors() {
     return this->prettyCursors;
 }
 
-QMap<QString, QByteArray> PorymapConfig::getGeometry() {
+QMap<QString, QByteArray> PorymapConfig::getMainGeometry() {
     QMap<QString, QByteArray> geometry;
 
-    geometry.insert("window_geometry", this->windowGeometry);
-    geometry.insert("window_state", this->windowState);
+    geometry.insert("main_window_geometry", this->mainWindowGeometry);
+    geometry.insert("main_window_state", this->mainWindowState);
     geometry.insert("map_splitter_state", this->mapSplitterState);
     geometry.insert("main_splitter_state", this->mainSplitterState);
+
+    return geometry;
+}
+
+QMap<QString, QByteArray> PorymapConfig::getTilesetEditorGeometry() {
+    QMap<QString, QByteArray> geometry;
+
+    geometry.insert("tileset_editor_geometry", this->tilesetEditorGeometry);
+    geometry.insert("tileset_editor_state", this->tilesetEditorState);
 
     return geometry;
 }

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -141,6 +141,10 @@ void PorymapConfig::parseConfigKeyValue(QString key, QString value) {
         this->tilesetEditorGeometry = bytesFromString(value);
     } else if (key == "tileset_editor_state") {
         this->tilesetEditorState = bytesFromString(value);
+    } else if (key == "palette_editor_geometry") {
+        this->paletteEditorGeometry = bytesFromString(value);
+    } else if (key == "palette_editor_state") {
+        this->paletteEditorState = bytesFromString(value);
     } else if (key == "region_map_editor_geometry") {
         this->regionMapEditorGeometry = bytesFromString(value);
     } else if (key == "region_map_editor_state") {
@@ -200,6 +204,8 @@ QMap<QString, QString> PorymapConfig::getKeyValueMap() {
     map.insert("main_splitter_state", stringFromByteArray(this->mainSplitterState));
     map.insert("tileset_editor_geometry", stringFromByteArray(this->tilesetEditorGeometry));
     map.insert("tileset_editor_state", stringFromByteArray(this->tilesetEditorState));
+    map.insert("palette_editor_geometry", stringFromByteArray(this->paletteEditorGeometry));
+    map.insert("palette_editor_state", stringFromByteArray(this->paletteEditorState));
     map.insert("region_map_editor_geometry", stringFromByteArray(this->regionMapEditorGeometry));
     map.insert("region_map_editor_state", stringFromByteArray(this->regionMapEditorState));
     map.insert("collision_opacity", QString("%1").arg(this->collisionOpacity));
@@ -270,6 +276,12 @@ void PorymapConfig::setTilesetEditorGeometry(QByteArray tilesetEditorGeometry_, 
     this->save();
 }
 
+void PorymapConfig::setPaletteEditorGeometry(QByteArray paletteEditorGeometry_, QByteArray paletteEditorState_) {
+    this->paletteEditorGeometry = paletteEditorGeometry_;
+    this->paletteEditorState = paletteEditorState_;
+    this->save();
+}
+
 void PorymapConfig::setRegionMapEditorGeometry(QByteArray regionMapEditorGeometry_, QByteArray regionMapEditorState_) {
     this->regionMapEditorGeometry = regionMapEditorGeometry_;
     this->regionMapEditorState = regionMapEditorState_;
@@ -336,6 +348,15 @@ QMap<QString, QByteArray> PorymapConfig::getTilesetEditorGeometry() {
 
     geometry.insert("tileset_editor_geometry", this->tilesetEditorGeometry);
     geometry.insert("tileset_editor_state", this->tilesetEditorState);
+
+    return geometry;
+}
+
+QMap<QString, QByteArray> PorymapConfig::getPaletteEditorGeometry() {
+    QMap<QString, QByteArray> geometry;
+
+    geometry.insert("palette_editor_geometry", this->paletteEditorGeometry);
+    geometry.insert("palette_editor_state", this->paletteEditorState);
 
     return geometry;
 }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -2659,7 +2659,10 @@ void MainWindow::on_actionRegion_Map_Editor_triggered() {
             return;
         }
         connect(this->regionMapEditor, &QObject::destroyed, [=](QObject *) { this->regionMapEditor = nullptr; });
-        this->regionMapEditor->setAttribute(Qt::WA_DeleteOnClose);
+        logInfo("Restoring region map editor geometry from previous session.");
+        QMap<QString, QByteArray> geometry = porymapConfig.getRegionMapEditorGeometry();
+        this->regionMapEditor->restoreGeometry(geometry.value("region_map_editor_geometry"));
+        this->regionMapEditor->restoreState(geometry.value("region_map_editor_state"));
     }
 
     if (!this->regionMapEditor->isVisible()) {

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1204,8 +1204,11 @@ void MainWindow::on_actionNew_Tileset_triggered() {
 
 void MainWindow::updateTilesetEditor() {
     if (this->tilesetEditor) {
-        this->tilesetEditor->setMap(this->editor->map);
-        this->tilesetEditor->setTilesets(editor->ui->comboBox_PrimaryTileset->currentText(), editor->ui->comboBox_SecondaryTileset->currentText());
+        this->tilesetEditor->update(
+            this->editor->map,
+            editor->ui->comboBox_PrimaryTileset->currentText(),
+            editor->ui->comboBox_SecondaryTileset->currentText()
+        );
     }
 }
 
@@ -2516,10 +2519,6 @@ void MainWindow::on_actionTileset_Editor_triggered()
         this->tilesetEditor = new TilesetEditor(this->editor->project, this->editor->map, this);
         connect(this->tilesetEditor, SIGNAL(tilesetsSaved(QString, QString)), this, SLOT(onTilesetsSaved(QString, QString)));
         connect(this->tilesetEditor, &QObject::destroyed, [=](QObject *) { this->tilesetEditor = nullptr; });
-        logInfo("Restoring tileset editor geometry from previous session.");
-        QMap<QString, QByteArray> geometry = porymapConfig.getTilesetEditorGeometry();
-        this->tilesetEditor->restoreGeometry(geometry.value("tileset_editor_geometry"));
-        this->tilesetEditor->restoreState(geometry.value("tileset_editor_state"));
     }
 
     if (!this->tilesetEditor->isVisible()) {
@@ -2659,10 +2658,6 @@ void MainWindow::on_actionRegion_Map_Editor_triggered() {
             return;
         }
         connect(this->regionMapEditor, &QObject::destroyed, [=](QObject *) { this->regionMapEditor = nullptr; });
-        logInfo("Restoring region map editor geometry from previous session.");
-        QMap<QString, QByteArray> geometry = porymapConfig.getRegionMapEditorGeometry();
-        this->regionMapEditor->restoreGeometry(geometry.value("region_map_editor_geometry"));
-        this->regionMapEditor->restoreState(geometry.value("region_map_editor_state"));
     }
 
     if (!this->regionMapEditor->isVisible()) {

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -348,10 +348,10 @@ void MainWindow::loadUserSettings() {
 }
 
 void MainWindow::restoreWindowState() {
-    logInfo("Restoring window geometry from previous session.");
-    QMap<QString, QByteArray> geometry = porymapConfig.getGeometry();
-    this->restoreGeometry(geometry.value("window_geometry"));
-    this->restoreState(geometry.value("window_state"));
+    logInfo("Restoring main window geometry from previous session.");
+    QMap<QString, QByteArray> geometry = porymapConfig.getMainGeometry();
+    this->restoreGeometry(geometry.value("main_window_geometry"));
+    this->restoreState(geometry.value("main_window_state"));
     this->ui->splitter_map->restoreState(geometry.value("map_splitter_state"));
     this->ui->splitter_main->restoreState(geometry.value("main_splitter_state"));
 }
@@ -2516,7 +2516,10 @@ void MainWindow::on_actionTileset_Editor_triggered()
         this->tilesetEditor = new TilesetEditor(this->editor->project, this->editor->map, this);
         connect(this->tilesetEditor, SIGNAL(tilesetsSaved(QString, QString)), this, SLOT(onTilesetsSaved(QString, QString)));
         connect(this->tilesetEditor, &QObject::destroyed, [=](QObject *) { this->tilesetEditor = nullptr; });
-        this->tilesetEditor->setAttribute(Qt::WA_DeleteOnClose);
+        logInfo("Restoring tileset editor geometry from previous session.");
+        QMap<QString, QByteArray> geometry = porymapConfig.getTilesetEditorGeometry();
+        this->tilesetEditor->restoreGeometry(geometry.value("tileset_editor_geometry"));
+        this->tilesetEditor->restoreState(geometry.value("tileset_editor_state"));
     }
 
     if (!this->tilesetEditor->isVisible()) {
@@ -2695,7 +2698,7 @@ void MainWindow::closeEvent(QCloseEvent *event) {
         }
     }
 
-    porymapConfig.setGeometry(
+    porymapConfig.setMainGeometry(
         this->saveGeometry(),
         this->saveState(),
         this->ui->splitter_map->saveState(),

--- a/src/mainwindow_scriptapi.cpp
+++ b/src/mainwindow_scriptapi.cpp
@@ -247,7 +247,7 @@ void MainWindow::addImage(int x, int y, QString filepath) {
 
 void MainWindow::refreshAfterPaletteChange(Tileset *tileset) {
     if (this->tilesetEditor) {
-        this->tilesetEditor->setTilesets(this->editor->map->layout->tileset_primary_label, this->editor->map->layout->tileset_secondary_label);
+        this->tilesetEditor->updateTilesets(this->editor->map->layout->tileset_primary_label, this->editor->map->layout->tileset_secondary_label);
     }
     this->editor->metatile_selector_item->draw();
     this->editor->selected_border_metatiles_item->draw();

--- a/src/ui/paletteeditor.cpp
+++ b/src/ui/paletteeditor.cpp
@@ -113,6 +113,7 @@ PaletteEditor::PaletteEditor(Project *project, Tileset *primaryTileset, Tileset 
     this->initColorSliders();
     this->setPaletteId(paletteId);
     this->commitEditHistory(this->ui->spinBox_PaletteId->value());
+    this->restoreWindowState();
 }
 
 PaletteEditor::~PaletteEditor()
@@ -226,6 +227,13 @@ void PaletteEditor::commitEditHistory(int paletteId) {
     }
     PaletteHistoryItem *commit = new PaletteHistoryItem(colors);
     this->palettesHistory[paletteId].push(commit);
+}
+
+void PaletteEditor::restoreWindowState() {
+    logInfo("Restoring palette editor geometry from previous session.");
+    QMap<QString, QByteArray> geometry = porymapConfig.getPaletteEditorGeometry();
+    this->restoreGeometry(geometry.value("palette_editor_geometry"));
+    this->restoreState(geometry.value("palette_editor_state"));
 }
 
 void PaletteEditor::on_actionUndo_triggered()

--- a/src/ui/paletteeditor.cpp
+++ b/src/ui/paletteeditor.cpp
@@ -1,9 +1,10 @@
 #include "paletteeditor.h"
 #include "ui_paletteeditor.h"
 #include "paletteutil.h"
+#include "config.h"
+#include "log.h"
 #include <QFileDialog>
 #include <QMessageBox>
-#include "log.h"
 
 PaletteEditor::PaletteEditor(Project *project, Tileset *primaryTileset, Tileset *secondaryTileset, int paletteId, QWidget *parent) :
     QMainWindow(parent),
@@ -310,4 +311,11 @@ void PaletteEditor::on_actionImport_Palette_triggered()
     this->refreshColors();
     this->commitEditHistory(paletteId);
     emit this->changedPaletteColor();
+}
+
+void PaletteEditor::closeEvent(QCloseEvent*) {
+    porymapConfig.setPaletteEditorGeometry(
+        this->saveGeometry(),
+        this->saveState()
+    );
 }

--- a/src/ui/regionmapeditor.cpp
+++ b/src/ui/regionmapeditor.cpp
@@ -899,6 +899,11 @@ void RegionMapEditor::closeEvent(QCloseEvent *event)
     } else {
         event->accept();
     }
+
+    porymapConfig.setRegionMapEditorGeometry(
+        this->saveGeometry(),
+        this->saveState()
+    );
 }
 
 void RegionMapEditor::on_verticalSlider_Zoom_Map_Image_valueChanged(int val) {

--- a/src/ui/regionmapeditor.cpp
+++ b/src/ui/regionmapeditor.cpp
@@ -24,6 +24,7 @@ RegionMapEditor::RegionMapEditor(QWidget *parent, Project *project_) :
     this->project = project_;
     this->region_map = new RegionMap;
     this->ui->action_RegionMap_Resize->setVisible(false);
+    this->restoreWindowState();
 }
 
 RegionMapEditor::~RegionMapEditor()
@@ -40,6 +41,13 @@ RegionMapEditor::~RegionMapEditor()
     delete scene_city_map_image;
     delete scene_region_map_layout;
     delete scene_region_map_tiles;
+}
+
+void RegionMapEditor::restoreWindowState() {
+    logInfo("Restoring region map editor geometry from previous session.");
+    QMap<QString, QByteArray> geometry = porymapConfig.getRegionMapEditorGeometry();
+    this->restoreGeometry(geometry.value("region_map_editor_geometry"));
+    this->restoreState(geometry.value("region_map_editor_state"));
 }
 
 void RegionMapEditor::on_action_RegionMap_Save_triggered() {

--- a/src/ui/tileseteditor.cpp
+++ b/src/ui/tileseteditor.cpp
@@ -694,6 +694,10 @@ void TilesetEditor::on_actionChange_Palettes_triggered()
         this->paletteEditor = new PaletteEditor(this->project, this->primaryTileset, this->secondaryTileset, this->paletteId, this);
         connect(this->paletteEditor, SIGNAL(changedPaletteColor()), this, SLOT(onPaletteEditorChangedPaletteColor()));
         connect(this->paletteEditor, SIGNAL(changedPalette(int)), this, SLOT(onPaletteEditorChangedPalette(int)));
+        logInfo("Restoring palette editor geometry from previous session.");
+        QMap<QString, QByteArray> geometry = porymapConfig.getPaletteEditorGeometry();
+        this->paletteEditor->restoreGeometry(geometry.value("palette_editor_geometry"));
+        this->paletteEditor->restoreState(geometry.value("palette_editor_state"));
     }
 
     if (!this->paletteEditor->isVisible()) {

--- a/src/ui/tileseteditor.cpp
+++ b/src/ui/tileseteditor.cpp
@@ -606,6 +606,11 @@ void TilesetEditor::closeEvent(QCloseEvent *event)
     } else {
         event->accept();
     }
+
+    porymapConfig.setTilesetEditorGeometry(
+        this->saveGeometry(),
+        this->saveState()
+    );
 }
 
 void TilesetEditor::on_actionChange_Metatiles_Count_triggered()


### PR DESCRIPTION
So this started off as attempting to fix the size policies for the Tileset Editor which would cause all the widgets to display very cramped and overlapped with my theming on Linux and looked like this:

![Screenshot_2020-09-16_03-15-58](https://user-images.githubusercontent.com/58710639/93305658-d066ab80-f7cc-11ea-8270-17f823ff5ab4.png)

..Although I couldn't figure out how to do so in a way that didn't drastically alter the spacing, and I didn't want to needlessly mess with the styling on Windows and Mac. So I decided that the geometry & state of the Tileset Editor should just be stored in the config file so that I only had to adjust the window once, rather than every time I open the Tileset Editor. Once I did that I figured why not store & restore the geometries & states of the Region Map Editor and Palette Editor as well.

In addition I removed the `Qt::WA_DeleteOnClose` attribute from the Tileset Editor and Region Map Editor so that the log wasn't spammed with `"Restoring <window> geometry from previous session."` for re-opening those within the same session (which also speeds up the re-opening of those windows). I also gave the Palette Editor its appropriate `windowTitle`.