### PR TITLE
Fix crash caused by shortcuts when no project is loaded

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -70,28 +70,18 @@ MainWindow::~MainWindow()
 }
 
 void MainWindow::setWindowDisabled(bool disabled) {
-    for (auto *child : findChildren<QWidget *>(QString(), Qt::FindDirectChildrenOnly)) {
-        bool disableThis = disabled;
-        if (child->objectName() == "menuBar") {
-            // disable all but the menuFile and menuHelp
-            for (auto *menu : child->findChildren<QWidget *>(QString(), Qt::FindDirectChildrenOnly)) {
-                disableThis = disabled;
-                if (menu->objectName() == "menuFile") {
-                    // disable all but the action_Open_Project and action_Exit
-                    for (auto *action : menu->actions()) {
-                        action->setDisabled(disabled);
-                    }
-                    ui->action_Open_Project->setDisabled(false);
-                    ui->action_Exit->setDisabled(false);
-                    disableThis = false;
-                }
-                menu->setDisabled(disableThis);
-            }
-            child->findChild<QWidget *>("menuHelp")->setDisabled(false);
-            disableThis = false;
-        }
-        child->setDisabled(disableThis);
-    }
+    for (auto action : findChildren<QAction *>())
+        action->setDisabled(disabled);
+    for (auto child : findChildren<QWidget *>(QString(), Qt::FindDirectChildrenOnly))
+        child->setDisabled(disabled);
+    for (auto menu : ui->menuBar->findChildren<QMenu *>(QString(), Qt::FindDirectChildrenOnly))
+        menu->setDisabled(disabled);
+    ui->menuBar->setDisabled(false);
+    ui->menuFile->setDisabled(false);
+    ui->action_Open_Project->setDisabled(false);
+    ui->action_Exit->setDisabled(false);
+    ui->menuHelp->setDisabled(false);
+    ui->actionAbout_Porymap->setDisabled(false);
 }
 
 void MainWindow::initWindow() {


### PR DESCRIPTION
Menu actions can be activated by their shortcut even when their parent menu is disabled. This causes a crash for some actions when no project is loaded. 
Modifies `MainWindow::setWindowDisabled()` to disable `QAction`'s as well.