### PR TITLE
Strip leading digits from new map names

### DIFF
--- a/src/ui/newmappopup.cpp
+++ b/src/ui/newmappopup.cpp
@@ -185,7 +185,9 @@ void NewMapPopup::on_pushButton_NewMap_Accept_clicked() {
     MapLayout *layout;
 
     // If map name is not unique, use default value. Also use only valid characters.
+    // After stripping invalid characters, strip any leading digits.
     QString newMapName = this->ui->lineEdit_NewMap_Name->text().remove(QRegularExpression("[^a-zA-Z0-9_]+"));
+    newMapName = newMapName.remove(QRegularExpression("^[0-9]*"));
     if (project->mapNames->contains(newMapName) || newMapName.isEmpty()) {
         newMapName = project->getNewMapName();
     }

--- a/src/ui/newmappopup.cpp
+++ b/src/ui/newmappopup.cpp
@@ -187,7 +187,7 @@ void NewMapPopup::on_pushButton_NewMap_Accept_clicked() {
     // If map name is not unique, use default value. Also use only valid characters.
     // After stripping invalid characters, strip any leading digits.
     QString newMapName = this->ui->lineEdit_NewMap_Name->text().remove(QRegularExpression("[^a-zA-Z0-9_]+"));
-    newMapName = newMapName.remove(QRegularExpression("^[0-9]*"));
+    newMapName.remove(QRegularExpression("^[0-9]*"));
     if (project->mapNames->contains(newMapName) || newMapName.isEmpty()) {
         newMapName = project->getNewMapName();
     }


### PR DESCRIPTION
Map names with leading digits create invalid script labels that the user will need to manually remove or rename.