### PR TITLE
Refactor Blockdata

### DIFF
--- a/include/core/block.h
+++ b/include/core/block.h
@@ -12,12 +12,12 @@ public:
     Block(uint16_t tile, uint16_t collision, uint16_t elevation);
     Block(const Block &);
     Block &operator=(const Block &);
-    bool operator ==(Block);
-    bool operator !=(Block);
+    bool operator ==(Block) const;
+    bool operator !=(Block) const;
     uint16_t tile:10;
     uint16_t collision:2;
     uint16_t elevation:4;
-    uint16_t rawValue();
+    uint16_t rawValue() const;
 };
 
 #endif // BLOCK_H

--- a/include/core/blockdata.h
+++ b/include/core/blockdata.h
@@ -10,7 +10,7 @@
 class Blockdata : public QVector<Block>
 {
 public:
-    QByteArray serialize();
+    QByteArray serialize() const;
 };
 
 #endif // BLOCKDATA_H

--- a/include/core/blockdata.h
+++ b/include/core/blockdata.h
@@ -4,31 +4,13 @@
 
 #include "block.h"
 
-#include <QObject>
 #include <QByteArray>
 #include <QVector>
 
-class Blockdata : public QObject
+class Blockdata : public QVector<Block>
 {
-    Q_OBJECT
 public:
-    explicit Blockdata(QObject *parent = nullptr);
-    ~Blockdata() {
-        if (blocks) delete blocks;
-    }
-
-public:
-    QVector<Block> *blocks = nullptr;
-    void addBlock(uint16_t);
-    void addBlock(Block);
     QByteArray serialize();
-    void copyFrom(Blockdata*);
-    Blockdata* copy();
-    bool equals(Blockdata *);
-
-signals:
-
-public slots:
 };
 
 #endif // BLOCKDATA_H

--- a/include/core/editcommands.h
+++ b/include/core/editcommands.h
@@ -2,6 +2,8 @@
 #ifndef EDITCOMMANDS_H
 #define EDITCOMMANDS_H
 
+#include "blockdata.h"
+
 #include <QUndoCommand>
 #include <QList>
 
@@ -41,9 +43,8 @@ enum CommandId {
 class PaintMetatile : public QUndoCommand {
 public:
     PaintMetatile(Map *map,
-        Blockdata *oldMetatiles, Blockdata *newMetatiles,
+        const Blockdata &oldMetatiles, const Blockdata &newMetatiles,
         unsigned actionId, QUndoCommand *parent = nullptr);
-    virtual ~PaintMetatile();
 
     void undo() override;
     void redo() override;
@@ -54,8 +55,8 @@ public:
 private:
     Map *map;
 
-    Blockdata *newMetatiles;
-    Blockdata *oldMetatiles;
+    Blockdata newMetatiles;
+    Blockdata oldMetatiles;
 
     unsigned actionId;
 };
@@ -67,7 +68,7 @@ private:
 class PaintCollision : public PaintMetatile {
 public:
     PaintCollision(Map *map,
-        Blockdata *oldCollision, Blockdata *newCollision,
+        const Blockdata &oldCollision, const Blockdata &newCollision,
         unsigned actionId, QUndoCommand *parent = nullptr)
     : PaintMetatile(map, oldCollision, newCollision, actionId, parent) {
         setText("Paint Collision");
@@ -82,9 +83,8 @@ public:
 class PaintBorder : public QUndoCommand {
 public:
     PaintBorder(Map *map,
-        Blockdata *oldBorder, Blockdata *newBorder,
+        const Blockdata &oldBorder, const Blockdata &newBorder,
         unsigned actionId, QUndoCommand *parent = nullptr);
-    ~PaintBorder();
 
     void undo() override;
     void redo() override;
@@ -95,8 +95,8 @@ public:
 private:
     Map *map;
 
-    Blockdata *newBorder;
-    Blockdata *oldBorder;
+    Blockdata newBorder;
+    Blockdata oldBorder;
 
     unsigned actionId;
 };
@@ -108,7 +108,7 @@ private:
 class BucketFillMetatile : public PaintMetatile {
 public:
     BucketFillMetatile(Map *map,
-        Blockdata *oldMetatiles, Blockdata *newMetatiles,
+        const Blockdata &oldMetatiles, const Blockdata &newMetatiles,
         unsigned actionId, QUndoCommand *parent = nullptr)
       : PaintMetatile(map, oldMetatiles, newMetatiles, actionId, parent) {
         setText("Bucket Fill Metatiles");
@@ -124,7 +124,7 @@ public:
 class BucketFillCollision : public PaintCollision {
 public:
     BucketFillCollision(Map *map,
-        Blockdata *oldCollision, Blockdata *newCollision,
+        const Blockdata &oldCollision, const Blockdata &newCollision,
         QUndoCommand *parent = nullptr)
       : PaintCollision(map, oldCollision, newCollision, -1, parent) {
         setText("Flood Fill Collision");
@@ -141,7 +141,7 @@ public:
 class MagicFillMetatile : public PaintMetatile {
 public:
     MagicFillMetatile(Map *map,
-        Blockdata *oldMetatiles, Blockdata *newMetatiles,
+        const Blockdata &oldMetatiles, const Blockdata &newMetatiles,
         unsigned actionId, QUndoCommand *parent = nullptr)
       : PaintMetatile(map, oldMetatiles, newMetatiles, actionId, parent) {
         setText("Magic Fill Metatiles");
@@ -156,7 +156,7 @@ public:
 class MagicFillCollision : public PaintCollision {
 public:
     MagicFillCollision(Map *map,
-        Blockdata *oldCollision, Blockdata *newCollision,
+        const Blockdata &oldCollision, const Blockdata &newCollision,
         QUndoCommand *parent = nullptr)
     : PaintCollision(map, oldCollision, newCollision, -1, parent) {
         setText("Magic Fill Collision");
@@ -172,9 +172,8 @@ public:
 class ShiftMetatiles : public QUndoCommand {
 public:
     ShiftMetatiles(Map *map,
-        Blockdata *oldMetatiles, Blockdata *newMetatiles,
+        const Blockdata &oldMetatiles, const Blockdata &newMetatiles,
         unsigned actionId, QUndoCommand *parent = nullptr);
-    ~ShiftMetatiles();
 
     void undo() override;
     void redo() override;
@@ -185,8 +184,8 @@ public:
 private:
     Map *map;
 
-    Blockdata *newMetatiles;
-    Blockdata *oldMetatiles;
+    Blockdata newMetatiles;
+    Blockdata oldMetatiles;
 
     unsigned actionId;
 };
@@ -197,11 +196,10 @@ private:
 class ResizeMap : public QUndoCommand {
 public:
     ResizeMap(Map *map, QSize oldMapDimensions, QSize newMapDimensions,
-        Blockdata *oldMetatiles, Blockdata *newMetatiles,
+        const Blockdata &oldMetatiles, const Blockdata &newMetatiles,
         QSize oldBorderDimensions, QSize newBorderDimensions,
-        Blockdata *oldBorder, Blockdata *newBorder,
+        const Blockdata &oldBorder, const Blockdata &newBorder,
         QUndoCommand *parent = nullptr);
-    ~ResizeMap();
 
     void undo() override;
     void redo() override;
@@ -222,11 +220,11 @@ private:
     int newBorderWidth;
     int newBorderHeight;
 
-    Blockdata *newMetatiles;
-    Blockdata *oldMetatiles;
+    Blockdata newMetatiles;
+    Blockdata oldMetatiles;
 
-    Blockdata *newBorder;
-    Blockdata *oldBorder;
+    Blockdata newBorder;
+    Blockdata oldBorder;
 };
 
 
@@ -238,7 +236,6 @@ public:
     EventMove(QList<Event *> events,
         int deltaX, int deltaY, unsigned actionId,
         QUndoCommand *parent = nullptr);
-    ~EventMove();
 
     void undo() override;
     void redo() override;
@@ -262,7 +259,6 @@ public:
     EventShift(QList<Event *> events,
         int deltaX, int deltaY, unsigned actionId,
         QUndoCommand *parent = nullptr);
-    ~EventShift();
     int id() const override;
 private:
     QList<Event *> events;
@@ -276,7 +272,6 @@ class EventCreate : public QUndoCommand {
 public:
     EventCreate(Editor *editor, Map *map, Event *event,
         QUndoCommand *parent = nullptr);
-    ~EventCreate();
 
     void undo() override;
     void redo() override;
@@ -299,7 +294,6 @@ public:
     EventDelete(Editor *editor, Map *map,
         QList<Event *> selectedEvents, Event *nextSelectedEvent,
         QUndoCommand *parent = nullptr);
-    ~EventDelete();
 
     void undo() override;
     void redo() override;
@@ -321,7 +315,6 @@ class EventDuplicate : public QUndoCommand {
 public:
     EventDuplicate(Editor *editor, Map *map, QList<Event *> selectedEvents,
         QUndoCommand *parent = nullptr);
-    ~EventDuplicate();
 
     void undo() override;
     void redo() override;
@@ -343,9 +336,8 @@ class ScriptEditMap : public QUndoCommand {
 public:
     ScriptEditMap(Map *map,
         QSize oldMapDimensions, QSize newMapDimensions,
-        Blockdata *oldMetatiles, Blockdata *newMetatiles,
+        const Blockdata &oldMetatiles, const Blockdata &newMetatiles,
         QUndoCommand *parent = nullptr);
-    ~ScriptEditMap();
 
     void undo() override;
     void redo() override;
@@ -356,8 +348,8 @@ public:
 private:
     Map *map;
 
-    Blockdata *newMetatiles;
-    Blockdata *oldMetatiles;
+    Blockdata newMetatiles;
+    Blockdata oldMetatiles;
 
     int oldMapWidth;
     int oldMapHeight;

--- a/include/core/map.h
+++ b/include/core/map.h
@@ -75,8 +75,8 @@ public:
     int getBorderHeight();
     QPixmap render(bool ignoreCache, MapLayout * fromLayout = nullptr);
     QPixmap renderCollision(qreal opacity, bool ignoreCache);
-    bool mapBlockChanged(int i, Blockdata cache);
-    bool borderBlockChanged(int i, Blockdata cache);
+    bool mapBlockChanged(int i, const Blockdata &cache);
+    bool borderBlockChanged(int i, const Blockdata &cache);
     void cacheBlockdata();
     void cacheCollision();
     bool getBlock(int x, int y, Block *out);

--- a/include/core/map.h
+++ b/include/core/map.h
@@ -75,8 +75,8 @@ public:
     int getBorderHeight();
     QPixmap render(bool ignoreCache, MapLayout * fromLayout = nullptr);
     QPixmap renderCollision(qreal opacity, bool ignoreCache);
-    bool mapBlockChanged(int i, Blockdata * cache);
-    bool borderBlockChanged(int i, Blockdata * cache);
+    bool mapBlockChanged(int i, Blockdata cache);
+    bool borderBlockChanged(int i, Blockdata cache);
     void cacheBlockdata();
     void cacheCollision();
     bool getBlock(int x, int y, Block *out);

--- a/include/core/maplayout.h
+++ b/include/core/maplayout.h
@@ -24,15 +24,15 @@ public:
     QString tileset_secondary_label;
     Tileset *tileset_primary = nullptr;
     Tileset *tileset_secondary = nullptr;
-    Blockdata *blockdata = nullptr;
+    Blockdata blockdata;
     QImage border_image;
     QPixmap border_pixmap;
-    Blockdata *border = nullptr;
-    Blockdata *cached_blockdata = nullptr;
-    Blockdata *cached_collision = nullptr;
-    Blockdata *cached_border = nullptr;
+    Blockdata border;
+    Blockdata cached_blockdata;
+    Blockdata cached_collision;
+    Blockdata cached_border;
     struct {
-        Blockdata *blocks = nullptr;
+        Blockdata blocks;
         QSize dimensions;
     } lastCommitMapBlocks; // to track map changes
 };

--- a/include/project.h
+++ b/include/project.h
@@ -91,7 +91,7 @@ public:
     Tileset* getTileset(QString, bool forceLoad = false);
     QMap<QString, QStringList> tilesetLabels;
 
-    Blockdata* readBlockdata(QString);
+    Blockdata readBlockdata(QString);
     bool loadBlockdata(Map*);
 
     void saveTextFile(QString path, QString text);
@@ -129,7 +129,7 @@ public:
 
     void saveLayoutBlockdata(Map*);
     void saveLayoutBorder(Map*);
-    void writeBlockdata(QString, Blockdata*);
+    void writeBlockdata(QString, const Blockdata &);
     void saveAllMaps();
     void saveMap(Map*);
     void saveAllDataStructures();

--- a/src/core/block.cpp
+++ b/src/core/block.cpp
@@ -27,17 +27,17 @@ Block &Block::operator=(const Block &other) {
     return *this;
 }
 
-uint16_t Block::rawValue() {
+uint16_t Block::rawValue() const {
     return static_cast<uint16_t>(
                 (tile & 0x3ff) +
                 ((collision & 0x3) << 10) +
                 ((elevation & 0xf) << 12));
 }
 
-bool Block::operator ==(Block other) {
+bool Block::operator ==(Block other) const {
     return (tile == other.tile) && (collision == other.collision) && (elevation == other.elevation);
 }
 
-bool Block::operator !=(Block other) {
+bool Block::operator !=(Block other) const {
     return !(operator ==(other));
 }

--- a/src/core/blockdata.cpp
+++ b/src/core/blockdata.cpp
@@ -1,6 +1,6 @@
 #include "blockdata.h"
 
-QByteArray Blockdata::serialize() {
+QByteArray Blockdata::serialize() const {
     QByteArray data;
     for (const auto &block : *this) {
         uint16_t word = block.rawValue();

--- a/src/core/blockdata.cpp
+++ b/src/core/blockdata.cpp
@@ -1,54 +1,11 @@
 #include "blockdata.h"
 
-Blockdata::Blockdata(QObject *parent) : QObject(parent)
-{
-    blocks = new QVector<Block>;
-}
-
-void Blockdata::addBlock(uint16_t word) {
-    Block block(word);
-    blocks->append(block);
-}
-
-void Blockdata::addBlock(Block block) {
-    blocks->append(block);
-}
-
 QByteArray Blockdata::serialize() {
     QByteArray data;
-    for (int i = 0; i < blocks->length(); i++) {
-        Block block = blocks->value(i);
+    for (const auto &block : *this) {
         uint16_t word = block.rawValue();
         data.append(static_cast<char>(word & 0xff));
         data.append(static_cast<char>((word >> 8) & 0xff));
     }
     return data;
-}
-
-void Blockdata::copyFrom(Blockdata* other) {
-    blocks->clear();
-    for (int i = 0; i < other->blocks->length(); i++) {
-        addBlock(other->blocks->value(i));
-    }
-}
-
-Blockdata* Blockdata::copy() {
-    Blockdata* blockdata = new Blockdata;
-    blockdata->copyFrom(this);
-    return blockdata;
-}
-
-bool Blockdata::equals(Blockdata *other) {
-    if (!other) {
-        return false;
-    }
-    if (blocks->length() != other->blocks->length()) {
-        return false;
-    }
-    for (int i = 0; i < blocks->length(); i++) {
-        if (blocks->value(i) != other->blocks->value(i)) {
-            return false;
-        }
-    }
-    return true;
 }

--- a/src/core/editcommands.cpp
+++ b/src/core/editcommands.cpp
@@ -31,8 +31,9 @@ void renderMapBlocks(Map *map, bool ignoreCache = false) {
     map->mapItem->draw(ignoreCache);
     map->collisionItem->draw(ignoreCache);
 }
+
 PaintMetatile::PaintMetatile(Map *map,
-    Blockdata *oldMetatiles, Blockdata *newMetatiles,
+    const Blockdata &oldMetatiles, const Blockdata &newMetatiles,
     unsigned actionId, QUndoCommand *parent) : QUndoCommand(parent) {
     setText("Paint Metatiles");
 
@@ -43,21 +44,16 @@ PaintMetatile::PaintMetatile(Map *map,
     this->actionId = actionId;
 }
 
-PaintMetatile::~PaintMetatile() {
-    if (newMetatiles) delete newMetatiles;
-    if (oldMetatiles) delete oldMetatiles;
-}
-
 void PaintMetatile::redo() {
     QUndoCommand::redo();
 
     if (!map) return;
 
     if (map->layout->blockdata) {
-        map->layout->blockdata->copyFrom(newMetatiles);
+        *map->layout->blockdata = newMetatiles;
     }
 
-    map->layout->lastCommitMapBlocks.blocks->copyFrom(map->layout->blockdata);
+    *map->layout->lastCommitMapBlocks.blocks = *map->layout->blockdata;
 
     renderMapBlocks(map);
 }
@@ -66,10 +62,10 @@ void PaintMetatile::undo() {
     if (!map) return;
 
     if (map->layout->blockdata) {
-        map->layout->blockdata->copyFrom(oldMetatiles);
+        *map->layout->blockdata = oldMetatiles;
     }
 
-    map->layout->lastCommitMapBlocks.blocks->copyFrom(map->layout->blockdata);
+    *map->layout->lastCommitMapBlocks.blocks = *map->layout->blockdata;
 
     renderMapBlocks(map);
 
@@ -79,13 +75,13 @@ void PaintMetatile::undo() {
 bool PaintMetatile::mergeWith(const QUndoCommand *command) {
     const PaintMetatile *other = static_cast<const PaintMetatile *>(command);
 
-    if (this->map != other->map)
+    if (map != other->map)
         return false;
 
     if (actionId != other->actionId)
         return false;
 
-    this->newMetatiles->copyFrom(other->newMetatiles);
+    newMetatiles = other->newMetatiles;
 
     return true;
 }
@@ -95,7 +91,7 @@ bool PaintMetatile::mergeWith(const QUndoCommand *command) {
  ******************************************************************************/
 
 PaintBorder::PaintBorder(Map *map,
-    Blockdata *oldBorder, Blockdata *newBorder,
+    const Blockdata &oldBorder, const Blockdata &newBorder,
     unsigned actionId, QUndoCommand *parent) : QUndoCommand(parent) {
     setText("Paint Border");
 
@@ -106,18 +102,13 @@ PaintBorder::PaintBorder(Map *map,
     this->actionId = actionId;
 }
 
-PaintBorder::~PaintBorder() {
-    if (newBorder) delete newBorder;
-    if (oldBorder) delete oldBorder;
-}
-
 void PaintBorder::redo() {
     QUndoCommand::redo();
 
     if (!map) return;
 
     if (map->layout->border) {
-        map->layout->border->copyFrom(newBorder);
+        *map->layout->border = newBorder;
     }
 
     map->borderItem->draw();
@@ -127,7 +118,7 @@ void PaintBorder::undo() {
     if (!map) return;
 
     if (map->layout->border) {
-        map->layout->border->copyFrom(oldBorder);
+        *map->layout->border = oldBorder;
     }
 
     map->borderItem->draw();
@@ -140,7 +131,7 @@ void PaintBorder::undo() {
  ******************************************************************************/
 
 ShiftMetatiles::ShiftMetatiles(Map *map,
-    Blockdata *oldMetatiles, Blockdata *newMetatiles,
+    const Blockdata &oldMetatiles, const Blockdata &newMetatiles,
     unsigned actionId, QUndoCommand *parent) : QUndoCommand(parent) {
     setText("Shift Metatiles");
 
@@ -151,21 +142,16 @@ ShiftMetatiles::ShiftMetatiles(Map *map,
     this->actionId = actionId;
 }
 
-ShiftMetatiles::~ShiftMetatiles() {
-    if (newMetatiles) delete newMetatiles;
-    if (oldMetatiles) delete oldMetatiles;
-}
-
 void ShiftMetatiles::redo() {
     QUndoCommand::redo();
 
     if (!map) return;
 
     if (map->layout->blockdata) {
-        map->layout->blockdata->copyFrom(newMetatiles);
+        *map->layout->blockdata = newMetatiles;
     }
 
-    map->layout->lastCommitMapBlocks.blocks->copyFrom(map->layout->blockdata);
+    *map->layout->lastCommitMapBlocks.blocks = *map->layout->blockdata;
 
     renderMapBlocks(map, true);
 }
@@ -174,10 +160,10 @@ void ShiftMetatiles::undo() {
     if (!map) return;
 
     if (map->layout->blockdata) {
-        map->layout->blockdata->copyFrom(oldMetatiles);
+        *map->layout->blockdata = oldMetatiles;
     }
 
-    map->layout->lastCommitMapBlocks.blocks->copyFrom(map->layout->blockdata);
+    *map->layout->lastCommitMapBlocks.blocks = *map->layout->blockdata;
 
     renderMapBlocks(map, true);
 
@@ -193,7 +179,7 @@ bool ShiftMetatiles::mergeWith(const QUndoCommand *command) {
     if (actionId != other->actionId)
         return false;
 
-    this->newMetatiles->copyFrom(other->newMetatiles);
+    this->newMetatiles = other->newMetatiles;
 
     return true;
 }
@@ -203,9 +189,9 @@ bool ShiftMetatiles::mergeWith(const QUndoCommand *command) {
  ******************************************************************************/
 
 ResizeMap::ResizeMap(Map *map, QSize oldMapDimensions, QSize newMapDimensions,
-    Blockdata *oldMetatiles, Blockdata *newMetatiles,
+    const Blockdata &oldMetatiles, const Blockdata &newMetatiles,
     QSize oldBorderDimensions, QSize newBorderDimensions,
-    Blockdata *oldBorder, Blockdata *newBorder,
+    const Blockdata &oldBorder, const Blockdata &newBorder,
     QUndoCommand *parent) : QUndoCommand(parent) {
     setText("Resize Map");
 
@@ -230,23 +216,18 @@ ResizeMap::ResizeMap(Map *map, QSize oldMapDimensions, QSize newMapDimensions,
     this->newBorder = newBorder;
 }
 
-ResizeMap::~ResizeMap() {
-    if (newMetatiles) delete newMetatiles;
-    if (oldMetatiles) delete oldMetatiles;
-}
-
 void ResizeMap::redo() {
     QUndoCommand::redo();
 
     if (!map) return;
 
     if (map->layout->blockdata) {
-        map->layout->blockdata->copyFrom(newMetatiles);
+        *map->layout->blockdata = newMetatiles;
         map->setDimensions(newMapWidth, newMapHeight, false);
     }
 
     if (map->layout->border) {
-        map->layout->border->copyFrom(newBorder);
+        *map->layout->border = newBorder;
         map->setBorderDimensions(newBorderWidth, newBorderHeight, false);
     }
 
@@ -259,12 +240,12 @@ void ResizeMap::undo() {
     if (!map) return;
 
     if (map->layout->blockdata) {
-        map->layout->blockdata->copyFrom(oldMetatiles);
+        *map->layout->blockdata = oldMetatiles;
         map->setDimensions(oldMapWidth, oldMapHeight, false);
     }
 
     if (map->layout->border) {
-        map->layout->border->copyFrom(oldBorder);
+        *map->layout->border = oldBorder;
         map->setBorderDimensions(oldBorderWidth, oldBorderHeight, false);
     }
 
@@ -291,8 +272,6 @@ EventMove::EventMove(QList<Event *> events,
 
     this->actionId = actionId;
 }
-
-EventMove::~EventMove() {}
 
 void EventMove::redo() {
     QUndoCommand::redo();
@@ -340,8 +319,6 @@ EventShift::EventShift(QList<Event *> events,
     setText("Shift Events");
 }
 
-EventShift::~EventShift() {}
-
 int EventShift::id() const {
     return CommandId::ID_EventShift | getEventTypeMask(events);
 }
@@ -360,13 +337,11 @@ EventCreate::EventCreate(Editor *editor, Map *map, Event *event,
     this->event = event;
 }
 
-EventCreate::~EventCreate() {}
-
 void EventCreate::redo() {
     QUndoCommand::redo();
 
     map->addEvent(event);
-    
+
     editor->project->loadEventPixmaps(map->getAllEvents());
     editor->addMapEvent(event);
 
@@ -412,8 +387,6 @@ EventDelete::EventDelete(Editor *editor, Map *map,
     this->nextSelectedEvent = nextSelectedEvent;
 }
 
-EventDelete::~EventDelete() {}
-
 void EventDelete::redo() {
     QUndoCommand::redo();
 
@@ -435,7 +408,7 @@ void EventDelete::redo() {
 void EventDelete::undo() {
     for (Event *event : selectedEvents) {
         map->addEvent(event);
-    
+
         editor->project->loadEventPixmaps(map->getAllEvents());
         editor->addMapEvent(event);
     }
@@ -468,8 +441,6 @@ EventDuplicate::EventDuplicate(Editor *editor, Map *map,
     this->map = map;
     this->selectedEvents = selectedEvents;
 }
-
-EventDuplicate::~EventDuplicate() {}
 
 void EventDuplicate::redo() {
     QUndoCommand::redo();
@@ -517,7 +488,7 @@ int EventDuplicate::id() const {
 
 ScriptEditMap::ScriptEditMap(Map *map,
         QSize oldMapDimensions, QSize newMapDimensions,
-        Blockdata *oldMetatiles, Blockdata *newMetatiles,
+        const Blockdata &oldMetatiles, const Blockdata &newMetatiles,
         QUndoCommand *parent) : QUndoCommand(parent) {
     setText("Script Edit Map");
 
@@ -532,24 +503,19 @@ ScriptEditMap::ScriptEditMap(Map *map,
     this->newMapHeight = newMapDimensions.height();
 }
 
-ScriptEditMap::~ScriptEditMap() {
-    if (newMetatiles) delete newMetatiles;
-    if (oldMetatiles) delete oldMetatiles;
-}
-
 void ScriptEditMap::redo() {
     QUndoCommand::redo();
 
     if (!map) return;
 
     if (map->layout->blockdata) {
-        map->layout->blockdata->copyFrom(newMetatiles);
+        *map->layout->blockdata = newMetatiles;
         if (newMapWidth != map->getWidth() || newMapHeight != map->getHeight()) {
             map->setDimensions(newMapWidth, newMapHeight, false);
         }
     }
 
-    map->layout->lastCommitMapBlocks.blocks->copyFrom(newMetatiles);
+    *map->layout->lastCommitMapBlocks.blocks = newMetatiles;
     map->layout->lastCommitMapBlocks.dimensions = QSize(newMapWidth, newMapHeight);
 
     renderMapBlocks(map);
@@ -559,13 +525,13 @@ void ScriptEditMap::undo() {
     if (!map) return;
 
     if (map->layout->blockdata) {
-        map->layout->blockdata->copyFrom(oldMetatiles);
+        *map->layout->blockdata = oldMetatiles;
         if (oldMapWidth != map->getWidth() || oldMapHeight != map->getHeight()) {
             map->setDimensions(oldMapWidth, oldMapHeight, false);
         }
     }
 
-    map->layout->lastCommitMapBlocks.blocks->copyFrom(oldMetatiles);
+    *map->layout->lastCommitMapBlocks.blocks = oldMetatiles;
     map->layout->lastCommitMapBlocks.dimensions = QSize(oldMapWidth, oldMapHeight);
 
     renderMapBlocks(map);

--- a/src/core/editcommands.cpp
+++ b/src/core/editcommands.cpp
@@ -49,11 +49,9 @@ void PaintMetatile::redo() {
 
     if (!map) return;
 
-    if (map->layout->blockdata) {
-        *map->layout->blockdata = newMetatiles;
-    }
+    map->layout->blockdata = newMetatiles;
 
-    *map->layout->lastCommitMapBlocks.blocks = *map->layout->blockdata;
+    map->layout->lastCommitMapBlocks.blocks = map->layout->blockdata;
 
     renderMapBlocks(map);
 }
@@ -61,11 +59,9 @@ void PaintMetatile::redo() {
 void PaintMetatile::undo() {
     if (!map) return;
 
-    if (map->layout->blockdata) {
-        *map->layout->blockdata = oldMetatiles;
-    }
+    map->layout->blockdata = oldMetatiles;
 
-    *map->layout->lastCommitMapBlocks.blocks = *map->layout->blockdata;
+    map->layout->lastCommitMapBlocks.blocks = map->layout->blockdata;
 
     renderMapBlocks(map);
 
@@ -107,9 +103,7 @@ void PaintBorder::redo() {
 
     if (!map) return;
 
-    if (map->layout->border) {
-        *map->layout->border = newBorder;
-    }
+    map->layout->border = newBorder;
 
     map->borderItem->draw();
 }
@@ -117,9 +111,7 @@ void PaintBorder::redo() {
 void PaintBorder::undo() {
     if (!map) return;
 
-    if (map->layout->border) {
-        *map->layout->border = oldBorder;
-    }
+    map->layout->border = oldBorder;
 
     map->borderItem->draw();
 
@@ -147,11 +139,9 @@ void ShiftMetatiles::redo() {
 
     if (!map) return;
 
-    if (map->layout->blockdata) {
-        *map->layout->blockdata = newMetatiles;
-    }
+    map->layout->blockdata = newMetatiles;
 
-    *map->layout->lastCommitMapBlocks.blocks = *map->layout->blockdata;
+    map->layout->lastCommitMapBlocks.blocks = map->layout->blockdata;
 
     renderMapBlocks(map, true);
 }
@@ -159,11 +149,9 @@ void ShiftMetatiles::redo() {
 void ShiftMetatiles::undo() {
     if (!map) return;
 
-    if (map->layout->blockdata) {
-        *map->layout->blockdata = oldMetatiles;
-    }
+    map->layout->blockdata = oldMetatiles;
 
-    *map->layout->lastCommitMapBlocks.blocks = *map->layout->blockdata;
+    map->layout->lastCommitMapBlocks.blocks = map->layout->blockdata;
 
     renderMapBlocks(map, true);
 
@@ -221,15 +209,11 @@ void ResizeMap::redo() {
 
     if (!map) return;
 
-    if (map->layout->blockdata) {
-        *map->layout->blockdata = newMetatiles;
-        map->setDimensions(newMapWidth, newMapHeight, false);
-    }
+    map->layout->blockdata = newMetatiles;
+    map->setDimensions(newMapWidth, newMapHeight, false);
 
-    if (map->layout->border) {
-        *map->layout->border = newBorder;
-        map->setBorderDimensions(newBorderWidth, newBorderHeight, false);
-    }
+    map->layout->border = newBorder;
+    map->setBorderDimensions(newBorderWidth, newBorderHeight, false);
 
     map->layout->lastCommitMapBlocks.dimensions = QSize(map->getWidth(), map->getHeight());
 
@@ -239,15 +223,11 @@ void ResizeMap::redo() {
 void ResizeMap::undo() {
     if (!map) return;
 
-    if (map->layout->blockdata) {
-        *map->layout->blockdata = oldMetatiles;
-        map->setDimensions(oldMapWidth, oldMapHeight, false);
-    }
+    map->layout->blockdata = oldMetatiles;
+    map->setDimensions(oldMapWidth, oldMapHeight, false);
 
-    if (map->layout->border) {
-        *map->layout->border = oldBorder;
-        map->setBorderDimensions(oldBorderWidth, oldBorderHeight, false);
-    }
+    map->layout->border = oldBorder;
+    map->setBorderDimensions(oldBorderWidth, oldBorderHeight, false);
 
     map->layout->lastCommitMapBlocks.dimensions = QSize(map->getWidth(), map->getHeight());
 
@@ -508,14 +488,12 @@ void ScriptEditMap::redo() {
 
     if (!map) return;
 
-    if (map->layout->blockdata) {
-        *map->layout->blockdata = newMetatiles;
-        if (newMapWidth != map->getWidth() || newMapHeight != map->getHeight()) {
-            map->setDimensions(newMapWidth, newMapHeight, false);
-        }
+    map->layout->blockdata = newMetatiles;
+    if (newMapWidth != map->getWidth() || newMapHeight != map->getHeight()) {
+        map->setDimensions(newMapWidth, newMapHeight, false);
     }
 
-    *map->layout->lastCommitMapBlocks.blocks = newMetatiles;
+    map->layout->lastCommitMapBlocks.blocks = newMetatiles;
     map->layout->lastCommitMapBlocks.dimensions = QSize(newMapWidth, newMapHeight);
 
     renderMapBlocks(map);
@@ -524,14 +502,12 @@ void ScriptEditMap::redo() {
 void ScriptEditMap::undo() {
     if (!map) return;
 
-    if (map->layout->blockdata) {
-        *map->layout->blockdata = oldMetatiles;
-        if (oldMapWidth != map->getWidth() || oldMapHeight != map->getHeight()) {
-            map->setDimensions(oldMapWidth, oldMapHeight, false);
-        }
+    map->layout->blockdata = oldMetatiles;
+    if (oldMapWidth != map->getWidth() || oldMapHeight != map->getHeight()) {
+        map->setDimensions(oldMapWidth, oldMapHeight, false);
     }
 
-    *map->layout->lastCommitMapBlocks.blocks = oldMetatiles;
+    map->layout->lastCommitMapBlocks.blocks = oldMetatiles;
     map->layout->lastCommitMapBlocks.dimensions = QSize(oldMapWidth, oldMapHeight);
 
     renderMapBlocks(map);

--- a/src/core/map.cpp
+++ b/src/core/map.cpp
@@ -78,7 +78,7 @@ int Map::getBorderHeight() {
     return layout->border_height.toInt(nullptr, 0);
 }
 
-bool Map::mapBlockChanged(int i, Blockdata cache) {
+bool Map::mapBlockChanged(int i, const Blockdata &cache) {
     if (cache.length() <= i)
         return true;
     if (layout->blockdata.length() <= i)
@@ -87,7 +87,7 @@ bool Map::mapBlockChanged(int i, Blockdata cache) {
     return layout->blockdata.at(i) != cache.at(i);
 }
 
-bool Map::borderBlockChanged(int i, Blockdata cache) {
+bool Map::borderBlockChanged(int i, const Blockdata &cache) {
     if (cache.length() <= i)
         return true;
     if (layout->border.length() <= i)

--- a/src/core/map.cpp
+++ b/src/core/map.cpp
@@ -271,34 +271,38 @@ void Map::setNewDimensionsBlockdata(int newWidth, int newHeight) {
     int oldWidth = getWidth();
     int oldHeight = getHeight();
 
-    layout->blockdata.clear();
+    Blockdata newBlockdata;
 
     for (int y = 0; y < newHeight; y++)
     for (int x = 0; x < newWidth; x++) {
         if (x < oldWidth && y < oldHeight) {
             int index = y * oldWidth + x;
-            layout->blockdata.append(layout->blockdata.value(index));
+            newBlockdata.append(layout->blockdata.value(index));
         } else {
-            layout->blockdata.append(0);
+            newBlockdata.append(0);
         }
     }
+
+    layout->blockdata = newBlockdata;
 }
 
 void Map::setNewBorderDimensionsBlockdata(int newWidth, int newHeight) {
     int oldWidth = getBorderWidth();
     int oldHeight = getBorderHeight();
 
-    layout->border.clear();
+    Blockdata newBlockdata;
 
     for (int y = 0; y < newHeight; y++)
     for (int x = 0; x < newWidth; x++) {
         if (x < oldWidth && y < oldHeight) {
             int index = y * oldWidth + x;
-            layout->border.append(layout->border.value(index));
+            newBlockdata.append(layout->border.value(index));
         } else {
-            layout->border.append(0);
+            newBlockdata.append(0);
         }
     }
+
+    layout->border = newBlockdata;
 }
 
 void Map::setDimensions(int newWidth, int newHeight, bool setNewBlockdata) {

--- a/src/core/map.cpp
+++ b/src/core/map.cpp
@@ -78,88 +78,61 @@ int Map::getBorderHeight() {
     return layout->border_height.toInt(nullptr, 0);
 }
 
-bool Map::mapBlockChanged(int i, Blockdata * cache) {
-    if (!cache)
+bool Map::mapBlockChanged(int i, Blockdata cache) {
+    if (cache.length() <= i)
         return true;
-    if (!layout->blockdata)
-        return true;
-    if (cache->length() <= i)
-        return true;
-    if (layout->blockdata->length() <= i)
+    if (layout->blockdata.length() <= i)
         return true;
 
-    return layout->blockdata->value(i) != cache->value(i);
+    return layout->blockdata.at(i) != cache.at(i);
 }
 
-bool Map::borderBlockChanged(int i, Blockdata * cache) {
-    if (!cache)
+bool Map::borderBlockChanged(int i, Blockdata cache) {
+    if (cache.length() <= i)
         return true;
-    if (!layout->border)
-        return true;
-    if (cache->length() <= i)
-        return true;
-    if (layout->border->length() <= i)
+    if (layout->border.length() <= i)
         return true;
 
-    return layout->border->value(i) != cache->value(i);
+    return layout->border.at(i) != cache.at(i);
 }
 
 void Map::cacheBorder() {
-    if (layout->cached_border) delete layout->cached_border;
-    layout->cached_border = new Blockdata;
-    if (layout->border) {
-        for (int i = 0; i < layout->border->length(); i++) {
-            Block block = layout->border->value(i);
-            layout->cached_border->append(block);
-        }
-    }
+    layout->cached_border.clear();
+    for (const auto &block : layout->border)
+        layout->cached_border.append(block);
 }
 
 void Map::cacheBlockdata() {
-    if (layout->cached_blockdata) delete layout->cached_blockdata;
-    layout->cached_blockdata = new Blockdata;
-    if (layout->blockdata) {
-        for (int i = 0; i < layout->blockdata->length(); i++) {
-            Block block = layout->blockdata->value(i);
-            layout->cached_blockdata->append(block);
-        }
-    }
+    layout->cached_blockdata.clear();
+    for (const auto &block : layout->blockdata)
+        layout->cached_blockdata.append(block);
 }
 
 void Map::cacheCollision() {
-    if (layout->cached_collision) delete layout->cached_collision;
-    layout->cached_collision = new Blockdata;
-    if (layout->blockdata) {
-        for (int i = 0; i < layout->blockdata->length(); i++) {
-            Block block = layout->blockdata->value(i);
-            layout->cached_collision->append(block);
-        }
-    }
+    layout->cached_collision.clear();
+    for (const auto &block : layout->blockdata)
+        layout->cached_collision.append(block);
 }
 
 QPixmap Map::renderCollision(qreal opacity, bool ignoreCache) {
     bool changed_any = false;
     int width_ = getWidth();
     int height_ = getHeight();
-    if (
-            collision_image.isNull()
-            || collision_image.width() != width_ * 16
-            || collision_image.height() != height_ * 16
-    ) {
+    if (collision_image.isNull() || collision_image.width() != width_ * 16 || collision_image.height() != height_ * 16) {
         collision_image = QImage(width_ * 16, height_ * 16, QImage::Format_RGBA8888);
         changed_any = true;
     }
-    if (!(layout->blockdata && width_ && height_)) {
+    if (layout->blockdata.isEmpty() || !width_ || !height_) {
         collision_pixmap = collision_pixmap.fromImage(collision_image);
         return collision_pixmap;
     }
     QPainter painter(&collision_image);
-    for (int i = 0; i < layout->blockdata->length(); i++) {
-        if (!ignoreCache && layout->cached_collision && !mapBlockChanged(i, layout->cached_collision)) {
+    for (int i = 0; i < layout->blockdata.length(); i++) {
+        if (!ignoreCache && !mapBlockChanged(i, layout->cached_collision)) {
             continue;
         }
         changed_any = true;
-        Block block = layout->blockdata->value(i);
+        Block block = layout->blockdata.at(i);
         QImage metatile_image = getMetatileImage(block.tile, layout->tileset_primary, layout->tileset_secondary, metatileLayerOrder, metatileLayerOpacity);
         QImage collision_metatile_image = getCollisionMetatileImage(block);
         int map_y = width_ ? i / width_ : 0;
@@ -184,26 +157,22 @@ QPixmap Map::render(bool ignoreCache = false, MapLayout * fromLayout) {
     bool changed_any = false;
     int width_ = getWidth();
     int height_ = getHeight();
-    if (
-            image.isNull()
-            || image.width() != width_ * 16
-            || image.height() != height_ * 16
-    ) {
+    if (image.isNull() || image.width() != width_ * 16 || image.height() != height_ * 16) {
         image = QImage(width_ * 16, height_ * 16, QImage::Format_RGBA8888);
         changed_any = true;
     }
-    if (!(layout->blockdata && width_ && height_)) {
+    if (layout->blockdata.isEmpty() || !width_ || !height_) {
         pixmap = pixmap.fromImage(image);
         return pixmap;
     }
 
     QPainter painter(&image);
-    for (int i = 0; i < layout->blockdata->length(); i++) {
+    for (int i = 0; i < layout->blockdata.length(); i++) {
         if (!ignoreCache && !mapBlockChanged(i, layout->cached_blockdata)) {
             continue;
         }
         changed_any = true;
-        Block block = layout->blockdata->value(i);
+        Block block = layout->blockdata.at(i);
         QImage metatile_image = getMetatileImage(
             block.tile,
             fromLayout ? fromLayout->tileset_primary   : layout->tileset_primary,
@@ -237,18 +206,18 @@ QPixmap Map::renderBorder(bool ignoreCache) {
         layout->border_image = QImage(width_ * 16, height_ * 16, QImage::Format_RGBA8888);
         border_resized = true;
     }
-    if (!layout->border) {
+    if (layout->border.isEmpty()) {
         layout->border_pixmap = layout->border_pixmap.fromImage(layout->border_image);
         return layout->border_pixmap;
     }
     QPainter painter(&layout->border_image);
-    for (int i = 0; i < layout->border->length(); i++) {
+    for (int i = 0; i < layout->border.length(); i++) {
         if (!ignoreCache && (!border_resized && !borderBlockChanged(i, layout->cached_border))) {
             continue;
         }
 
         changed_any = true;
-        Block block = layout->border->value(i);
+        Block block = layout->border.at(i);
         uint16_t tile = block.tile;
         QImage metatile_image = getMetatileImage(tile, layout->tileset_primary, layout->tileset_secondary, metatileLayerOrder, metatileLayerOpacity);
         int map_y = width_ ? i / width_ : 0;
@@ -302,38 +271,34 @@ void Map::setNewDimensionsBlockdata(int newWidth, int newHeight) {
     int oldWidth = getWidth();
     int oldHeight = getHeight();
 
-    Blockdata* newBlockData = new Blockdata;
+    layout->blockdata.clear();
 
     for (int y = 0; y < newHeight; y++)
     for (int x = 0; x < newWidth; x++) {
         if (x < oldWidth && y < oldHeight) {
             int index = y * oldWidth + x;
-            newBlockData->append(layout->blockdata->value(index));
+            layout->blockdata.append(layout->blockdata.value(index));
         } else {
-            newBlockData->append(0);
+            layout->blockdata.append(0);
         }
     }
-
-    *layout->blockdata = *newBlockData;
 }
 
 void Map::setNewBorderDimensionsBlockdata(int newWidth, int newHeight) {
     int oldWidth = getBorderWidth();
     int oldHeight = getBorderHeight();
 
-    Blockdata* newBlockData = new Blockdata;
+    layout->border.clear();
 
     for (int y = 0; y < newHeight; y++)
     for (int x = 0; x < newWidth; x++) {
         if (x < oldWidth && y < oldHeight) {
             int index = y * oldWidth + x;
-            newBlockData->append(layout->border->value(index));
+            layout->border.append(layout->border.value(index));
         } else {
-            newBlockData->append(0);
+            layout->border.append(0);
         }
     }
-
-    *layout->border = *newBlockData;
 }
 
 void Map::setDimensions(int newWidth, int newHeight, bool setNewBlockdata) {
@@ -360,21 +325,19 @@ void Map::setBorderDimensions(int newWidth, int newHeight, bool setNewBlockdata)
 }
 
 bool Map::getBlock(int x, int y, Block *out) {
-    if (layout->blockdata) {
-        if (x >= 0 && x < getWidth() && y >= 0 && y < getHeight()) {
-            int i = y * getWidth() + x;
-            *out = layout->blockdata->value(i);
-            return true;
-        }
+    if (x >= 0 && x < getWidth() && y >= 0 && y < getHeight()) {
+        int i = y * getWidth() + x;
+        *out = layout->blockdata.value(i);
+        return true;
     }
     return false;
 }
 
 void Map::setBlock(int x, int y, Block block, bool enableScriptCallback) {
     int i = y * getWidth() + x;
-    if (layout->blockdata && i < layout->blockdata->size()) {
-        Block prevBlock = layout->blockdata->value(i);
-        layout->blockdata->replace(i, block);
+    if (i < layout->blockdata.size()) {
+        Block prevBlock = layout->blockdata.at(i);
+        layout->blockdata.replace(i, block);
         if (enableScriptCallback) {
             Scripting::cb_MetatileChanged(x, y, prevBlock, block);
         }
@@ -385,40 +348,40 @@ void Map::_floodFillCollisionElevation(int x, int y, uint16_t collision, uint16_
     QList<QPoint> todo;
     todo.append(QPoint(x, y));
     while (todo.length()) {
-            QPoint point = todo.takeAt(0);
-            x = point.x();
-            y = point.y();
-            Block block;
-            if (!getBlock(x, y, &block)) {
-                continue;
-            }
+        QPoint point = todo.takeAt(0);
+        x = point.x();
+        y = point.y();
+        Block block;
+        if (!getBlock(x, y, &block)) {
+            continue;
+        }
 
-            uint old_coll = block.collision;
-            uint old_elev = block.elevation;
-            if (old_coll == collision && old_elev == elevation) {
-                continue;
-            }
+        uint old_coll = block.collision;
+        uint old_elev = block.elevation;
+        if (old_coll == collision && old_elev == elevation) {
+            continue;
+        }
 
-            block.collision = collision;
-            block.elevation = elevation;
-            setBlock(x, y, block, true);
-            if (getBlock(x + 1, y, &block) && block.collision == old_coll && block.elevation == old_elev) {
-                todo.append(QPoint(x + 1, y));
-            }
-            if (getBlock(x - 1, y, &block) && block.collision == old_coll && block.elevation == old_elev) {
-                todo.append(QPoint(x - 1, y));
-            }
-            if (getBlock(x, y + 1, &block) && block.collision == old_coll && block.elevation == old_elev) {
-                todo.append(QPoint(x, y + 1));
-            }
-            if (getBlock(x, y - 1, &block) && block.collision == old_coll && block.elevation == old_elev) {
-                todo.append(QPoint(x, y - 1));
-            }
+        block.collision = collision;
+        block.elevation = elevation;
+        setBlock(x, y, block, true);
+        if (getBlock(x + 1, y, &block) && block.collision == old_coll && block.elevation == old_elev) {
+            todo.append(QPoint(x + 1, y));
+        }
+        if (getBlock(x - 1, y, &block) && block.collision == old_coll && block.elevation == old_elev) {
+            todo.append(QPoint(x - 1, y));
+        }
+        if (getBlock(x, y + 1, &block) && block.collision == old_coll && block.elevation == old_elev) {
+            todo.append(QPoint(x, y + 1));
+        }
+        if (getBlock(x, y - 1, &block) && block.collision == old_coll && block.elevation == old_elev) {
+            todo.append(QPoint(x, y - 1));
+        }
     }
 }
 
 void Map::floodFillCollisionElevation(int x, int y, uint16_t collision, uint16_t elevation) {
-    Block block;;
+    Block block;
     if (getBlock(x, y, &block) && (block.collision != collision || block.elevation != elevation)) {
         _floodFillCollisionElevation(x, y, collision, elevation);
     }

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -959,7 +959,7 @@ void Editor::onHoveredMapMetatileChanged(const QPoint &pos) {
     if (map_item->paintingMode == MapPixmapItem::PaintMode::Metatiles
      && pos.x() >= 0 && pos.x() < map->getWidth() && pos.y() >= 0 && pos.y() < map->getHeight()) {
         int blockIndex = pos.y() * map->getWidth() + pos.x();
-        int metatileId = map->layout->blockdata->at(blockIndex).tile;
+        int metatileId = map->layout->blockdata.at(blockIndex).tile;
         this->ui->statusBar->showMessage(QString("X: %1, Y: %2, %3, Scale = %4x")
                               .arg(pos.x())
                               .arg(pos.y())
@@ -989,8 +989,8 @@ void Editor::onHoveredMapMovementPermissionChanged(int x, int y) {
     if (map_item->paintingMode == MapPixmapItem::PaintMode::Metatiles
      && x >= 0 && x < map->getWidth() && y >= 0 && y < map->getHeight()) {
         int blockIndex = y * map->getWidth() + x;
-        uint16_t collision = map->layout->blockdata->at(blockIndex).collision;
-        uint16_t elevation = map->layout->blockdata->at(blockIndex).elevation;
+        uint16_t collision = map->layout->blockdata.at(blockIndex).collision;
+        uint16_t elevation = map->layout->blockdata.at(blockIndex).elevation;
         QString message = QString("X: %1, Y: %2, %3")
                             .arg(x)
                             .arg(y)

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -959,7 +959,7 @@ void Editor::onHoveredMapMetatileChanged(const QPoint &pos) {
     if (map_item->paintingMode == MapPixmapItem::PaintMode::Metatiles
      && pos.x() >= 0 && pos.x() < map->getWidth() && pos.y() >= 0 && pos.y() < map->getHeight()) {
         int blockIndex = pos.y() * map->getWidth() + pos.x();
-        int metatileId = map->layout->blockdata->blocks->at(blockIndex).tile;
+        int metatileId = map->layout->blockdata->at(blockIndex).tile;
         this->ui->statusBar->showMessage(QString("X: %1, Y: %2, %3, Scale = %4x")
                               .arg(pos.x())
                               .arg(pos.y())
@@ -989,8 +989,8 @@ void Editor::onHoveredMapMovementPermissionChanged(int x, int y) {
     if (map_item->paintingMode == MapPixmapItem::PaintMode::Metatiles
      && x >= 0 && x < map->getWidth() && y >= 0 && y < map->getHeight()) {
         int blockIndex = y * map->getWidth() + x;
-        uint16_t collision = map->layout->blockdata->blocks->at(blockIndex).collision;
-        uint16_t elevation = map->layout->blockdata->blocks->at(blockIndex).elevation;
+        uint16_t collision = map->layout->blockdata->at(blockIndex).collision;
+        uint16_t elevation = map->layout->blockdata->at(blockIndex).elevation;
         QString message = QString("X: %1, Y: %2, %3")
                             .arg(x)
                             .arg(y)

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -2614,8 +2614,8 @@ void MainWindow::on_pushButton_ChangeDimensions_clicked()
 
     if (dialog.exec() == QDialog::Accepted) {
         Map *map = editor->map;
-        Blockdata *oldMetatiles = map->layout->blockdata->copy();
-        Blockdata *oldBorder = map->layout->border->copy();
+        Blockdata *oldMetatiles = new Blockdata(*map->layout->blockdata);
+        Blockdata *oldBorder = new Blockdata(*map->layout->border);
         QSize oldMapDimensions(map->getWidth(), map->getHeight());
         QSize oldBorderDimensions(map->getBorderWidth(), map->getBorderHeight());
         QSize newMapDimensions(widthSpinBox->value(), heightSpinBox->value());
@@ -2625,9 +2625,9 @@ void MainWindow::on_pushButton_ChangeDimensions_clicked()
             editor->map->setBorderDimensions(newBorderDimensions.width(), newBorderDimensions.height());
             editor->map->editHistory.push(new ResizeMap(map, 
                 oldMapDimensions, newMapDimensions,
-                oldMetatiles, map->layout->blockdata->copy(),
+                *oldMetatiles, *map->layout->blockdata,
                 oldBorderDimensions, newBorderDimensions,
-                oldBorder, map->layout->border->copy()
+                *oldBorder, *map->layout->border
             ));
         }
     }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -2623,7 +2623,7 @@ void MainWindow::on_pushButton_ChangeDimensions_clicked()
         if (oldMapDimensions != newMapDimensions || oldBorderDimensions != newBorderDimensions) {
             editor->map->setDimensions(newMapDimensions.width(), newMapDimensions.height());
             editor->map->setBorderDimensions(newBorderDimensions.width(), newBorderDimensions.height());
-            editor->map->editHistory.push(new ResizeMap(map, 
+            editor->map->editHistory.push(new ResizeMap(map,
                 oldMapDimensions, newMapDimensions,
                 oldMetatiles, map->layout->blockdata,
                 oldBorderDimensions, newBorderDimensions,

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -2614,8 +2614,8 @@ void MainWindow::on_pushButton_ChangeDimensions_clicked()
 
     if (dialog.exec() == QDialog::Accepted) {
         Map *map = editor->map;
-        Blockdata *oldMetatiles = new Blockdata(*map->layout->blockdata);
-        Blockdata *oldBorder = new Blockdata(*map->layout->border);
+        Blockdata oldMetatiles = map->layout->blockdata;
+        Blockdata oldBorder = map->layout->border;
         QSize oldMapDimensions(map->getWidth(), map->getHeight());
         QSize oldBorderDimensions(map->getBorderWidth(), map->getBorderHeight());
         QSize newMapDimensions(widthSpinBox->value(), heightSpinBox->value());
@@ -2625,9 +2625,9 @@ void MainWindow::on_pushButton_ChangeDimensions_clicked()
             editor->map->setBorderDimensions(newBorderDimensions.width(), newBorderDimensions.height());
             editor->map->editHistory.push(new ResizeMap(map, 
                 oldMapDimensions, newMapDimensions,
-                *oldMetatiles, *map->layout->blockdata,
+                oldMetatiles, map->layout->blockdata,
                 oldBorderDimensions, newBorderDimensions,
-                *oldBorder, *map->layout->border
+                oldBorder, map->layout->border
             ));
         }
     }

--- a/src/mainwindow_scriptapi.cpp
+++ b/src/mainwindow_scriptapi.cpp
@@ -26,7 +26,7 @@ void MainWindow::tryCommitMapChanges(bool commitChanges) {
         if (map) {
             map->editHistory.push(new ScriptEditMap(map,
                 map->layout->lastCommitMapBlocks.dimensions, QSize(map->getWidth(), map->getHeight()),
-                map->layout->lastCommitMapBlocks.blocks->copy(), map->layout->blockdata->copy()
+                *map->layout->lastCommitMapBlocks.blocks, *map->layout->blockdata
             ));
         }
     }

--- a/src/mainwindow_scriptapi.cpp
+++ b/src/mainwindow_scriptapi.cpp
@@ -26,7 +26,7 @@ void MainWindow::tryCommitMapChanges(bool commitChanges) {
         if (map) {
             map->editHistory.push(new ScriptEditMap(map,
                 map->layout->lastCommitMapBlocks.dimensions, QSize(map->getWidth(), map->getHeight()),
-                *map->layout->lastCommitMapBlocks.blocks, *map->layout->blockdata
+                map->layout->lastCommitMapBlocks.blocks, map->layout->blockdata
             ));
         }
     }

--- a/src/mainwindow_scriptapi.cpp
+++ b/src/mainwindow_scriptapi.cpp
@@ -149,7 +149,7 @@ void MainWindow::magicFillFromSelection(int x, int y, bool forceRedraw, bool com
 void MainWindow::shift(int xDelta, int yDelta, bool forceRedraw, bool commitChanges) {
     if (!this->editor || !this->editor->map)
         return;
-    this->editor->map_item->shift(xDelta, yDelta);
+    this->editor->map_item->shift(xDelta, yDelta, true);
     this->tryCommitMapChanges(commitChanges);
     this->tryRedrawMapArea(forceRedraw);
 }

--- a/src/project.cpp
+++ b/src/project.cpp
@@ -1183,7 +1183,6 @@ bool Project::loadBlockdata(Map *map) {
 
     QString path = QString("%1/%2").arg(root).arg(map->layout->blockdata_path);
     map->layout->blockdata = readBlockdata(path);
-    map->layout->lastCommitMapBlocks.blocks.clear();
     map->layout->lastCommitMapBlocks.blocks = map->layout->blockdata;
     map->layout->lastCommitMapBlocks.dimensions = QSize(map->getWidth(), map->getHeight());
 

--- a/src/project.cpp
+++ b/src/project.cpp
@@ -1186,17 +1186,16 @@ bool Project::loadBlockdata(Map *map) {
     if (map->layout->lastCommitMapBlocks.blocks) {
         delete map->layout->lastCommitMapBlocks.blocks;
     }
-    map->layout->lastCommitMapBlocks.blocks = new Blockdata;
-    map->layout->lastCommitMapBlocks.blocks->copyFrom(map->layout->blockdata);
+    *map->layout->lastCommitMapBlocks.blocks = *map->layout->blockdata;
     map->layout->lastCommitMapBlocks.dimensions = QSize(map->getWidth(), map->getHeight());
 
-    if (map->layout->blockdata->blocks->count() != map->getWidth() * map->getHeight()) {
+    if (map->layout->blockdata->count() != map->getWidth() * map->getHeight()) {
         logWarn(QString("Layout blockdata length %1 does not match dimensions %2x%3 (should be %4). Resizing blockdata.")
-                .arg(map->layout->blockdata->blocks->count())
+                .arg(map->layout->blockdata->count())
                 .arg(map->getWidth())
                 .arg(map->getHeight())
                 .arg(map->getWidth() * map->getHeight()));
-        map->layout->blockdata->blocks->resize(map->getWidth() * map->getHeight());
+        map->layout->blockdata->resize(map->getWidth() * map->getHeight());
     }
     return true;
 }
@@ -1204,11 +1203,10 @@ bool Project::loadBlockdata(Map *map) {
 void Project::setNewMapBlockdata(Map *map) {
     Blockdata *blockdata = new Blockdata;
     for (int i = 0; i < map->getWidth() * map->getHeight(); i++) {
-        blockdata->addBlock(qint16(0x3001));
+        blockdata->append(qint16(0x3001));
     }
     map->layout->blockdata = blockdata;
-    map->layout->lastCommitMapBlocks.blocks = new Blockdata;
-    map->layout->lastCommitMapBlocks.blocks->copyFrom(map->layout->blockdata);
+    *map->layout->lastCommitMapBlocks.blocks = *map->layout->blockdata;
     map->layout->lastCommitMapBlocks.dimensions = QSize(map->getWidth(), map->getHeight());
 }
 
@@ -1220,11 +1218,11 @@ bool Project::loadMapBorder(Map *map) {
     QString path = QString("%1/%2").arg(root).arg(map->layout->border_path);
     map->layout->border = readBlockdata(path);
     int borderLength = map->getBorderWidth() * map->getBorderHeight();
-    if (map->layout->border->blocks->count() != borderLength) {
+    if (map->layout->border->count() != borderLength) {
         logWarn(QString("Layout border blockdata length %1 must be %2. Resizing border blockdata.")
-                .arg(map->layout->border->blocks->count())
+                .arg(map->layout->border->count())
                 .arg(borderLength));
-        map->layout->border->blocks->resize(borderLength);
+        map->layout->border->resize(borderLength);
     }
     return true;
 }
@@ -1233,18 +1231,18 @@ void Project::setNewMapBorder(Map *map) {
     Blockdata *blockdata = new Blockdata;
     if (map->getBorderWidth() != DEFAULT_BORDER_WIDTH || map->getBorderHeight() != DEFAULT_BORDER_HEIGHT) {
         for (int i = 0; i < map->getBorderWidth() * map->getBorderHeight(); i++) {
-            blockdata->addBlock(0);
+            blockdata->append(0);
         }
     } else if (projectConfig.getBaseGameVersion() == BaseGameVersion::pokefirered) {
-        blockdata->addBlock(qint16(0x0014));
-        blockdata->addBlock(qint16(0x0015));
-        blockdata->addBlock(qint16(0x001C));
-        blockdata->addBlock(qint16(0x001D));
+        blockdata->append(qint16(0x0014));
+        blockdata->append(qint16(0x0015));
+        blockdata->append(qint16(0x001C));
+        blockdata->append(qint16(0x001D));
     } else {
-        blockdata->addBlock(qint16(0x01D4));
-        blockdata->addBlock(qint16(0x01D5));
-        blockdata->addBlock(qint16(0x01DC));
-        blockdata->addBlock(qint16(0x01DD));
+        blockdata->append(qint16(0x01D4));
+        blockdata->append(qint16(0x01D5));
+        blockdata->append(qint16(0x01DC));
+        blockdata->append(qint16(0x01DD));
     }
     map->layout->border = blockdata;
 }
@@ -1709,7 +1707,7 @@ Blockdata* Project::readBlockdata(QString path) {
         QByteArray data = file.readAll();
         for (int i = 0; (i + 1) < data.length(); i += 2) {
             uint16_t word = static_cast<uint16_t>((data[i] & 0xff) + ((data[i + 1] & 0xff) << 8));
-            blockdata->addBlock(word);
+            blockdata->append(word);
         }
     } else {
         logError(QString("Failed to open blockdata path '%1'").arg(path));

--- a/src/ui/bordermetatilespixmapitem.cpp
+++ b/src/ui/bordermetatilespixmapitem.cpp
@@ -11,22 +11,19 @@ void BorderMetatilesPixmapItem::mousePressEvent(QGraphicsSceneMouseEvent *event)
     int width = map->getBorderWidth();
     int height = map->getBorderHeight();
 
-    Blockdata *oldBorder = new Blockdata(*map->layout->border);
+    Blockdata oldBorder = map->layout->border;
 
     for (int i = 0; i < selectionDimensions.x() && (i + pos.x()) < width; i++) {
         for (int j = 0; j < selectionDimensions.y() && (j + pos.y()) < height; j++) {
             int blockIndex = (j + pos.y()) * width + (i + pos.x());
             uint16_t tile = selectedMetatiles->at(j * selectionDimensions.x() + i);
-            (*map->layout->border)[blockIndex].tile = tile;
+            map->layout->border[blockIndex].tile = tile;
         }
     }
 
-    Blockdata *newBorder = new Blockdata(*map->layout->border);
-    if (*newBorder == *oldBorder) {
-        delete newBorder;
-        delete oldBorder;
-    } else {
-        map->editHistory.push(new PaintBorder(map, *oldBorder, *newBorder, 0));
+    Blockdata newBorder = map->layout->border;
+    if (newBorder != oldBorder) {
+        map->editHistory.push(new PaintBorder(map, oldBorder, newBorder, 0));
     }
 
     emit borderMetatilesChanged();
@@ -46,7 +43,7 @@ void BorderMetatilesPixmapItem::draw() {
             int y = j * 16;
             int index = j * width + i;
             QImage metatile_image = getMetatileImage(
-                        map->layout->border->value(index).tile,
+                        map->layout->border.value(index).tile,
                         map->layout->tileset_primary,
                         map->layout->tileset_secondary,
                         map->metatileLayerOrder,

--- a/src/ui/bordermetatilespixmapitem.cpp
+++ b/src/ui/bordermetatilespixmapitem.cpp
@@ -11,22 +11,22 @@ void BorderMetatilesPixmapItem::mousePressEvent(QGraphicsSceneMouseEvent *event)
     int width = map->getBorderWidth();
     int height = map->getBorderHeight();
 
-    Blockdata *oldBorder = map->layout->border->copy();
+    Blockdata *oldBorder = new Blockdata(*map->layout->border);
 
     for (int i = 0; i < selectionDimensions.x() && (i + pos.x()) < width; i++) {
         for (int j = 0; j < selectionDimensions.y() && (j + pos.y()) < height; j++) {
             int blockIndex = (j + pos.y()) * width + (i + pos.x());
             uint16_t tile = selectedMetatiles->at(j * selectionDimensions.x() + i);
-            (*map->layout->border->blocks)[blockIndex].tile = tile;
+            (*map->layout->border)[blockIndex].tile = tile;
         }
     }
 
-    Blockdata *newBorder = map->layout->border->copy();
-    if (newBorder->equals(oldBorder)) {
+    Blockdata *newBorder = new Blockdata(*map->layout->border);
+    if (*newBorder == *oldBorder) {
         delete newBorder;
         delete oldBorder;
     } else {
-        map->editHistory.push(new PaintBorder(map, oldBorder, newBorder, 0));
+        map->editHistory.push(new PaintBorder(map, *oldBorder, *newBorder, 0));
     }
 
     emit borderMetatilesChanged();
@@ -39,7 +39,6 @@ void BorderMetatilesPixmapItem::draw() {
     int height = map->getBorderHeight();
     QImage image(16 * width, 16 * height, QImage::Format_RGBA8888);
     QPainter painter(&image);
-    QVector<Block> *blocks = map->layout->border->blocks;
 
     for (int i = 0; i < width; i++) {
         for (int j = 0; j < height; j++) {
@@ -47,7 +46,7 @@ void BorderMetatilesPixmapItem::draw() {
             int y = j * 16;
             int index = j * width + i;
             QImage metatile_image = getMetatileImage(
-                        blocks->value(index).tile,
+                        map->layout->border->value(index).tile,
                         map->layout->tileset_primary,
                         map->layout->tileset_secondary,
                         map->metatileLayerOrder,

--- a/src/ui/bordermetatilespixmapitem.cpp
+++ b/src/ui/bordermetatilespixmapitem.cpp
@@ -21,9 +21,8 @@ void BorderMetatilesPixmapItem::mousePressEvent(QGraphicsSceneMouseEvent *event)
         }
     }
 
-    Blockdata newBorder = map->layout->border;
-    if (newBorder != oldBorder) {
-        map->editHistory.push(new PaintBorder(map, oldBorder, newBorder, 0));
+    if (map->layout->border != oldBorder) {
+        map->editHistory.push(new PaintBorder(map, oldBorder, map->layout->border, 0));
     }
 
     emit borderMetatilesChanged();

--- a/src/ui/collisionpixmapitem.cpp
+++ b/src/ui/collisionpixmapitem.cpp
@@ -65,9 +65,8 @@ void CollisionPixmapItem::paint(QGraphicsSceneMouseEvent *event) {
             map->setBlock(pos.x(), pos.y(), block, true);
         }
 
-        Blockdata newCollision = map->layout->blockdata;
-        if (newCollision != oldCollision) {
-            map->editHistory.push(new PaintCollision(map, oldCollision, newCollision, actionId_));
+        if (map->layout->blockdata != oldCollision) {
+            map->editHistory.push(new PaintCollision(map, oldCollision, map->layout->blockdata, actionId_));
         }
     }
 }
@@ -83,9 +82,8 @@ void CollisionPixmapItem::floodFill(QGraphicsSceneMouseEvent *event) {
         uint16_t elevation = this->movementPermissionsSelector->getSelectedElevation();
         map->floodFillCollisionElevation(pos.x(), pos.y(), collision, elevation);
 
-        Blockdata newCollision = map->layout->blockdata;
-        if (newCollision != oldCollision) {
-            map->editHistory.push(new BucketFillCollision(map, oldCollision, newCollision));
+        if (map->layout->blockdata != oldCollision) {
+            map->editHistory.push(new BucketFillCollision(map, oldCollision, map->layout->blockdata));
         }
     }
 }
@@ -100,9 +98,8 @@ void CollisionPixmapItem::magicFill(QGraphicsSceneMouseEvent *event) {
         uint16_t elevation = this->movementPermissionsSelector->getSelectedElevation();
         map->magicFillCollisionElevation(pos.x(), pos.y(), collision, elevation);
 
-        Blockdata newCollision = map->layout->blockdata;
-        if (newCollision != oldCollision) {
-            map->editHistory.push(new MagicFillCollision(map, oldCollision, newCollision));
+        if (map->layout->blockdata != oldCollision) {
+            map->editHistory.push(new MagicFillCollision(map, oldCollision, map->layout->blockdata));
         }
     }
 }

--- a/src/ui/collisionpixmapitem.cpp
+++ b/src/ui/collisionpixmapitem.cpp
@@ -45,7 +45,7 @@ void CollisionPixmapItem::paint(QGraphicsSceneMouseEvent *event) {
     if (event->type() == QEvent::GraphicsSceneMouseRelease) {
         actionId_++;
     } else if (map) {
-        Blockdata *oldCollision = new Blockdata(*map->layout->blockdata);
+        Blockdata oldCollision = map->layout->blockdata;
 
         QPoint pos = Metatile::coordFromPixmapCoord(event->pos());
 
@@ -65,12 +65,9 @@ void CollisionPixmapItem::paint(QGraphicsSceneMouseEvent *event) {
             map->setBlock(pos.x(), pos.y(), block, true);
         }
 
-        Blockdata *newCollision = new Blockdata(*map->layout->blockdata);
-        if (*newCollision == *oldCollision) {
-            delete newCollision;
-            delete oldCollision;
-        } else {
-            map->editHistory.push(new PaintCollision(map, *oldCollision, *newCollision, actionId_));
+        Blockdata newCollision = map->layout->blockdata;
+        if (newCollision != oldCollision) {
+            map->editHistory.push(new PaintCollision(map, oldCollision, newCollision, actionId_));
         }
     }
 }
@@ -79,19 +76,16 @@ void CollisionPixmapItem::floodFill(QGraphicsSceneMouseEvent *event) {
     if (event->type() == QEvent::GraphicsSceneMouseRelease) {
         this->actionId_++;
     } else if (map) {
-        Blockdata *oldCollision = new Blockdata(*map->layout->blockdata);
+        Blockdata oldCollision = map->layout->blockdata;
 
         QPoint pos = Metatile::coordFromPixmapCoord(event->pos());
         uint16_t collision = this->movementPermissionsSelector->getSelectedCollision();
         uint16_t elevation = this->movementPermissionsSelector->getSelectedElevation();
         map->floodFillCollisionElevation(pos.x(), pos.y(), collision, elevation);
 
-        Blockdata *newCollision = new Blockdata(*map->layout->blockdata);
-        if (*newCollision == *oldCollision) {
-            delete newCollision;
-            delete oldCollision;
-        } else {
-            map->editHistory.push(new BucketFillCollision(map, *oldCollision, *newCollision));
+        Blockdata newCollision = map->layout->blockdata;
+        if (newCollision != oldCollision) {
+            map->editHistory.push(new BucketFillCollision(map, oldCollision, newCollision));
         }
     }
 }
@@ -100,18 +94,15 @@ void CollisionPixmapItem::magicFill(QGraphicsSceneMouseEvent *event) {
     if (event->type() == QEvent::GraphicsSceneMouseRelease) {
         this->actionId_++;
     } else if (map) {
-        Blockdata *oldCollision = new Blockdata(*map->layout->blockdata);
+        Blockdata oldCollision = map->layout->blockdata;
         QPoint pos = Metatile::coordFromPixmapCoord(event->pos());
         uint16_t collision = this->movementPermissionsSelector->getSelectedCollision();
         uint16_t elevation = this->movementPermissionsSelector->getSelectedElevation();
         map->magicFillCollisionElevation(pos.x(), pos.y(), collision, elevation);
 
-        Blockdata *newCollision = new Blockdata(*map->layout->blockdata);
-        if (*newCollision == *oldCollision) {
-            delete newCollision;
-            delete oldCollision;
-        } else {
-            map->editHistory.push(new MagicFillCollision(map, *oldCollision, *newCollision));
+        Blockdata newCollision = map->layout->blockdata;
+        if (newCollision != oldCollision) {
+            map->editHistory.push(new MagicFillCollision(map, oldCollision, newCollision));
         }
     }
 }

--- a/src/ui/collisionpixmapitem.cpp
+++ b/src/ui/collisionpixmapitem.cpp
@@ -45,7 +45,7 @@ void CollisionPixmapItem::paint(QGraphicsSceneMouseEvent *event) {
     if (event->type() == QEvent::GraphicsSceneMouseRelease) {
         actionId_++;
     } else if (map) {
-        Blockdata *oldCollision = map->layout->blockdata->copy();
+        Blockdata *oldCollision = new Blockdata(*map->layout->blockdata);
 
         QPoint pos = Metatile::coordFromPixmapCoord(event->pos());
 
@@ -65,12 +65,12 @@ void CollisionPixmapItem::paint(QGraphicsSceneMouseEvent *event) {
             map->setBlock(pos.x(), pos.y(), block, true);
         }
 
-        Blockdata *newCollision = map->layout->blockdata->copy();
-        if (newCollision->equals(oldCollision)) {
+        Blockdata *newCollision = new Blockdata(*map->layout->blockdata);
+        if (*newCollision == *oldCollision) {
             delete newCollision;
             delete oldCollision;
         } else {
-            map->editHistory.push(new PaintCollision(map, oldCollision, newCollision, actionId_));
+            map->editHistory.push(new PaintCollision(map, *oldCollision, *newCollision, actionId_));
         }
     }
 }
@@ -79,19 +79,19 @@ void CollisionPixmapItem::floodFill(QGraphicsSceneMouseEvent *event) {
     if (event->type() == QEvent::GraphicsSceneMouseRelease) {
         this->actionId_++;
     } else if (map) {
-        Blockdata *oldCollision = map->layout->blockdata->copy();
+        Blockdata *oldCollision = new Blockdata(*map->layout->blockdata);
 
         QPoint pos = Metatile::coordFromPixmapCoord(event->pos());
         uint16_t collision = this->movementPermissionsSelector->getSelectedCollision();
         uint16_t elevation = this->movementPermissionsSelector->getSelectedElevation();
         map->floodFillCollisionElevation(pos.x(), pos.y(), collision, elevation);
 
-        Blockdata *newCollision = map->layout->blockdata->copy();
-        if (newCollision->equals(oldCollision)) {
+        Blockdata *newCollision = new Blockdata(*map->layout->blockdata);
+        if (*newCollision == *oldCollision) {
             delete newCollision;
             delete oldCollision;
         } else {
-            map->editHistory.push(new BucketFillCollision(map, oldCollision, newCollision));
+            map->editHistory.push(new BucketFillCollision(map, *oldCollision, *newCollision));
         }
     }
 }
@@ -100,18 +100,18 @@ void CollisionPixmapItem::magicFill(QGraphicsSceneMouseEvent *event) {
     if (event->type() == QEvent::GraphicsSceneMouseRelease) {
         this->actionId_++;
     } else if (map) {
-        Blockdata *oldCollision = map->layout->blockdata->copy();
+        Blockdata *oldCollision = new Blockdata(*map->layout->blockdata);
         QPoint pos = Metatile::coordFromPixmapCoord(event->pos());
         uint16_t collision = this->movementPermissionsSelector->getSelectedCollision();
         uint16_t elevation = this->movementPermissionsSelector->getSelectedElevation();
         map->magicFillCollisionElevation(pos.x(), pos.y(), collision, elevation);
 
-        Blockdata *newCollision = map->layout->blockdata->copy();
-        if (newCollision->equals(oldCollision)) {
+        Blockdata *newCollision = new Blockdata(*map->layout->blockdata);
+        if (*newCollision == *oldCollision) {
             delete newCollision;
             delete oldCollision;
         } else {
-            map->editHistory.push(new MagicFillCollision(map, oldCollision, newCollision));
+            map->editHistory.push(new MagicFillCollision(map, *oldCollision, *newCollision));
         }
     }
 }

--- a/src/ui/mappixmapitem.cpp
+++ b/src/ui/mappixmapitem.cpp
@@ -76,7 +76,7 @@ void MapPixmapItem::shift(QGraphicsSceneMouseEvent *event) {
 }
 
 void MapPixmapItem::shift(int xDelta, int yDelta, bool fromScriptCall) {
-    Blockdata oldMetatiles = !fromScriptCall ? map->layout->blockdata : Blockdata();
+    Blockdata oldMetatiles = map->layout->blockdata;
 
     for (int i = 0; i < map->getWidth(); i++)
     for (int j = 0; j < map->getHeight(); j++) {

--- a/src/ui/mappixmapitem.cpp
+++ b/src/ui/mappixmapitem.cpp
@@ -76,7 +76,8 @@ void MapPixmapItem::shift(QGraphicsSceneMouseEvent *event) {
 }
 
 void MapPixmapItem::shift(int xDelta, int yDelta, bool fromScriptCall) {
-    Blockdata backupBlockdata = map->layout->blockdata;
+    Blockdata oldMetatiles = !fromScriptCall ? map->layout->blockdata : Blockdata();
+
     for (int i = 0; i < map->getWidth(); i++)
     for (int j = 0; j < map->getHeight(); j++) {
         int destX = i + xDelta;
@@ -89,15 +90,12 @@ void MapPixmapItem::shift(int xDelta, int yDelta, bool fromScriptCall) {
         destY %= map->getHeight();
 
         int blockIndex = j * map->getWidth() + i;
-        Block srcBlock = backupBlockdata.at(blockIndex);
+        Block srcBlock = oldMetatiles.at(blockIndex);
         map->setBlock(destX, destY, srcBlock);
     }
 
-    if (!fromScriptCall) {
-        Blockdata newMetatiles = map->layout->blockdata;
-        if (newMetatiles != backupBlockdata) {
-            map->editHistory.push(new ShiftMetatiles(map, backupBlockdata, newMetatiles, actionId_));
-        }
+    if (!fromScriptCall && map->layout->blockdata != oldMetatiles) {
+        map->editHistory.push(new ShiftMetatiles(map, oldMetatiles, map->layout->blockdata, actionId_));
     }
 }
 
@@ -137,11 +135,8 @@ void MapPixmapItem::paintNormal(int x, int y, bool fromScriptCall) {
         }
     }
 
-    if (!fromScriptCall) {
-        Blockdata newMetatiles = map->layout->blockdata;
-        if (newMetatiles != oldMetatiles) {
-            map->editHistory.push(new PaintMetatile(map, oldMetatiles, newMetatiles, actionId_));
-        }
+    if (!fromScriptCall && map->layout->blockdata != oldMetatiles) {
+        map->editHistory.push(new PaintMetatile(map, oldMetatiles, map->layout->blockdata, actionId_));
     }
 }
 
@@ -253,11 +248,8 @@ void MapPixmapItem::paintSmartPath(int x, int y, bool fromScriptCall) {
         map->setBlock(actualX, actualY, block, !fromScriptCall);
     }
 
-    if (!fromScriptCall) {
-        Blockdata newMetatiles = map->layout->blockdata;
-        if (newMetatiles != oldMetatiles) {
-            map->editHistory.push(new PaintMetatile(map, oldMetatiles, newMetatiles, actionId_));
-        }
+    if (!fromScriptCall && map->layout->blockdata != oldMetatiles) {
+        map->editHistory.push(new PaintMetatile(map, oldMetatiles, map->layout->blockdata, actionId_));
     }
 }
 
@@ -432,11 +424,8 @@ void MapPixmapItem::magicFill(
             }
         }
 
-        if (!fromScriptCall) {
-            Blockdata newMetatiles = map->layout->blockdata;
-            if (newMetatiles != oldMetatiles) {
-                map->editHistory.push(new MagicFillMetatile(map, oldMetatiles, newMetatiles, actionId_));
-            }
+        if (!fromScriptCall && map->layout->blockdata != oldMetatiles) {
+            map->editHistory.push(new MagicFillMetatile(map, oldMetatiles, map->layout->blockdata, actionId_));
         }
     }
 }
@@ -513,11 +502,8 @@ void MapPixmapItem::floodFill(
         }
     }
 
-    if (!fromScriptCall) {
-        Blockdata newMetatiles = map->layout->blockdata;
-        if (newMetatiles != oldMetatiles) {
-            map->editHistory.push(new BucketFillMetatile(map, oldMetatiles, newMetatiles, actionId_));
-        }
+    if (!fromScriptCall && map->layout->blockdata != oldMetatiles) {
+        map->editHistory.push(new BucketFillMetatile(map, oldMetatiles, map->layout->blockdata, actionId_));
     }
 }
 
@@ -635,11 +621,8 @@ void MapPixmapItem::floodFillSmartPath(int initialX, int initialY, bool fromScri
         }
     }
 
-    if (!fromScriptCall) {
-        Blockdata newMetatiles = map->layout->blockdata;
-        if (newMetatiles != oldMetatiles) {
-            map->editHistory.push(new BucketFillMetatile(map, oldMetatiles, newMetatiles, actionId_));
-        }
+    if (!fromScriptCall && map->layout->blockdata != oldMetatiles) {
+        map->editHistory.push(new BucketFillMetatile(map, oldMetatiles, map->layout->blockdata, actionId_));
     }
 }
 

--- a/src/ui/mappixmapitem.cpp
+++ b/src/ui/mappixmapitem.cpp
@@ -76,7 +76,7 @@ void MapPixmapItem::shift(QGraphicsSceneMouseEvent *event) {
 }
 
 void MapPixmapItem::shift(int xDelta, int yDelta, bool fromScriptCall) {
-    Blockdata *backupBlockdata = map->layout->blockdata->copy();
+    Blockdata *backupBlockdata = new Blockdata(*map->layout->blockdata);
     for (int i = 0; i < map->getWidth(); i++)
     for (int j = 0; j < map->getHeight(); j++) {
         int destX = i + xDelta;
@@ -89,17 +89,17 @@ void MapPixmapItem::shift(int xDelta, int yDelta, bool fromScriptCall) {
         destY %= map->getHeight();
 
         int blockIndex = j * map->getWidth() + i;
-        Block srcBlock = backupBlockdata->blocks->at(blockIndex);
+        Block srcBlock = backupBlockdata->at(blockIndex);
         map->setBlock(destX, destY, srcBlock);
     }
 
     if (!fromScriptCall) {
-        Blockdata *newMetatiles = map->layout->blockdata->copy();
-        if (newMetatiles->equals(backupBlockdata)) {
+        Blockdata *newMetatiles = new Blockdata(*map->layout->blockdata);
+        if (*newMetatiles == *backupBlockdata) {
             delete newMetatiles;
             delete backupBlockdata;
         } else {
-            map->editHistory.push(new ShiftMetatiles(map, backupBlockdata, newMetatiles, actionId_));
+            map->editHistory.push(new ShiftMetatiles(map, *backupBlockdata, *newMetatiles, actionId_));
         }
     } else {
         delete backupBlockdata;
@@ -125,7 +125,7 @@ void MapPixmapItem::paintNormal(int x, int y, bool fromScriptCall) {
 
     // for edit history
     Blockdata *oldMetatiles = nullptr;
-    if (!fromScriptCall) oldMetatiles = map->layout->blockdata->copy();
+    if (!fromScriptCall) oldMetatiles = new Blockdata(*map->layout->blockdata);
 
     for (int i = 0; i < selectionDimensions.x() && i + x < map->getWidth(); i++)
     for (int j = 0; j < selectionDimensions.y() && j + y < map->getHeight(); j++) {
@@ -144,12 +144,12 @@ void MapPixmapItem::paintNormal(int x, int y, bool fromScriptCall) {
     }
 
     if (!fromScriptCall) {
-        Blockdata *newMetatiles = map->layout->blockdata->copy();
-        if (newMetatiles->equals(oldMetatiles)) {
+        Blockdata *newMetatiles = new Blockdata(*map->layout->blockdata);
+        if (*newMetatiles == *oldMetatiles) {
             delete newMetatiles;
             delete oldMetatiles;
         } else {
-            map->editHistory.push(new PaintMetatile(map, oldMetatiles, newMetatiles, actionId_));
+            map->editHistory.push(new PaintMetatile(map, *oldMetatiles, *newMetatiles, actionId_));
         }
     }
 }
@@ -199,7 +199,7 @@ void MapPixmapItem::paintSmartPath(int x, int y, bool fromScriptCall) {
 
     // for edit history
     Blockdata *oldMetatiles = nullptr;
-    if (!fromScriptCall) oldMetatiles = map->layout->blockdata->copy();
+    if (!fromScriptCall) oldMetatiles = new Blockdata(*map->layout->blockdata);
 
     // Fill the region with the open tile.
     for (int i = 0; i <= 1; i++)
@@ -264,12 +264,12 @@ void MapPixmapItem::paintSmartPath(int x, int y, bool fromScriptCall) {
     }
 
     if (!fromScriptCall) {
-        Blockdata *newMetatiles = map->layout->blockdata->copy();
-        if (newMetatiles->equals(oldMetatiles)) {
+        Blockdata *newMetatiles = new Blockdata(*map->layout->blockdata);
+        if (*newMetatiles == *oldMetatiles) {
             delete newMetatiles;
             delete oldMetatiles;
         } else {
-            map->editHistory.push(new PaintMetatile(map, oldMetatiles, newMetatiles, actionId_));
+            map->editHistory.push(new PaintMetatile(map, *oldMetatiles, *newMetatiles, actionId_));
         }
     }
 }
@@ -287,7 +287,7 @@ void MapPixmapItem::lockNondominantAxis(QGraphicsSceneMouseEvent *event) {
         this->straight_path_initial_x = pos.x();
         this->straight_path_initial_y = pos.y();
     }
-    
+
     // Only lock an axis when the current position != initial
     int xDiff = pos.x() - this->straight_path_initial_x;
     int yDiff = pos.y() - this->straight_path_initial_y;
@@ -352,7 +352,7 @@ void MapPixmapItem::updateMetatileSelection(QGraphicsSceneMouseEvent *event) {
                 metatiles.append(block.tile);
             }
             int blockIndex = y * map->getWidth() + x;
-            block = map->layout->blockdata->blocks->at(blockIndex);
+            block = map->layout->blockdata->at(blockIndex);
             auto collision = block.collision;
             auto elevation = block.elevation;
             collisions.append(QPair<uint16_t, uint16_t>(collision, elevation));
@@ -422,7 +422,7 @@ void MapPixmapItem::magicFill(
         }
 
         Blockdata *oldMetatiles = nullptr;
-        if (!fromScriptCall) oldMetatiles = map->layout->blockdata->copy();
+        if (!fromScriptCall) oldMetatiles = new Blockdata(*map->layout->blockdata);
 
         bool setCollisions = selectedCollisions && selectedCollisions->length() == selectedMetatiles->length();
         uint16_t tile = block.tile;
@@ -447,12 +447,12 @@ void MapPixmapItem::magicFill(
         }
 
         if (!fromScriptCall) {
-            Blockdata *newMetatiles = map->layout->blockdata->copy();
-            if (newMetatiles->equals(oldMetatiles)) {
+            Blockdata *newMetatiles = new Blockdata(*map->layout->blockdata);
+            if (*newMetatiles == *oldMetatiles) {
                 delete newMetatiles;
                 delete oldMetatiles;
             } else {
-                map->editHistory.push(new MagicFillMetatile(map, oldMetatiles, newMetatiles, actionId_));
+                map->editHistory.push(new MagicFillMetatile(map, *oldMetatiles, *newMetatiles, actionId_));
             }
         }
     }
@@ -482,7 +482,7 @@ void MapPixmapItem::floodFill(
     bool setCollisions = selectedCollisions && selectedCollisions->length() == selectedMetatiles->length();
     Blockdata *oldMetatiles = nullptr;
     if (!fromScriptCall) {
-        oldMetatiles = map->layout->blockdata->copy();
+        oldMetatiles = new Blockdata(*map->layout->blockdata);
     }
 
     QSet<int> visited;
@@ -534,12 +534,12 @@ void MapPixmapItem::floodFill(
     }
 
     if (!fromScriptCall) {
-        Blockdata *newMetatiles = map->layout->blockdata->copy();
-        if (newMetatiles->equals(oldMetatiles)) {
+        Blockdata *newMetatiles = new Blockdata(*map->layout->blockdata);
+        if (*newMetatiles == *oldMetatiles) {
             delete newMetatiles;
             delete oldMetatiles;
         } else {
-            map->editHistory.push(new BucketFillMetatile(map, oldMetatiles, newMetatiles, actionId_));
+            map->editHistory.push(new BucketFillMetatile(map, *oldMetatiles, *newMetatiles, actionId_));
         }
     }
 }
@@ -564,7 +564,7 @@ void MapPixmapItem::floodFillSmartPath(int initialX, int initialY, bool fromScri
     }
 
     Blockdata *oldMetatiles = nullptr;
-    if (!fromScriptCall) oldMetatiles = map->layout->blockdata->copy();
+    if (!fromScriptCall) oldMetatiles = new Blockdata(*map->layout->blockdata);
 
     // Flood fill the region with the open tile.
     QList<QPoint> todo;
@@ -660,13 +660,13 @@ void MapPixmapItem::floodFillSmartPath(int initialX, int initialY, bool fromScri
     }
 
     if (!fromScriptCall) {
-        Blockdata *newMetatiles = map->layout->blockdata->copy();
-        if (newMetatiles->equals(oldMetatiles)) {
+        Blockdata *newMetatiles = new Blockdata(*map->layout->blockdata);
+        if (*newMetatiles == *oldMetatiles) {
             delete newMetatiles;
             delete oldMetatiles;
         } else {
-            map->editHistory.push(new BucketFillMetatile(map, oldMetatiles, newMetatiles, actionId_));
-        }    
+            map->editHistory.push(new BucketFillMetatile(map, *oldMetatiles, *newMetatiles, actionId_));
+        }
     }
 }
 


### PR DESCRIPTION
Refactors `Blockdata` to simply inherit `QVector<Block>` which simplifies a lot of code as it only needs the `serialize()` member function. Additionally, all usages of pointers to `Blockdata` have been removed to fix/prevent memory leaks. There shouldn't be any runtime impact from using values over pointers, since Qt's shared-data classes are just pointers that copy-on-write (for this reason, all other usages of pointers to shared-data classes should eventually be changed).

Reference for shared-data classes: https://doc.qt.io/qt-5/implicit-sharing.html

This shouldn't be merged until I or someone else reviews/tests the code further. I intend review this in-depth later this evening.