### PR TITLE
Upgrade signal/slot connections

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -575,7 +575,7 @@ void ProjectConfig::onNewConfigFileCreated() {
         form.addRow(new QLabel("Game Version"), baseGameVersionComboBox);
 
         QDialogButtonBox buttonBox(QDialogButtonBox::Ok, Qt::Horizontal, &dialog);
-        connect(&buttonBox, SIGNAL(accepted()), &dialog, SLOT(accept()));
+        connect(&buttonBox, &QDialogButtonBox::accepted, &dialog, &QDialog::accept);
         form.addRow(&buttonBox);
 
         if (dialog.exec() == QDialog::Accepted) {

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -316,7 +316,7 @@ void Editor::addNewWildMonGroup(QWidget *window) {
             dialog.accept();
         }
     });
-    connect(&buttonBox, SIGNAL(rejected()), &dialog, SLOT(reject()));
+    connect(&buttonBox, &QDialogButtonBox::rejected, &dialog, &QDialog::reject);
     form.addRow(&buttonBox);
 
     if (dialog.exec() == QDialog::Accepted) {
@@ -511,8 +511,8 @@ void Editor::configureEncounterJSON(QWidget *window) {
 
     QDialogButtonBox buttonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel, Qt::Horizontal, &dialog);
 
-    connect(&buttonBox, SIGNAL(accepted()), &dialog, SLOT(accept()));
-    connect(&buttonBox, SIGNAL(rejected()), &dialog, SLOT(reject()));
+    connect(&buttonBox, &QDialogButtonBox::accepted, &dialog, &QDialog::accept);
+    connect(&buttonBox, &QDialogButtonBox::rejected, &dialog, &QDialog::reject);
 
     // lambda: Get a QStringList of the existing field names.
     auto getFieldNames = [&tempFields]() {
@@ -552,8 +552,8 @@ void Editor::configureEncounterJSON(QWidget *window) {
         QDialog newNameDialog(nullptr, Qt::WindowTitleHint | Qt::WindowCloseButtonHint);
         newNameDialog.setWindowModality(Qt::NonModal);
         QDialogButtonBox newFieldButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel, Qt::Horizontal, &newNameDialog);
-        connect(&newFieldButtonBox, SIGNAL(accepted()), &newNameDialog, SLOT(accept()));
-        connect(&newFieldButtonBox, SIGNAL(rejected()), &newNameDialog, SLOT(reject()));
+        connect(&newFieldButtonBox, &QDialogButtonBox::accepted, &newNameDialog, &QDialog::accept);
+        connect(&newFieldButtonBox, &QDialogButtonBox::rejected, &newNameDialog, &QDialog::reject);
 
         QLineEdit *newNameEdit = new QLineEdit;
         newNameEdit->setClearButtonEnabled(true);
@@ -1320,12 +1320,12 @@ void Editor::displayMetatileSelector() {
     scene_metatiles = new QGraphicsScene;
     if (!metatile_selector_item) {
         metatile_selector_item = new MetatileSelector(8, map);
-        connect(metatile_selector_item, SIGNAL(hoveredMetatileSelectionChanged(uint16_t)),
-                this, SLOT(onHoveredMetatileSelectionChanged(uint16_t)));
-        connect(metatile_selector_item, SIGNAL(hoveredMetatileSelectionCleared()),
-                this, SLOT(onHoveredMetatileSelectionCleared()));
-        connect(metatile_selector_item, SIGNAL(selectedMetatilesChanged()),
-                this, SLOT(onSelectedMetatilesChanged()));
+        connect(metatile_selector_item, &MetatileSelector::hoveredMetatileSelectionChanged,
+                this, &Editor::onHoveredMetatileSelectionChanged);
+        connect(metatile_selector_item, &MetatileSelector::hoveredMetatileSelectionCleared,
+                this, &Editor::onHoveredMetatileSelectionCleared);
+        connect(metatile_selector_item, &MetatileSelector::selectedMetatilesChanged,
+                this, &Editor::onSelectedMetatilesChanged);
         metatile_selector_item->select(0);
     } else {
         metatile_selector_item->setMap(map);
@@ -1337,16 +1337,11 @@ void Editor::displayMetatileSelector() {
 
 void Editor::displayMapMetatiles() {
     map_item = new MapPixmapItem(map, this->metatile_selector_item, this->settings);
-    connect(map_item, SIGNAL(mouseEvent(QGraphicsSceneMouseEvent*,MapPixmapItem*)),
-            this, SLOT(mouseEvent_map(QGraphicsSceneMouseEvent*,MapPixmapItem*)));
-    connect(map_item, SIGNAL(startPaint(QGraphicsSceneMouseEvent*,MapPixmapItem*)),
-            this, SLOT(onMapStartPaint(QGraphicsSceneMouseEvent*,MapPixmapItem*)));
-    connect(map_item, SIGNAL(endPaint(QGraphicsSceneMouseEvent*,MapPixmapItem*)),
-            this, SLOT(onMapEndPaint(QGraphicsSceneMouseEvent*,MapPixmapItem*)));
-    connect(map_item, SIGNAL(hoveredMapMetatileChanged(const QPoint&)),
-            this, SLOT(onHoveredMapMetatileChanged(const QPoint&)));
-    connect(map_item, SIGNAL(hoveredMapMetatileCleared()),
-            this, SLOT(onHoveredMapMetatileCleared()));
+    connect(map_item, &MapPixmapItem::mouseEvent, this, &Editor::mouseEvent_map);
+    connect(map_item, &MapPixmapItem::startPaint, this, &Editor::onMapStartPaint);
+    connect(map_item, &MapPixmapItem::endPaint, this, &Editor::onMapEndPaint);
+    connect(map_item, &MapPixmapItem::hoveredMapMetatileChanged, this, &Editor::onHoveredMapMetatileChanged);
+    connect(map_item, &MapPixmapItem::hoveredMapMetatileCleared, this, &Editor::onHoveredMapMetatileCleared);
 
     map_item->draw(true);
     scene->addItem(map_item);
@@ -1366,13 +1361,13 @@ void Editor::displayMapMovementPermissions() {
         scene->removeItem(collision_item);
         delete collision_item;
     }
-    collision_item = new CollisionPixmapItem(map, this->movement_permissions_selector_item, this->metatile_selector_item, this->settings, &this->collisionOpacity);
-    connect(collision_item, SIGNAL(mouseEvent(QGraphicsSceneMouseEvent*,CollisionPixmapItem*)),
-            this, SLOT(mouseEvent_collision(QGraphicsSceneMouseEvent*,CollisionPixmapItem*)));
-    connect(collision_item, SIGNAL(hoveredMapMovementPermissionChanged(int, int)),
-            this, SLOT(onHoveredMapMovementPermissionChanged(int, int)));
-    connect(collision_item, SIGNAL(hoveredMapMovementPermissionCleared()),
-            this, SLOT(onHoveredMapMovementPermissionCleared()));
+    collision_item = new CollisionPixmapItem(map, this->movement_permissions_selector_item,
+                                             this->metatile_selector_item, this->settings, &this->collisionOpacity);
+    connect(collision_item, &CollisionPixmapItem::mouseEvent, this, &Editor::mouseEvent_collision);
+    connect(collision_item, &CollisionPixmapItem::hoveredMapMovementPermissionChanged,
+            this, &Editor::onHoveredMapMovementPermissionChanged);
+    connect(collision_item, &CollisionPixmapItem::hoveredMapMovementPermissionCleared,
+            this, &Editor::onHoveredMapMovementPermissionCleared);
 
     collision_item->draw(true);
     scene->addItem(collision_item);
@@ -1389,7 +1384,8 @@ void Editor::displayBorderMetatiles() {
     selected_border_metatiles_item->draw();
     scene_selected_border_metatiles->addItem(selected_border_metatiles_item);
 
-    connect(selected_border_metatiles_item, SIGNAL(borderMetatilesChanged()), this, SLOT(onBorderMetatilesChanged()));
+    connect(selected_border_metatiles_item, &BorderMetatilesPixmapItem::borderMetatilesChanged,
+            this, &Editor::onBorderMetatilesChanged);
 }
 
 void Editor::displayCurrentMetatilesSelection() {
@@ -1421,10 +1417,10 @@ void Editor::displayMovementPermissionSelector() {
     scene_collision_metatiles = new QGraphicsScene;
     if (!movement_permissions_selector_item) {
         movement_permissions_selector_item = new MovementPermissionsSelector();
-        connect(movement_permissions_selector_item, SIGNAL(hoveredMovementPermissionChanged(uint16_t, uint16_t)),
-                this, SLOT(onHoveredMovementPermissionChanged(uint16_t, uint16_t)));
-        connect(movement_permissions_selector_item, SIGNAL(hoveredMovementPermissionCleared()),
-                this, SLOT(onHoveredMovementPermissionCleared()));
+        connect(movement_permissions_selector_item, &MovementPermissionsSelector::hoveredMovementPermissionChanged,
+                this, &Editor::onHoveredMovementPermissionChanged);
+        connect(movement_permissions_selector_item, &MovementPermissionsSelector::hoveredMovementPermissionCleared,
+                this, &Editor::onHoveredMovementPermissionCleared);
         movement_permissions_selector_item->select(0, 3);
     }
 
@@ -1540,9 +1536,12 @@ void Editor::createConnectionItem(MapConnection* connection, bool hide) {
     connection_edit_item->setY(y);
     connection_edit_item->setZValue(-1);
     scene->addItem(connection_edit_item);
-    connect(connection_edit_item, SIGNAL(connectionMoved(MapConnection*)), this, SLOT(onConnectionMoved(MapConnection*)));
-    connect(connection_edit_item, SIGNAL(connectionItemSelected(ConnectionPixmapItem*)), this, SLOT(onConnectionItemSelected(ConnectionPixmapItem*)));
-    connect(connection_edit_item, SIGNAL(connectionItemDoubleClicked(ConnectionPixmapItem*)), this, SLOT(onConnectionItemDoubleClicked(ConnectionPixmapItem*)));
+    connect(connection_edit_item, &ConnectionPixmapItem::connectionMoved,
+            this, &Editor::onConnectionMoved);
+    connect(connection_edit_item, &ConnectionPixmapItem::connectionItemSelected,
+            this, &Editor::onConnectionItemSelected);
+    connect(connection_edit_item, &ConnectionPixmapItem::connectionItemDoubleClicked,
+            this, &Editor::onConnectionItemDoubleClicked);
     connection_edit_items.append(connection_edit_item);
 }
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -189,11 +189,11 @@ void MainWindow::initCustomUI() {
 void MainWindow::initExtraSignals() {
     // Right-clicking on items in the map list tree view brings up a context menu.
     ui->mapList->setContextMenuPolicy(Qt::CustomContextMenu);
-    connect(ui->mapList, SIGNAL(customContextMenuRequested(const QPoint &)),
-            this, SLOT(onOpenMapListContextMenu(const QPoint &)));
+    connect(ui->mapList, &QTreeView::customContextMenuRequested,
+            this, &MainWindow::onOpenMapListContextMenu);
 
     // other signals
-    connect(ui->newEventToolButton, SIGNAL(newEventAdded(QString)), this, SLOT(addNewEvent(QString)));
+    connect(ui->newEventToolButton, &NewEventToolButton::newEventAdded, this, &MainWindow::addNewEvent);
     connect(ui->tabWidget_EventType, &QTabWidget::currentChanged, this, &MainWindow::eventTabChanged);
 
     // Change pages on wild encounter groups
@@ -230,12 +230,12 @@ void MainWindow::initExtraSignals() {
 
 void MainWindow::initEditor() {
     this->editor = new Editor(ui);
-    connect(this->editor, SIGNAL(objectsChanged()), this, SLOT(updateObjects()));
-    connect(this->editor, SIGNAL(selectedObjectsChanged()), this, SLOT(updateSelectedObjects()));
-    connect(this->editor, SIGNAL(loadMapRequested(QString, QString)), this, SLOT(onLoadMapRequested(QString, QString)));
-    connect(this->editor, SIGNAL(warpEventDoubleClicked(QString,QString)), this, SLOT(openWarpMap(QString,QString)));
-    connect(this->editor, SIGNAL(currentMetatilesSelectionChanged()), this, SLOT(currentMetatilesSelectionChanged()));
-    connect(this->editor, SIGNAL(wildMonDataChanged()), this, SLOT(onWildMonDataChanged()));
+    connect(this->editor, &Editor::objectsChanged, this, &MainWindow::updateObjects);
+    connect(this->editor, &Editor::selectedObjectsChanged, this, &MainWindow::updateSelectedObjects);
+    connect(this->editor, &Editor::loadMapRequested, this, &MainWindow::onLoadMapRequested);
+    connect(this->editor, &Editor::warpEventDoubleClicked, this, &MainWindow::openWarpMap);
+    connect(this->editor, &Editor::currentMetatilesSelectionChanged, this, &MainWindow::currentMetatilesSelectionChanged);
+    connect(this->editor, &Editor::wildMonDataChanged, this, &MainWindow::onWildMonDataChanged);
     connect(this->editor, &Editor::mapRulerStatusChanged, this, &MainWindow::onMapRulerStatusChanged);
     connect(ui->toolButton_Open_Scripts, &QToolButton::pressed, this->editor, &Editor::openMapScripts);
     connect(ui->actionOpen_Project_in_Text_Editor, &QAction::triggered, this->editor, &Editor::openProjectInTextEditor);
@@ -492,9 +492,9 @@ bool MainWindow::openProject(QString dir) {
     if (!already_open) {
         editor->closeProject();
         editor->project = new Project(this);
-        QObject::connect(editor->project, SIGNAL(reloadProject()), this, SLOT(on_action_Reload_Project_triggered()));
-        QObject::connect(editor->project, SIGNAL(mapCacheCleared()), this, SLOT(onMapCacheCleared()));
-        QObject::connect(editor->project, &Project::uncheckMonitorFilesAction, [this] () { ui->actionMonitor_Project_Files->setChecked(false); });
+        QObject::connect(editor->project, &Project::reloadProject, this, &MainWindow::on_action_Reload_Project_triggered);
+        QObject::connect(editor->project, &Project::mapCacheCleared, this, &MainWindow::onMapCacheCleared);
+        QObject::connect(editor->project, &Project::uncheckMonitorFilesAction, [this]() { ui->actionMonitor_Project_Files->setChecked(false); });
         on_actionMonitor_Project_Files_triggered(porymapConfig.getMonitorFiles());
         editor->project->set_root(dir);
         success = loadDataStructures()
@@ -624,8 +624,8 @@ bool MainWindow::setMap(QString map_name, bool scrollTreeView) {
 
     showWindowTitle();
 
-    connect(editor->map, SIGNAL(mapChanged(Map*)), this, SLOT(onMapChanged(Map *)));
-    connect(editor->map, SIGNAL(mapNeedsRedrawing()), this, SLOT(onMapNeedsRedrawing()));
+    connect(editor->map, &Map::mapChanged, this, &MainWindow::onMapChanged);
+    connect(editor->map, &Map::mapNeedsRedrawing, this, &MainWindow::onMapNeedsRedrawing);
 
     setRecentMap(map_name);
     updateMapList();
@@ -1066,21 +1066,21 @@ void MainWindow::onOpenMapListContextMenu(const QPoint &point)
         QMenu* menu = new QMenu(this);
         QActionGroup* actions = new QActionGroup(menu);
         actions->addAction(menu->addAction("Add New Map to Group"))->setData(groupNum);
-        connect(actions, SIGNAL(triggered(QAction*)), this, SLOT(onAddNewMapToGroupClick(QAction*)));
+        connect(actions, &QActionGroup::triggered, this, &MainWindow::onAddNewMapToGroupClick);
         menu->exec(QCursor::pos());
     } else if (itemType == "map_sec") {
         QString secName = selectedItem->data(Qt::UserRole).toString();
         QMenu* menu = new QMenu(this);
         QActionGroup* actions = new QActionGroup(menu);
         actions->addAction(menu->addAction("Add New Map to Area"))->setData(secName);
-        connect(actions, SIGNAL(triggered(QAction*)), this, SLOT(onAddNewMapToAreaClick(QAction*)));
+        connect(actions, &QActionGroup::triggered, this, &MainWindow::onAddNewMapToAreaClick);
         menu->exec(QCursor::pos());
     } else if (itemType == "map_layout") {
         QString layoutId = selectedItem->data(MapListUserRoles::TypeRole2).toString();
         QMenu* menu = new QMenu(this);
         QActionGroup* actions = new QActionGroup(menu);
         actions->addAction(menu->addAction("Add New Map with Layout"))->setData(layoutId);
-        connect(actions, SIGNAL(triggered(QAction*)), this, SLOT(onAddNewMapToLayoutClick(QAction*)));
+        connect(actions, &QActionGroup::triggered, this, &MainWindow::onAddNewMapToLayoutClick);
         menu->exec(QCursor::pos());
     }
 }
@@ -1132,7 +1132,7 @@ void MainWindow::onNewMapCreated() {
         editor->save();// required
     }
 
-    disconnect(this->newmapprompt, SIGNAL(applied()), this, SLOT(onNewMapCreated()));
+    disconnect(this->newmapprompt, &NewMapPopup::applied, this, &MainWindow::onNewMapCreated);
 }
 
 void MainWindow::openNewMapPopupWindow(int type, QVariant data) {
@@ -1157,7 +1157,7 @@ void MainWindow::openNewMapPopupWindow(int type, QVariant data) {
             this->newmapprompt->init(type, 0, QString(), data.toString());
             break;
     }
-    connect(this->newmapprompt, SIGNAL(applied()), this, SLOT(onNewMapCreated()));
+    connect(this->newmapprompt, &NewMapPopup::applied, this, &MainWindow::onNewMapCreated);
     connect(this->newmapprompt, &QObject::destroyed, [=](QObject *) { this->newmapprompt = nullptr; });
             this->newmapprompt->setAttribute(Qt::WA_DeleteOnClose);
 }
@@ -1682,7 +1682,7 @@ void MainWindow::updateSelectedObjects() {
             if (delta)
                 editor->map->editHistory.push(new EventMove(QList<Event *>() << item->event, delta, 0, x->getActionId()));
         });
-        connect(item, SIGNAL(xChanged(int)), x, SLOT(setValue(int)));
+        connect(item, &DraggablePixmapItem::xChanged, x, &NoScrollSpinBox::setValue);
 
         y->setValue(item->event->y());
         connect(y, QOverload<int>::of(&QSpinBox::valueChanged), [this, item, y](int value) {
@@ -1690,11 +1690,11 @@ void MainWindow::updateSelectedObjects() {
             if (delta)
                 editor->map->editHistory.push(new EventMove(QList<Event *>() << item->event, 0, delta, y->getActionId()));
         });
-        connect(item, SIGNAL(yChanged(int)), y, SLOT(setValue(int)));
+        connect(item, &DraggablePixmapItem::yChanged, y, &NoScrollSpinBox::setValue);
 
         z->setValue(item->event->elevation());
-        connect(z, SIGNAL(valueChanged(QString)), item, SLOT(set_elevation(QString)));
-        connect(item, SIGNAL(elevationChanged(int)), z, SLOT(setValue(int)));
+        connect(z, &NoScrollSpinBox::textChanged, item, &DraggablePixmapItem::set_elevation);
+        connect(item, &DraggablePixmapItem::elevationChanged, z, &NoScrollSpinBox::setValue);
 
         QString event_type = item->event->get("event_type");
         QString event_group_type = item->event->get("event_group_type");
@@ -1717,7 +1717,7 @@ void MainWindow::updateSelectedObjects() {
         }
 
         frame->ui->label_spritePixmap->setPixmap(item->event->pixmap);
-        connect(item, SIGNAL(spriteChanged(QPixmap)), frame->ui->label_spritePixmap, SLOT(setPixmap(QPixmap)));
+        connect(item, &DraggablePixmapItem::spriteChanged, frame->ui->label_spritePixmap, &QLabel::setPixmap);
 
         frame->ui->sprite->setVisible(false);
 
@@ -2608,7 +2608,7 @@ void MainWindow::on_pushButton_ChangeDimensions_clicked()
             errorLabel->setVisible(true);
         }
     });
-    connect(&buttonBox, SIGNAL(rejected()), &dialog, SLOT(reject()));
+    connect(&buttonBox, &QDialogButtonBox::rejected, &dialog, &QDialog::reject);
 
     form.addRow(errorLabel);
 
@@ -2668,7 +2668,7 @@ void MainWindow::on_actionTileset_Editor_triggered()
 
 void MainWindow::initTilesetEditor() {
     this->tilesetEditor = new TilesetEditor(this->editor->project, this->editor->map, this);
-    connect(this->tilesetEditor, SIGNAL(tilesetsSaved(QString, QString)), this, SLOT(onTilesetsSaved(QString, QString)));
+    connect(this->tilesetEditor, &TilesetEditor::tilesetsSaved, this, &MainWindow::onTilesetsSaved);
     connect(this->tilesetEditor, &QObject::destroyed, [=](QObject *) { this->tilesetEditor = nullptr; });
 }
 

--- a/src/mainwindow_scriptapi.cpp
+++ b/src/mainwindow_scriptapi.cpp
@@ -502,7 +502,7 @@ void MainWindow::setTimeout(QJSValue callback, int milliseconds) {
     connect(timer, &QTimer::timeout, [=](){
         this->invokeCallback(callback);
     });
-    connect(timer, SIGNAL(timeout()), timer, SLOT(deleteLater()));
+    connect(timer, &QTimer::timeout, timer, &QTimer::deleteLater);
     timer->setSingleShot(true);
     timer->start(milliseconds);
 }

--- a/src/ui/neweventtoolbutton.cpp
+++ b/src/ui/neweventtoolbutton.cpp
@@ -7,8 +7,7 @@ NewEventToolButton::NewEventToolButton(QWidget *parent) :
     QToolButton(parent)
 {
     setPopupMode(QToolButton::MenuButtonPopup);
-    QObject::connect(this, SIGNAL(triggered(QAction*)),
-                     this, SLOT(setDefaultAction(QAction*)));
+    QObject::connect(this, &NewEventToolButton::triggered, this, &NewEventToolButton::setDefaultAction);
     this->init();
 }
 
@@ -17,11 +16,11 @@ void NewEventToolButton::init()
     // Add a context menu to select different types of map events.
     this->newObjectAction = new QAction("New Object", this);
     this->newObjectAction->setIcon(QIcon(":/icons/add.ico"));
-    connect(this->newObjectAction, SIGNAL(triggered(bool)), this, SLOT(newObject()));
+    connect(this->newObjectAction, &QAction::triggered, this, &NewEventToolButton::newObject);
 
     this->newWarpAction = new QAction("New Warp", this);
     this->newWarpAction->setIcon(QIcon(":/icons/add.ico"));
-    connect(this->newWarpAction, SIGNAL(triggered(bool)), this, SLOT(newWarp()));
+    connect(this->newWarpAction, &QAction::triggered, this, &NewEventToolButton::newWarp);
 
     /* // disable this functionality for now
     this->newHealLocationAction = new QAction("New Heal Location", this);
@@ -31,23 +30,23 @@ void NewEventToolButton::init()
 
     this->newTriggerAction = new QAction("New Trigger", this);
     this->newTriggerAction->setIcon(QIcon(":/icons/add.ico"));
-    connect(this->newTriggerAction, SIGNAL(triggered(bool)), this, SLOT(newTrigger()));
+    connect(this->newTriggerAction, &QAction::triggered, this, &NewEventToolButton::newTrigger);
 
     this->newWeatherTriggerAction = new QAction("New Weather Trigger", this);
     this->newWeatherTriggerAction->setIcon(QIcon(":/icons/add.ico"));
-    connect(this->newWeatherTriggerAction, SIGNAL(triggered(bool)), this, SLOT(newWeatherTrigger()));
+    connect(this->newWeatherTriggerAction, &QAction::triggered, this, &NewEventToolButton::newWeatherTrigger);
 
     this->newSignAction = new QAction("New Sign", this);
     this->newSignAction->setIcon(QIcon(":/icons/add.ico"));
-    connect(this->newSignAction, SIGNAL(triggered(bool)), this, SLOT(newSign()));
+    connect(this->newSignAction, &QAction::triggered, this, &NewEventToolButton::newSign);
 
     this->newHiddenItemAction = new QAction("New Hidden Item", this);
     this->newHiddenItemAction->setIcon(QIcon(":/icons/add.ico"));
-    connect(this->newHiddenItemAction, SIGNAL(triggered(bool)), this, SLOT(newHiddenItem()));
+    connect(this->newHiddenItemAction, &QAction::triggered, this, &NewEventToolButton::newHiddenItem);
 
     this->newSecretBaseAction = new QAction("New Secret Base", this);
     this->newSecretBaseAction->setIcon(QIcon(":/icons/add.ico"));
-    connect(this->newSecretBaseAction, SIGNAL(triggered(bool)), this, SLOT(newSecretBase()));
+    connect(this->newSecretBaseAction, &QAction::triggered, this, &NewEventToolButton::newSecretBase);
 
     QMenu *alignMenu = new QMenu();
     alignMenu->addAction(this->newObjectAction);

--- a/src/ui/regionmapeditor.cpp
+++ b/src/ui/regionmapeditor.cpp
@@ -631,7 +631,7 @@ void RegionMapEditor::on_pushButton_CityMap_add_clicked() {
     QString name;
 
     form.addRow(&buttonBox);
-    connect(&buttonBox, SIGNAL(rejected()), &popup, SLOT(reject()));
+    connect(&buttonBox, &QDialogButtonBox::rejected, &popup, &QDialog::reject);
     connect(&buttonBox, &QDialogButtonBox::accepted, [&popup, &input, &name](){
         name = input->text().remove(QRegularExpression("[^a-zA-Z0-9_]+"));
         if (!name.isEmpty())
@@ -666,8 +666,8 @@ void RegionMapEditor::on_action_RegionMap_Resize_triggered() {
     QDialogButtonBox buttonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel, Qt::Horizontal, &popup);
 
     form.addRow(&buttonBox);
-    connect(&buttonBox, SIGNAL(rejected()), &popup, SLOT(reject()));
-    connect(&buttonBox, SIGNAL(accepted()), &popup, SLOT(accept()));
+    connect(&buttonBox, &QDialogButtonBox::rejected, &popup, &QDialog::reject);
+    connect(&buttonBox, &QDialogButtonBox::accepted, &popup, &QDialog::accept);
 
     if (popup.exec() == QDialog::Accepted) {
         resize(widthSpinBox->value(), heightSpinBox->value());
@@ -760,7 +760,7 @@ void RegionMapEditor::on_action_Swap_triggered() {
 
     QString beforeSection, afterSection;
     uint8_t oldId, newId; 
-    connect(&buttonBox, SIGNAL(rejected()), &popup, SLOT(reject()));
+    connect(&buttonBox, &QDialogButtonBox::rejected, &popup, &QDialog::reject);
     connect(&buttonBox, &QDialogButtonBox::accepted, [this, &popup, &oldSecBox, &newSecBox, 
                                                       &beforeSection, &afterSection, &oldId, &newId](){
         beforeSection = oldSecBox->currentText();

--- a/src/ui/tileseteditor.cpp
+++ b/src/ui/tileseteditor.cpp
@@ -157,12 +157,12 @@ void TilesetEditor::setMetatileLabelValidator() {
 void TilesetEditor::initMetatileSelector()
 {
     this->metatileSelector = new TilesetEditorMetatileSelector(this->primaryTileset, this->secondaryTileset, this->map);
-    connect(this->metatileSelector, SIGNAL(hoveredMetatileChanged(uint16_t)),
-            this, SLOT(onHoveredMetatileChanged(uint16_t)));
-    connect(this->metatileSelector, SIGNAL(hoveredMetatileCleared()),
-            this, SLOT(onHoveredMetatileCleared()));
-    connect(this->metatileSelector, SIGNAL(selectedMetatileChanged(uint16_t)),
-            this, SLOT(onSelectedMetatileChanged(uint16_t)));
+    connect(this->metatileSelector, &TilesetEditorMetatileSelector::hoveredMetatileChanged,
+            this, &TilesetEditor::onHoveredMetatileChanged);
+    connect(this->metatileSelector, &TilesetEditorMetatileSelector::hoveredMetatileCleared,
+            this, &TilesetEditor::onHoveredMetatileCleared);
+    connect(this->metatileSelector, &TilesetEditorMetatileSelector::selectedMetatileChanged,
+            this, &TilesetEditor::onSelectedMetatileChanged);
 
     this->metatilesScene = new QGraphicsScene;
     this->metatilesScene->addItem(this->metatileSelector);
@@ -175,10 +175,10 @@ void TilesetEditor::initMetatileSelector()
 void TilesetEditor::initMetatileLayersItem() {
     Metatile *metatile = Tileset::getMetatile(this->metatileSelector->getSelectedMetatile(), this->primaryTileset, this->secondaryTileset);
     this->metatileLayersItem = new MetatileLayersItem(metatile, this->primaryTileset, this->secondaryTileset);
-    connect(this->metatileLayersItem, SIGNAL(tileChanged(int, int)),
-            this, SLOT(onMetatileLayerTileChanged(int, int)));
-    connect(this->metatileLayersItem, SIGNAL(selectedTilesChanged(QPoint, int, int)),
-            this, SLOT(onMetatileLayerSelectionChanged(QPoint, int, int)));
+    connect(this->metatileLayersItem, &MetatileLayersItem::tileChanged,
+            this, &TilesetEditor::onMetatileLayerTileChanged);
+    connect(this->metatileLayersItem, &MetatileLayersItem::selectedTilesChanged,
+            this, &TilesetEditor::onMetatileLayerSelectionChanged);
 
     this->metatileLayersScene = new QGraphicsScene;
     this->metatileLayersScene->addItem(this->metatileLayersItem);
@@ -187,13 +187,14 @@ void TilesetEditor::initMetatileLayersItem() {
 
 void TilesetEditor::initTileSelector()
 {
-    this->tileSelector = new TilesetEditorTileSelector(this->primaryTileset, this->secondaryTileset, projectConfig.getTripleLayerMetatilesEnabled());
-    connect(this->tileSelector, SIGNAL(hoveredTileChanged(uint16_t)),
-            this, SLOT(onHoveredTileChanged(uint16_t)));
-    connect(this->tileSelector, SIGNAL(hoveredTileCleared()),
-            this, SLOT(onHoveredTileCleared()));
-    connect(this->tileSelector, SIGNAL(selectedTilesChanged()),
-            this, SLOT(onSelectedTilesChanged()));
+    this->tileSelector = new TilesetEditorTileSelector(this->primaryTileset, this->secondaryTileset,
+                                                       projectConfig.getTripleLayerMetatilesEnabled());
+    connect(this->tileSelector, &TilesetEditorTileSelector::hoveredTileChanged,
+            this, &TilesetEditor::onHoveredTileChanged);
+    connect(this->tileSelector, &TilesetEditorTileSelector::hoveredTileCleared,
+            this, &TilesetEditor::onHoveredTileCleared);
+    connect(this->tileSelector, &TilesetEditorTileSelector::selectedTilesChanged,
+            this, &TilesetEditor::onSelectedTilesChanged);
 
     this->tilesScene = new QGraphicsScene;
     this->tilesScene->addItem(this->tileSelector);
@@ -715,8 +716,8 @@ void TilesetEditor::on_actionChange_Metatiles_Count_triggered()
     form.addRow(new QLabel("Secondary Tileset"), secondarySpinBox);
 
     QDialogButtonBox buttonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel, Qt::Horizontal, &dialog);
-    connect(&buttonBox, SIGNAL(accepted()), &dialog, SLOT(accept()));
-    connect(&buttonBox, SIGNAL(rejected()), &dialog, SLOT(reject()));
+    connect(&buttonBox, &QDialogButtonBox::accepted, &dialog, &QDialog::accept);
+    connect(&buttonBox, &QDialogButtonBox::rejected, &dialog, &QDialog::reject);
     form.addRow(&buttonBox);
 
     if (dialog.exec() == QDialog::Accepted) {
@@ -773,9 +774,12 @@ void TilesetEditor::on_actionChange_Metatiles_Count_triggered()
 void TilesetEditor::on_actionChange_Palettes_triggered()
 {
     if (!this->paletteEditor) {
-        this->paletteEditor = new PaletteEditor(this->project, this->primaryTileset, this->secondaryTileset, this->paletteId, this);
-        connect(this->paletteEditor, SIGNAL(changedPaletteColor()), this, SLOT(onPaletteEditorChangedPaletteColor()));
-        connect(this->paletteEditor, SIGNAL(changedPalette(int)), this, SLOT(onPaletteEditorChangedPalette(int)));
+        this->paletteEditor = new PaletteEditor(this->project, this->primaryTileset,
+                                                this->secondaryTileset, this->paletteId, this);
+        connect(this->paletteEditor, &PaletteEditor::changedPaletteColor,
+                this, &TilesetEditor::onPaletteEditorChangedPaletteColor);
+        connect(this->paletteEditor, &PaletteEditor::changedPalette,
+                this, &TilesetEditor::onPaletteEditorChangedPalette);
     }
 
     if (!this->paletteEditor->isVisible()) {


### PR DESCRIPTION
Upgrades all string-based connections to functor-based because they are checked at compile time and give better performance. Besides that, IDE's don't understand the `SIGNAL` and `SLOT` macros, and it's difficult to find references of functions within them (not even Qt Creator understands it, funnily enough).

Reference: https://doc.qt.io/qt-5/signalsandslots-syntaxes.html