### PR TITLE
Add auto-generated file warning to map_groups.h write

### DIFF
--- a/src/project.cpp
+++ b/src/project.cpp
@@ -819,7 +819,7 @@ void Project::saveWildMonData() {
 void Project::saveMapConstantsHeader() {
     QString text = QString("#ifndef GUARD_CONSTANTS_MAP_GROUPS_H\n");
     text += QString("#define GUARD_CONSTANTS_MAP_GROUPS_H\n");
-    text += QString("\n");
+    text += QString("\n//\n// DO NOT MODIFY THIS FILE! It is auto-generated from data/maps/map_groups.json\n//\n\n");
 
     int groupNum = 0;
     for (QStringList mapNames : groupedMapNames) {


### PR DESCRIPTION
Stop porymap from removing the warning in `map_groups.h` that gets added back by mapjson. Ultimately porymap shouldn't need to write to `map_groups.h`, but we have a weird build process.