### PR TITLE
Add completion suggestions for global event scripts

### DIFF
--- a/include/core/parseutil.h
+++ b/include/core/parseutil.h
@@ -60,6 +60,9 @@ public:
     static int getScriptLineNumber(const QString &filePath, const QString &scriptLabel);
     static int getRawScriptLineNumber(QString text, const QString &scriptLabel);
     static int getPoryScriptLineNumber(QString text, const QString &scriptLabel);
+    static QStringList getGlobalScriptLabels(const QString &filePath);
+    static QStringList getGlobalRawScriptLabels(QString text);
+    static QStringList getGlobalPoryScriptLabels(QString text);
     static QString &removeStringLiterals(QString &text);
     static QString &removeLineComments(QString &text, const QString &commentSymbol);
     static QString &removeLineComments(QString &text, const QStringList &commentSymbols);
@@ -74,6 +77,12 @@ private:
     QList<Token> generatePostfix(QList<Token> tokens);
     int evaluatePostfix(QList<Token> postfix);
     void error(QString message, QString expression);
+
+    static const QRegularExpression re_incScriptLabel;
+    static const QRegularExpression re_globalIncScriptLabel;
+    static const QRegularExpression re_poryScriptLabel;
+    static const QRegularExpression re_globalPoryScriptLabel;
+    static const QRegularExpression re_poryRawSection;
 };
 
 #endif // PARSEUTIL_H

--- a/include/project.h
+++ b/include/project.h
@@ -180,7 +180,7 @@ public:
     QString getScriptDefaultString(bool usePoryScript, QString mapName) const;
     QString getMapScriptsFilePath(const QString &mapName) const;
     QStringList getEventScriptsFilePaths() const;
-    QCompleter *getEventScriptLabelCompleter(const QStringList &additionalCompletions) const;
+    QCompleter *getEventScriptLabelCompleter(QStringList additionalCompletions) const;
 
     bool loadMapBorder(Map *map);
 

--- a/include/project.h
+++ b/include/project.h
@@ -62,7 +62,7 @@ public:
     QStringList secretBaseIds;
     QStringList bgEventFacingDirections;
     QStringList trainerTypes;
-    QStringList eventScriptLabels;
+    QStringList globalScriptLabels;
     QMap<QString, int> metatileBehaviorMap;
     QMap<int, QString> metatileBehaviorMapInverse;
     QMap<QString, QString> facingDirections;
@@ -180,7 +180,7 @@ public:
     QString getScriptDefaultString(bool usePoryScript, QString mapName) const;
     QString getMapScriptsFilePath(const QString &mapName) const;
     QStringList getEventScriptsFilePaths() const;
-    QCompleter *getEventScriptLabelCompleter(QStringList additionalCompletions) const;
+    QCompleter *getEventScriptLabelCompleter(QStringList additionalScriptLabels);
 
     bool loadMapBorder(Map *map);
 
@@ -223,8 +223,8 @@ private:
     static int default_map_size;
     static int max_object_events;
 
-    QStringListModel *eventScriptLabelModel = nullptr;
-    QCompleter *eventScriptLabelCompleter = nullptr;
+    QStringListModel eventScriptLabelModel;
+    QCompleter eventScriptLabelCompleter;
 
 signals:
     void reloadProject();

--- a/include/project.h
+++ b/include/project.h
@@ -60,6 +60,7 @@ public:
     QStringList *secretBaseIds = nullptr;
     QStringList *bgEventFacingDirections = nullptr;
     QStringList *trainerTypes = nullptr;
+    QStringList eventScriptLabels;
     QMap<QString, int> metatileBehaviorMap;
     QMap<int, QString> metatileBehaviorMapInverse;
     QMap<QString, QString> facingDirections;
@@ -167,6 +168,7 @@ public:
     bool readMetatileBehaviors();
     bool readHealLocations();
     bool readMiscellaneousConstants();
+    bool readEventScriptLabels();
 
     void loadEventPixmaps(QList<Event*> objects);
     QMap<QString, int> getEventObjGfxConstants();
@@ -177,6 +179,7 @@ public:
     QString getScriptDefaultString(bool usePoryScript, QString mapName) const;
     QString getMapScriptsFilePath(const QString &mapName) const;
     QStringList getEventScriptsFilePaths() const;
+    QCompleter *getEventScriptLabelCompleter(const QStringList &additionalCompletions) const;
 
     bool loadMapBorder(Map *map);
 
@@ -220,6 +223,8 @@ private:
     static int max_object_events;
 
     QWidget *parent;
+    QStringListModel *eventScriptLabelModel = nullptr;
+    QCompleter *eventScriptLabelCompleter = nullptr;
 
 signals:
     void reloadProject();

--- a/src/core/map.cpp
+++ b/src/core/map.cpp
@@ -427,8 +427,8 @@ QStringList Map::eventScriptLabels(const QString &event_group_type) const {
             scriptLabels << event->get("script_label");
     }
 
+    scriptLabels.removeAll("");
     scriptLabels.removeDuplicates();
-    scriptLabels.removeAll(QString());
     if (scriptLabels.contains("0x0"))
         scriptLabels.move(scriptLabels.indexOf("0x0"), scriptLabels.count() - 1);
     if (scriptLabels.contains("NULL"))

--- a/src/core/parseutil.cpp
+++ b/src/core/parseutil.cpp
@@ -467,15 +467,15 @@ QStringList ParseUtil::getGlobalScriptLabels(const QString &filePath) {
         return getGlobalRawScriptLabels(readTextFile(filePath));
     else if (filePath.endsWith(".pory"))
         return getGlobalPoryScriptLabels(readTextFile(filePath));
-
-    return { };
+    else
+        return { };
 }
 
 QStringList ParseUtil::getGlobalRawScriptLabels(QString text) {
     removeStringLiterals(text);
     removeLineComments(text, "@");
 
-    auto rawScriptLabels = QStringList();
+    QStringList rawScriptLabels;
 
     QRegularExpressionMatchIterator it = re_globalIncScriptLabel.globalMatch(text);
     while (it.hasNext()) {
@@ -490,7 +490,7 @@ QStringList ParseUtil::getGlobalPoryScriptLabels(QString text) {
     removeStringLiterals(text);
     removeLineComments(text, {"//", "#"});
 
-    auto poryScriptLabels = QStringList();
+    QStringList poryScriptLabels;
 
     QRegularExpressionMatchIterator it = re_globalPoryScriptLabel.globalMatch(text);
     while (it.hasNext())
@@ -520,12 +520,15 @@ QString ParseUtil::removeLineComments(QString text, const QStringList &commentSy
 }
 
 #if (QT_VERSION >= QT_VERSION_CHECK(5, 15, 0))
+
 #include <QProcess>
 
 QStringList ParseUtil::splitShellCommand(QStringView command) {
     return QProcess::splitCommand(command);
 }
+
 #else
+
 // The source for QProcess::splitCommand() as of Qt 5.15.2
 QStringList ParseUtil::splitShellCommand(QStringView command) {
     QStringList args;
@@ -565,4 +568,5 @@ QStringList ParseUtil::splitShellCommand(QStringView command) {
 
     return args;
 }
+
 #endif

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -876,8 +876,9 @@ bool MainWindow::loadDataStructures() {
                 && project->readHealLocations()
                 && project->readMiscellaneousConstants()
                 && project->readSpeciesIconPaths()
-                && project->readWildMonData();
-    
+                && project->readWildMonData()
+                && project->readEventScriptLabels();
+
     return success && loadProjectCombos();
 }
 
@@ -1917,7 +1918,9 @@ void MainWindow::updateSelectedObjects() {
                                   "normal movement behavior actions.");
                 combo->setMinimumContentsLength(4);
             } else if (key == "script_label") {
-                combo->addItems(editor->map->eventScriptLabels());
+                const auto localScriptLabels = editor->map->eventScriptLabels();
+                combo->addItems(localScriptLabels);
+                combo->setCompleter(editor->project->getEventScriptLabelCompleter(localScriptLabels));
                 combo->setToolTip("The script which is executed with this event.");
             } else if (key == "trainer_type") {
                 combo->addItems(*editor->project->trainerTypes);

--- a/src/project.cpp
+++ b/src/project.cpp
@@ -36,7 +36,10 @@ int Project::max_map_data_size = 10240; // 0x2800
 int Project::default_map_size = 20;
 int Project::max_object_events = 64;
 
-Project::Project(QWidget *parent) : QObject(parent)
+Project::Project(QWidget *parent) :
+    QObject(parent),
+    eventScriptLabelModel(this),
+    eventScriptLabelCompleter(this)
 {
     initSignals();
 }
@@ -2313,12 +2316,12 @@ bool Project::readMiscellaneousConstants() {
 
 bool Project::readEventScriptLabels() {
     for (const auto &filePath : getEventScriptsFilePaths())
-        eventScriptLabels << ParseUtil::getGlobalScriptLabels(filePath);
+        globalScriptLabels << ParseUtil::getGlobalScriptLabels(filePath);
 
-    eventScriptLabelModel = new QStringListModel(eventScriptLabels, this);
-    eventScriptLabelCompleter = new QCompleter(eventScriptLabelModel, this);
-    eventScriptLabelCompleter->setCaseSensitivity(Qt::CaseInsensitive);
-    eventScriptLabelCompleter->setFilterMode(Qt::MatchContains);
+    eventScriptLabelModel.setStringList(globalScriptLabels);
+    eventScriptLabelCompleter.setModel(&eventScriptLabelModel);
+    eventScriptLabelCompleter.setCaseSensitivity(Qt::CaseInsensitive);
+    eventScriptLabelCompleter.setFilterMode(Qt::MatchContains);
 
     return true;
 }
@@ -2386,11 +2389,11 @@ QStringList Project::getEventScriptsFilePaths() const {
     return filePaths;
 }
 
-QCompleter *Project::getEventScriptLabelCompleter(QStringList additionalCompletions) const {
-    additionalCompletions += eventScriptLabels;
-    additionalCompletions.removeDuplicates();
-    eventScriptLabelModel->setStringList(additionalCompletions);
-    return eventScriptLabelCompleter;
+QCompleter *Project::getEventScriptLabelCompleter(QStringList additionalScriptLabels) {
+    additionalScriptLabels << globalScriptLabels;
+    additionalScriptLabels.removeDuplicates();
+    eventScriptLabelModel.setStringList(additionalScriptLabels);
+    return &eventScriptLabelCompleter;
 }
 
 void Project::loadEventPixmaps(QList<Event*> objects) {

--- a/src/project.cpp
+++ b/src/project.cpp
@@ -2399,6 +2399,18 @@ bool Project::readMiscellaneousConstants() {
     return true;
 }
 
+bool Project::readEventScriptLabels() {
+    for (const auto &filePath : getEventScriptsFilePaths())
+        eventScriptLabels << ParseUtil::getGlobalScriptLabels(filePath);
+
+    eventScriptLabelModel = new QStringListModel(eventScriptLabels, this);
+    eventScriptLabelCompleter = new QCompleter(eventScriptLabelModel, this);
+    eventScriptLabelCompleter->setCaseSensitivity(Qt::CaseInsensitive);
+    eventScriptLabelCompleter->setFilterMode(Qt::MatchContains);
+
+    return true;
+}
+
 QString Project::fixPalettePath(QString path) {
     path = path.replace(QRegExp("\\.gbapal$"), ".pal");
     return path;
@@ -2460,6 +2472,11 @@ QStringList Project::getEventScriptsFilePaths() const {
         filePaths << it_inc_maps.next();
 
     return filePaths;
+}
+
+QCompleter *Project::getEventScriptLabelCompleter(const QStringList &additionalCompletions) const {
+    eventScriptLabelModel->setStringList(eventScriptLabels + additionalCompletions);
+    return eventScriptLabelCompleter;
 }
 
 void Project::loadEventPixmaps(QList<Event*> objects) {

--- a/src/project.cpp
+++ b/src/project.cpp
@@ -2386,8 +2386,10 @@ QStringList Project::getEventScriptsFilePaths() const {
     return filePaths;
 }
 
-QCompleter *Project::getEventScriptLabelCompleter(const QStringList &additionalCompletions) const {
-    eventScriptLabelModel->setStringList(eventScriptLabels + additionalCompletions);
+QCompleter *Project::getEventScriptLabelCompleter(QStringList additionalCompletions) const {
+    additionalCompletions += eventScriptLabels;
+    additionalCompletions.removeDuplicates();
+    eventScriptLabelModel->setStringList(additionalCompletions);
     return eventScriptLabelCompleter;
 }
 


### PR DESCRIPTION
Typing into the `Script` combo-box will now suggest all global event scripts, in addition to the map's scripts. Expanding the combo-box will still only show the map's scripts since showing a huge list of global scripts isn't very convenient.