### PR TITLE
Metatile leaks

### DIFF
--- a/include/core/metatile.h
+++ b/include/core/metatile.h
@@ -11,8 +11,9 @@ class Metatile
 {
 public:
     Metatile();
+    Metatile(const Metatile &other);
 public:
-    QList<Tile> *tiles = nullptr;
+    QList<Tile> tiles;
     uint16_t behavior;     // 8 bits RSE, 9 bits FRLG
     uint8_t layerType;
     uint8_t encounterType; // FRLG only

--- a/include/core/metatile.h
+++ b/include/core/metatile.h
@@ -11,7 +11,9 @@ class Metatile
 {
 public:
     Metatile();
-    Metatile(const Metatile &other);
+    Metatile(const Metatile &other) = default;
+    Metatile &operator=(const Metatile &other) = default;
+
 public:
     QList<Tile> tiles;
     uint16_t behavior;     // 8 bits RSE, 9 bits FRLG
@@ -20,8 +22,6 @@ public:
     uint8_t terrainType;   // FRLG only
     QString label;
 
-    Metatile *copy();
-    void copyInPlace(Metatile*);
     static int getBlockIndex(int);
     static QPoint coordFromPixmapCoord(const QPointF &pixelCoord);
 };

--- a/include/core/metatileparser.h
+++ b/include/core/metatileparser.h
@@ -10,7 +10,7 @@ class MetatileParser
 {
 public:
     MetatileParser();
-    QList<Metatile*> *parse(QString filepath, bool *error, bool primaryTileset);
+    QList<Metatile*> parse(QString filepath, bool *error, bool primaryTileset);
 };
 
 #endif // METATILEPARSER_H

--- a/include/core/tile.h
+++ b/include/core/tile.h
@@ -6,8 +6,20 @@
 class Tile
 {
 public:
-    Tile() {}
-    Tile(int tile, bool xflip, bool yflip, int palette);
+    Tile() :
+        tile(0),
+        xflip(false),
+        yflip(false),
+        palette(0)
+    {  }
+
+    Tile(int tile, bool xflip, bool yflip, int palette) :
+        tile(tile),
+        xflip(xflip),
+        yflip(yflip),
+        palette(palette)
+    {  }
+
 public:
     int tile;
     bool xflip;

--- a/include/core/tileset.h
+++ b/include/core/tileset.h
@@ -9,7 +9,10 @@
 class Tileset
 {
 public:
-    Tileset();
+    Tileset() = default;
+    Tileset(const Tileset &other) = default;
+    Tileset &operator=(const Tileset &other) = default;
+
 public:
     QString name;
     QString is_compressed;
@@ -24,14 +27,12 @@ public:
     QString metatile_attrs_path;
     QString tilesImagePath;
     QImage tilesImage;
-    QList<QString> palettePaths;
+    QStringList palettePaths;
 
-    QList<QImage> *tiles = nullptr;
-    QList<Metatile*> *metatiles = nullptr;
-    QList<QList<QRgb>> *palettes = nullptr;
-    QList<QList<QRgb>> *palettePreviews = nullptr;
-
-    Tileset* copy();
+    QList<QImage> tiles;
+    QList<Metatile*> metatiles;
+    QList<QList<QRgb>> palettes;
+    QList<QList<QRgb>> palettePreviews;
 
     static Tileset* getBlockTileset(int, Tileset*, Tileset*);
     static Metatile* getMetatile(int, Tileset*, Tileset*);

--- a/include/mainwindow.h
+++ b/include/mainwindow.h
@@ -77,8 +77,8 @@ public:
     Q_INVOKABLE void setPrimaryTilesetPalettes(QList<QList<QList<int>>> palettes);
     Q_INVOKABLE void setSecondaryTilesetPalette(int paletteIndex, QList<QList<int>> colors);
     Q_INVOKABLE void setSecondaryTilesetPalettes(QList<QList<QList<int>>> palettes);
-    QJSValue getTilesetPalette(QList<QList<QRgb>> *palettes, int paletteIndex);
-    QJSValue getTilesetPalettes(QList<QList<QRgb>> *palettes);
+    QJSValue getTilesetPalette(const QList<QList<QRgb>> &palettes, int paletteIndex);
+    QJSValue getTilesetPalettes(const QList<QList<QRgb>> &palettes);
     Q_INVOKABLE QJSValue getPrimaryTilesetPalette(int paletteIndex);
     Q_INVOKABLE QJSValue getPrimaryTilesetPalettes();
     Q_INVOKABLE QJSValue getSecondaryTilesetPalette(int paletteIndex);

--- a/porymap.pro
+++ b/porymap.pro
@@ -25,7 +25,6 @@ SOURCES += src/core/block.cpp \
     src/core/metatileparser.cpp \
     src/core/paletteutil.cpp \
     src/core/parseutil.cpp \
-    src/core/tile.cpp \
     src/core/tileset.cpp \
     src/core/regionmap.cpp \
     src/core/wildmoninfo.cpp \

--- a/src/core/metatile.cpp
+++ b/src/core/metatile.cpp
@@ -2,10 +2,21 @@
 #include "tileset.h"
 #include "project.h"
 
-Metatile::Metatile()
-{
-    tiles = new QList<Tile>;
-}
+Metatile::Metatile() :
+    behavior(0),
+    layerType(0),
+    encounterType(0),
+    terrainType(0)
+{  }
+
+Metatile::Metatile(const Metatile &other) :
+    tiles(other.tiles),
+    behavior(other.behavior),
+    layerType(other.layerType),
+    encounterType(other.encounterType),
+    terrainType(other.terrainType),
+    label(other.label)
+{  }
 
 Metatile* Metatile::copy() {
     Metatile *copy = new Metatile;
@@ -13,10 +24,9 @@ Metatile* Metatile::copy() {
     copy->layerType = this->layerType;
     copy->encounterType = this->encounterType;
     copy->terrainType = this->terrainType;
-    copy->tiles = new QList<Tile>;
     copy->label = this->label;
-    for (Tile tile : *this->tiles) {
-        copy->tiles->append(tile);
+    for (const Tile &tile : this->tiles) {
+        copy->tiles.append(tile);
     }
     return copy;
 }
@@ -27,8 +37,8 @@ void Metatile::copyInPlace(Metatile *other) {
     this->encounterType = other->encounterType;
     this->terrainType = other->terrainType;
     this->label = other->label;
-    for (int i = 0; i < this->tiles->length(); i++) {
-        (*this->tiles)[i] = other->tiles->at(i);
+    for (int i = 0; i < this->tiles.length(); i++) {
+        this->tiles[i] = other->tiles.at(i);
     }
 }
 

--- a/src/core/metatile.cpp
+++ b/src/core/metatile.cpp
@@ -9,39 +9,6 @@ Metatile::Metatile() :
     terrainType(0)
 {  }
 
-Metatile::Metatile(const Metatile &other) :
-    tiles(other.tiles),
-    behavior(other.behavior),
-    layerType(other.layerType),
-    encounterType(other.encounterType),
-    terrainType(other.terrainType),
-    label(other.label)
-{  }
-
-Metatile* Metatile::copy() {
-    Metatile *copy = new Metatile;
-    copy->behavior = this->behavior;
-    copy->layerType = this->layerType;
-    copy->encounterType = this->encounterType;
-    copy->terrainType = this->terrainType;
-    copy->label = this->label;
-    for (const Tile &tile : this->tiles) {
-        copy->tiles.append(tile);
-    }
-    return copy;
-}
-
-void Metatile::copyInPlace(Metatile *other) {
-    this->behavior = other->behavior;
-    this->layerType = other->layerType;
-    this->encounterType = other->encounterType;
-    this->terrainType = other->terrainType;
-    this->label = other->label;
-    for (int i = 0; i < this->tiles.length(); i++) {
-        this->tiles[i] = other->tiles.at(i);
-    }
-}
-
 int Metatile::getBlockIndex(int index) {
     if (index < Project::getNumMetatilesPrimary()) {
         return index;

--- a/src/core/metatileparser.cpp
+++ b/src/core/metatileparser.cpp
@@ -75,14 +75,14 @@ QList<Metatile*> *MetatileParser::parse(QString filepath, bool *error, bool prim
     QList<Metatile*> *metatiles = new QList<Metatile*>();
     for (int i = 0; i < numMetatiles; i++) {
         Metatile *metatile = new Metatile();
-        QList<Tile> *tiles = new QList<Tile>();
+        QList<Tile> tiles;
         for (int j = 0; j < 8; j++) {
             int metatileOffset = 4 + i * metatileSize + j * 2;
             uint16_t word = static_cast<uint16_t>(
                         static_cast<unsigned char>(in.at(metatileOffset)) |
                         (static_cast<unsigned char>(in.at(metatileOffset + 1)) << 8));
             Tile tile(word & 0x3ff, (word >> 10) & 1, (word >> 11) & 1, (word >> 12) & 0xf);
-            tiles->append(tile);
+            tiles.append(tile);
         }
 
         int attrOffset = 4 + (numMetatiles * metatileSize) + (i * attrSize);

--- a/src/core/metatileparser.cpp
+++ b/src/core/metatileparser.cpp
@@ -8,13 +8,13 @@ MetatileParser::MetatileParser()
 
 }
 
-QList<Metatile*> *MetatileParser::parse(QString filepath, bool *error, bool primaryTileset)
+QList<Metatile*> MetatileParser::parse(QString filepath, bool *error, bool primaryTileset)
 {
     QFile file(filepath);
     if (!file.open(QIODevice::ReadOnly)) {
         *error = true;
         logError(QString("Could not open Advance Map 1.92 Metatile .bvd file '%1': ").arg(filepath) + file.errorString());
-        return nullptr;
+        return { };
     }
 
     QByteArray in = file.readAll();
@@ -23,7 +23,7 @@ QList<Metatile*> *MetatileParser::parse(QString filepath, bool *error, bool prim
     if (in.length() < 9 || in.length() % 2 != 0) {
         *error = true;
         logError(QString("Advance Map 1.92 Metatile .bvd file '%1' is an unexpected size.").arg(filepath));
-        return nullptr;
+        return { };
     }
 
     int projIdOffset = in.length() - 4;
@@ -46,7 +46,7 @@ QList<Metatile*> *MetatileParser::parse(QString filepath, bool *error, bool prim
     } else {
         *error = true;
         logError(QString("Detected unsupported game type from .bvd file. Last 4 bytes of file must be 'RSE ' or 'FRLG'."));
-        return nullptr;
+        return { };
     }
 
     int maxMetatiles = primaryTileset ? Project::getNumMetatilesPrimary() : Project::getNumMetatilesTotal() - Project::getNumMetatilesPrimary();
@@ -57,22 +57,22 @@ QList<Metatile*> *MetatileParser::parse(QString filepath, bool *error, bool prim
     if (numMetatiles > maxMetatiles) {
         *error = true;
         logError(QString(".bvd file contains data for %1 metatiles, but the maximum number of metatiles is %2.").arg(numMetatiles).arg(maxMetatiles));
-        return nullptr;
+        return { };
     }
     if (numMetatiles < 1) {
         *error = true;
         logError(QString(".bvd file contains no data for metatiles."));
-        return nullptr;
+        return { };
     }
 
     int expectedFileSize = 4 + (metatileSize * numMetatiles) + (attrSize * numMetatiles) + 4;
     if (in.length() != expectedFileSize) {
         *error = true;
         logError(QString(".bvd file is an unexpected size. Expected %1 bytes, but it has %2 bytes.").arg(expectedFileSize).arg(in.length()));
-        return nullptr;
+        return { };
     }
 
-    QList<Metatile*> *metatiles = new QList<Metatile*>();
+    QList<Metatile*> metatiles;
     for (int i = 0; i < numMetatiles; i++) {
         Metatile *metatile = new Metatile();
         QList<Tile> tiles;
@@ -104,7 +104,7 @@ QList<Metatile*> *MetatileParser::parse(QString filepath, bool *error, bool prim
             metatile->terrainType = 0;
         }
         metatile->tiles = tiles;
-        metatiles->append(metatile);
+        metatiles.append(metatile);
     }
 
     return metatiles;

--- a/src/core/tile.cpp
+++ b/src/core/tile.cpp
@@ -1,9 +1,0 @@
-#include "tile.h"
-
-Tile::Tile(int tile, bool xflip, bool yflip, int palette)
-{
-    this->tile = tile;
-    this->xflip = xflip;
-    this->yflip = yflip;
-    this->palette = palette;
-}

--- a/src/core/tileset.cpp
+++ b/src/core/tileset.cpp
@@ -71,8 +71,7 @@ Metatile* Tileset::getMetatile(int index, Tileset *primaryTileset, Tileset *seco
     if (!tileset || !tileset->metatiles) {
         return nullptr;
     }
-    Metatile *metatile = tileset->metatiles->value(local_index, nullptr);
-    return metatile;
+    return tileset->metatiles->value(local_index, nullptr);
 }
 
 bool Tileset::metatileIsValid(uint16_t metatileId, Tileset *primaryTileset, Tileset *secondaryTileset) {

--- a/src/core/tileset.cpp
+++ b/src/core/tileset.cpp
@@ -7,55 +7,6 @@
 #include <QPainter>
 #include <QImage>
 
-Tileset::Tileset()
-{
-
-}
-
-Tileset* Tileset::copy() {
-    Tileset *copy = new Tileset;
-    copy->name = this->name;
-    copy->is_compressed = this->is_compressed;
-    copy->is_secondary = this->is_secondary;
-    copy->padding = this->padding;
-    copy->tiles_label = this->tiles_label;
-    copy->palettes_label = this->palettes_label;
-    copy->metatiles_label = this->metatiles_label;
-    copy->metatiles_path = this->metatiles_path;
-    copy->callback_label = this->callback_label;
-    copy->metatile_attrs_label = this->metatile_attrs_label;
-    copy->metatile_attrs_path = this->metatile_attrs_path;
-    copy->tilesImage = this->tilesImage.copy();
-    copy->tilesImagePath = this->tilesImagePath;
-    for (int i = 0; i < this->palettePaths.length(); i++) {
-        copy->palettePaths.append(this->palettePaths.at(i));
-    }
-    copy->tiles = new QList<QImage>;
-    for (QImage tile : *this->tiles) {
-        copy->tiles->append(tile.copy());
-    }
-    copy->metatiles = new QList<Metatile*>;
-    for (Metatile *metatile : *this->metatiles) {
-        copy->metatiles->append(new Metatile(*metatile));
-    }
-    copy->palettes = new QList<QList<QRgb>>;
-    for (QList<QRgb> palette : *this->palettes) {
-        QList<QRgb> copyPalette;
-        for (QRgb color : palette) {
-            copyPalette.append(color);
-        }
-        copy->palettes->append(copyPalette);
-    }
-    copy->palettePreviews = new QList<QList<QRgb>>;
-    for (QList<QRgb> palette : *this->palettePreviews) {
-        QList<QRgb> copyPalette;
-        for (QRgb color : palette) {
-            copyPalette.append(color);
-        }
-        copy->palettePreviews->append(copyPalette);
-    }
-    return copy;
-}
 
 Tileset* Tileset::getBlockTileset(int metatile_index, Tileset *primaryTileset, Tileset *secondaryTileset) {
     if (metatile_index < Project::getNumMetatilesPrimary()) {
@@ -68,20 +19,20 @@ Tileset* Tileset::getBlockTileset(int metatile_index, Tileset *primaryTileset, T
 Metatile* Tileset::getMetatile(int index, Tileset *primaryTileset, Tileset *secondaryTileset) {
     Tileset *tileset = Tileset::getBlockTileset(index, primaryTileset, secondaryTileset);
     int local_index = Metatile::getBlockIndex(index);
-    if (!tileset || !tileset->metatiles) {
+    if (!tileset) {
         return nullptr;
     }
-    return tileset->metatiles->value(local_index, nullptr);
+    return tileset->metatiles.value(local_index, nullptr);
 }
 
 bool Tileset::metatileIsValid(uint16_t metatileId, Tileset *primaryTileset, Tileset *secondaryTileset) {
     if (metatileId >= Project::getNumMetatilesTotal())
         return false;
 
-    if (metatileId < Project::getNumMetatilesPrimary() && metatileId >= primaryTileset->metatiles->length())
+    if (metatileId < Project::getNumMetatilesPrimary() && metatileId >= primaryTileset->metatiles.length())
         return false;
 
-    if (metatileId >= Project::getNumMetatilesPrimary() + secondaryTileset->metatiles->length())
+    if (metatileId >= Project::getNumMetatilesPrimary() + secondaryTileset->metatiles.length())
         return false;
 
     return true;
@@ -91,11 +42,11 @@ QList<QList<QRgb>> Tileset::getBlockPalettes(Tileset *primaryTileset, Tileset *s
     QList<QList<QRgb>> palettes;
     auto primaryPalettes = useTruePalettes ? primaryTileset->palettes : primaryTileset->palettePreviews;
     for (int i = 0; i < Project::getNumPalettesPrimary(); i++) {
-        palettes.append(primaryPalettes->at(i));
+        palettes.append(primaryPalettes.at(i));
     }
     auto secondaryPalettes = useTruePalettes ? secondaryTileset->palettes : secondaryTileset->palettePreviews;
     for (int i = Project::getNumPalettesPrimary(); i < Project::getNumPalettesTotal(); i++) {
-        palettes.append(secondaryPalettes->at(i));
+        palettes.append(secondaryPalettes.at(i));
     }
     return palettes;
 }
@@ -106,8 +57,8 @@ QList<QRgb> Tileset::getPalette(int paletteId, Tileset *primaryTileset, Tileset 
             ? primaryTileset
             : secondaryTileset;
     auto palettes = useTruePalettes ? tileset->palettes : tileset->palettePreviews;
-    for (int i = 0; i < palettes->at(paletteId).length(); i++) {
-        paletteTable.append(palettes->at(paletteId).at(i));
+    for (int i = 0; i < palettes.at(paletteId).length(); i++) {
+        paletteTable.append(palettes.at(paletteId).at(i));
     }
     return paletteTable;
 }

--- a/src/core/tileset.cpp
+++ b/src/core/tileset.cpp
@@ -36,7 +36,7 @@ Tileset* Tileset::copy() {
     }
     copy->metatiles = new QList<Metatile*>;
     for (Metatile *metatile : *this->metatiles) {
-        copy->metatiles->append(metatile->copy());
+        copy->metatiles->append(new Metatile(*metatile));
     }
     copy->palettes = new QList<QList<QRgb>>;
     for (QList<QRgb> palette : *this->palettes) {

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1219,16 +1219,16 @@ void MainWindow::on_actionNew_Tileset_triggered() {
             int tilesPerMetatile = projectConfig.getTripleLayerMetatilesEnabled() ? 12 : 8;
             Metatile *mt = new Metatile();
             for(int j = 0; j < tilesPerMetatile; ++j){
-                Tile *tile = new Tile();
+                Tile tile;
                 //Create a checkerboard-style dummy tileset
                 if(((i / 8) % 2) == 0)
-                    tile->tile = ((i % 2) == 0) ? 1 : 2;
+                    tile.tile = ((i % 2) == 0) ? 1 : 2;
                 else
-                    tile->tile = ((i % 2) == 1) ? 1 : 2;
-                tile->xflip = false;
-                tile->yflip = false;
-                tile->palette = 0;
-                mt->tiles->append(*tile);
+                    tile.tile = ((i % 2) == 1) ? 1 : 2;
+                tile.xflip = false;
+                tile.yflip = false;
+                tile.palette = 0;
+                mt->tiles.append(tile);
             }
             mt->behavior = 0;
             mt->layerType = 0;
@@ -1239,7 +1239,7 @@ void MainWindow::on_actionNew_Tileset_triggered() {
         }
         newSet->palettes = new QList<QList<QRgb>>();
         newSet->palettePreviews = new QList<QList<QRgb>>();
-        newSet->palettePaths = *new QList<QString>();
+        newSet->palettePaths.clear();
         for(int i = 0; i < 16; ++i) {
             QList<QRgb> *currentPal = new QList<QRgb>();
             for(int i = 0; i < 16;++i) {

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1212,22 +1212,18 @@ void MainWindow::on_actionNew_Tileset_triggered() {
         newSet->metatile_attrs_path = fullDirectoryPath + "/metatile_attributes.bin";
         newSet->is_secondary = createTilesetDialog->isSecondary ? "TRUE" : "FALSE";
         int numMetaTiles = createTilesetDialog->isSecondary ? (Project::getNumTilesTotal() - Project::getNumTilesPrimary()) : Project::getNumTilesPrimary();
-        QImage *tilesImage = new QImage(":/images/blank_tileset.png");
-        editor->project->loadTilesetTiles(newSet, *tilesImage);
-        newSet->metatiles = new QList<Metatile*>();
+        QImage tilesImage(":/images/blank_tileset.png");
+        editor->project->loadTilesetTiles(newSet, tilesImage);
         for(int i = 0; i < numMetaTiles; ++i) {
             int tilesPerMetatile = projectConfig.getTripleLayerMetatilesEnabled() ? 12 : 8;
             Metatile *mt = new Metatile();
             for(int j = 0; j < tilesPerMetatile; ++j){
-                Tile tile;
+                Tile tile(0, false, false, 0);
                 //Create a checkerboard-style dummy tileset
                 if(((i / 8) % 2) == 0)
                     tile.tile = ((i % 2) == 0) ? 1 : 2;
                 else
                     tile.tile = ((i % 2) == 1) ? 1 : 2;
-                tile.xflip = false;
-                tile.yflip = false;
-                tile.palette = 0;
                 mt->tiles.append(tile);
             }
             mt->behavior = 0;
@@ -1235,23 +1231,20 @@ void MainWindow::on_actionNew_Tileset_triggered() {
             mt->encounterType = 0;
             mt->terrainType = 0;
 
-            newSet->metatiles->append(mt);
+            newSet->metatiles.append(mt);
         }
-        newSet->palettes = new QList<QList<QRgb>>();
-        newSet->palettePreviews = new QList<QList<QRgb>>();
-        newSet->palettePaths.clear();
         for(int i = 0; i < 16; ++i) {
-            QList<QRgb> *currentPal = new QList<QRgb>();
+            QList<QRgb> currentPal;
             for(int i = 0; i < 16;++i) {
-                currentPal->append(qRgb(0,0,0));
+                currentPal.append(qRgb(0,0,0));
             }
-            newSet->palettes->append(*currentPal);
-            newSet->palettePreviews->append(*currentPal);
+            newSet->palettes.append(currentPal);
+            newSet->palettePreviews.append(currentPal);
             QString fileName = QString("%1.pal").arg(i, 2, 10, QLatin1Char('0'));
             newSet->palettePaths.append(fullDirectoryPath+"/palettes/" + fileName);
         }
-        (*newSet->palettes)[0][1] = qRgb(255,0,255);
-        (*newSet->palettePreviews)[0][1] = qRgb(255,0,255);
+        newSet->palettes[0][1] = qRgb(255,0,255);
+        newSet->palettePreviews[0][1] = qRgb(255,0,255);
         newSet->is_compressed = "TRUE";
         newSet->padding = "0";
         editor->project->saveTilesetTilesImage(newSet);

--- a/src/mainwindow_scriptapi.cpp
+++ b/src/mainwindow_scriptapi.cpp
@@ -260,7 +260,7 @@ void MainWindow::refreshAfterPaletteChange(Tileset *tileset) {
 void MainWindow::setTilesetPalette(Tileset *tileset, int paletteIndex, QList<QList<int>> colors) {
     if (!this->editor || !this->editor->map || !this->editor->map->layout)
         return;
-    if (paletteIndex >= tileset->palettes->size())
+    if (paletteIndex >= tileset->palettes.size())
         return;
     if (colors.size() != 16)
         return;
@@ -268,8 +268,8 @@ void MainWindow::setTilesetPalette(Tileset *tileset, int paletteIndex, QList<QLi
     for (int i = 0; i < 16; i++) {
         if (colors[i].size() != 3)
             continue;
-        (*tileset->palettes)[paletteIndex][i] = qRgb(colors[i][0], colors[i][1], colors[i][2]);
-        (*tileset->palettePreviews)[paletteIndex][i] = qRgb(colors[i][0], colors[i][1], colors[i][2]);
+        tileset->palettes[paletteIndex][i] = qRgb(colors[i][0], colors[i][1], colors[i][2]);
+        tileset->palettePreviews[paletteIndex][i] = qRgb(colors[i][0], colors[i][1], colors[i][2]);
     }
 }
 
@@ -305,22 +305,22 @@ void MainWindow::setSecondaryTilesetPalettes(QList<QList<QList<int>>> palettes) 
     this->refreshAfterPaletteChange(this->editor->map->layout->tileset_secondary);
 }
 
-QJSValue MainWindow::getTilesetPalette(QList<QList<QRgb>> *palettes, int paletteIndex) {
-    if (paletteIndex >= palettes->size())
+QJSValue MainWindow::getTilesetPalette(const QList<QList<QRgb>> &palettes, int paletteIndex) {
+    if (paletteIndex >= palettes.size())
         return QJSValue();
 
     QList<QList<int>> palette;
-    for (auto color : palettes->value(paletteIndex)) {
+    for (auto color : palettes.value(paletteIndex)) {
         palette.append(QList<int>({qRed(color), qGreen(color), qBlue(color)}));
     }
     return Scripting::getEngine()->toScriptValue(palette);
 }
 
-QJSValue MainWindow::getTilesetPalettes(QList<QList<QRgb>> *palettes) {
+QJSValue MainWindow::getTilesetPalettes(const QList<QList<QRgb>> &palettes) {
     QList<QList<QList<int>>> outPalettes;
-    for (int i = 0; i < palettes->size(); i++) {
+    for (int i = 0; i < palettes.size(); i++) {
         QList<QList<int>> colors;
-        for (auto color : palettes->value(i)) {
+        for (auto color : palettes.value(i)) {
             colors.append(QList<int>({qRed(color), qGreen(color), qBlue(color)}));
         }
         outPalettes.append(colors);
@@ -363,7 +363,7 @@ void MainWindow::refreshAfterPalettePreviewChange() {
 void MainWindow::setTilesetPalettePreview(Tileset *tileset, int paletteIndex, QList<QList<int>> colors) {
     if (!this->editor || !this->editor->map || !this->editor->map->layout)
         return;
-    if (paletteIndex >= tileset->palettePreviews->size())
+    if (paletteIndex >= tileset->palettePreviews.size())
         return;
     if (colors.size() != 16)
         return;
@@ -371,8 +371,7 @@ void MainWindow::setTilesetPalettePreview(Tileset *tileset, int paletteIndex, QL
     for (int i = 0; i < 16; i++) {
         if (colors[i].size() != 3)
             continue;
-        auto palettes = tileset->palettePreviews;
-        (*palettes)[paletteIndex][i] = qRgb(colors[i][0], colors[i][1], colors[i][2]);
+        tileset->palettePreviews[paletteIndex][i] = qRgb(colors[i][0], colors[i][1], colors[i][2]);
     }
 }
 

--- a/src/project.cpp
+++ b/src/project.cpp
@@ -1088,7 +1088,7 @@ void Project::saveTilesetMetatiles(Tileset *tileset) {
         for (Metatile *metatile : *tileset->metatiles) {
             int numTiles = projectConfig.getTripleLayerMetatilesEnabled() ? 12 : 8;
             for (int i = 0; i < numTiles; i++) {
-                Tile tile = metatile->tiles->at(i);
+                Tile tile = metatile->tiles.at(i);
                 uint16_t value = static_cast<uint16_t>((tile.tile & 0x3ff)
                                                     | ((tile.xflip & 1) << 10)
                                                     | ((tile.yflip & 1) << 11)
@@ -1626,7 +1626,7 @@ void Project::loadTilesetMetatiles(Tileset* tileset) {
                 tile.xflip = (word >> 10) & 1;
                 tile.yflip = (word >> 11) & 1;
                 tile.palette = (word >> 12) & 0xf;
-                metatile->tiles->append(tile);
+                metatile->tiles.append(tile);
             }
             metatiles->append(metatile);
         }

--- a/src/ui/imageproviders.cpp
+++ b/src/ui/imageproviders.cpp
@@ -97,10 +97,10 @@ QImage getMetatileImage(
 QImage getTileImage(uint16_t tile, Tileset *primaryTileset, Tileset *secondaryTileset) {
     Tileset *tileset = Tileset::getBlockTileset(tile, primaryTileset, secondaryTileset);
     int local_index = Metatile::getBlockIndex(tile);
-    if (!tileset || !tileset->tiles) {
+    if (!tileset) {
         return QImage();
     }
-    return tileset->tiles->value(local_index, QImage());
+    return tileset->tiles.value(local_index, QImage());
 }
 
 QImage getColoredTileImage(uint16_t tile, Tileset *primaryTileset, Tileset *secondaryTileset, QList<QRgb> palette) {

--- a/src/ui/imageproviders.cpp
+++ b/src/ui/imageproviders.cpp
@@ -26,7 +26,7 @@ QImage getMetatileImage(
     metatile_image.fill(Qt::black);
 
     Metatile* metatile = Tileset::getMetatile(tile, primaryTileset, secondaryTileset);
-    if (!metatile || !metatile->tiles) {
+    if (!metatile) {
         metatile_image.fill(Qt::magenta);
         return metatile_image;
     }
@@ -46,7 +46,7 @@ QImage getMetatileImage(
     for (int x = 0; x < 2; x++) {
         int l = layerOrder.size() >= numLayers ? layerOrder[layer] : layer;
         int bottomLayer = layerOrder.size() >= numLayers ? layerOrder[0] : 0;
-        Tile tile_ = metatile->tiles->value((y * 2) + x + (l * 4));
+        Tile tile_ = metatile->tiles.value((y * 2) + x + (l * 4));
         QImage tile_image = getTileImage(tile_.tile, primaryTileset, secondaryTileset);
         if (tile_image.isNull()) {
             // Some metatiles specify tiles that are outside the valid range.

--- a/src/ui/metatilelayersitem.cpp
+++ b/src/ui/metatilelayersitem.cpp
@@ -25,7 +25,7 @@ void MetatileLayersItem::draw() {
     QPainter painter(&pixmap);
     int numTiles = isTripleLayerMetatile ? 12 : 8;
     for (int i = 0; i < numTiles; i++) {
-        Tile tile = this->metatile->tiles->at(i);
+        Tile tile = this->metatile->tiles.at(i);
         QImage tileImage = getPalettedTileImage(tile.tile, this->primaryTileset, this->secondaryTileset, tile.palette, true)
                 .mirrored(tile.xflip, tile.yflip)
                 .scaled(16, 16);

--- a/src/ui/metatileselector.cpp
+++ b/src/ui/metatileselector.cpp
@@ -12,13 +12,12 @@ QPoint MetatileSelector::getSelectionDimensions() {
 }
 
 void MetatileSelector::draw() {
-    if (!this->primaryTileset || !this->primaryTileset->metatiles
-     || !this->secondaryTileset || !this->secondaryTileset->metatiles) {
+    if (!this->primaryTileset || !this->secondaryTileset) {
         this->setPixmap(QPixmap());
     }
 
-    int primaryLength = this->primaryTileset->metatiles->length();
-    int length_ = primaryLength + this->secondaryTileset->metatiles->length();
+    int primaryLength = this->primaryTileset->metatiles.length();
+    int length_ = primaryLength + this->secondaryTileset->metatiles.length();
     int height_ = length_ / this->numMetatilesWide;
     if (length_ % this->numMetatilesWide != 0) {
         height_++;
@@ -69,7 +68,7 @@ void MetatileSelector::setTilesets(Tileset *primaryTileset, Tileset *secondaryTi
         if (this->externalSelection) {
             this->select(0);
         } else {
-            this->select(Project::getNumMetatilesPrimary() + this->secondaryTileset->metatiles->length() - 1);
+            this->select(Project::getNumMetatilesPrimary() + this->secondaryTileset->metatiles.length() - 1);
         }
     } else if (this->externalSelection) {
         emit selectedMetatilesChanged();
@@ -181,10 +180,10 @@ bool MetatileSelector::selectionIsValid() {
 
 uint16_t MetatileSelector::getMetatileId(int x, int y) {
     int index = y * this->numMetatilesWide + x;
-    if (index < this->primaryTileset->metatiles->length()) {
+    if (index < this->primaryTileset->metatiles.length()) {
         return static_cast<uint16_t>(index);
     } else {
-        return static_cast<uint16_t>(Project::getNumMetatilesPrimary() + index - this->primaryTileset->metatiles->length());
+        return static_cast<uint16_t>(Project::getNumMetatilesPrimary() + index - this->primaryTileset->metatiles.length());
     }
 }
 
@@ -197,7 +196,7 @@ QPoint MetatileSelector::getMetatileIdCoords(uint16_t metatileId) {
 
     int index = metatileId < Project::getNumMetatilesPrimary()
                 ? metatileId
-                : metatileId - Project::getNumMetatilesPrimary() + this->primaryTileset->metatiles->length();
+                : metatileId - Project::getNumMetatilesPrimary() + this->primaryTileset->metatiles.length();
     return QPoint(index % this->numMetatilesWide, index / this->numMetatilesWide);
 }
 

--- a/src/ui/paletteeditor.cpp
+++ b/src/ui/paletteeditor.cpp
@@ -151,9 +151,9 @@ void PaletteEditor::refreshColorSliders() {
     for (int i = 0; i < 16; i++) {
         QRgb color;
         if (paletteNum < Project::getNumPalettesPrimary()) {
-            color = this->primaryTileset->palettes->at(paletteNum).at(i);
+            color = this->primaryTileset->palettes.at(paletteNum).at(i);
         } else {
-            color = this->secondaryTileset->palettes->at(paletteNum).at(i);
+            color = this->secondaryTileset->palettes.at(paletteNum).at(i);
         }
 
         this->sliders[i][0]->setValue(qRed(color)   / 8);
@@ -204,8 +204,8 @@ void PaletteEditor::setColor(int colorIndex) {
     Tileset *tileset = paletteNum < Project::getNumPalettesPrimary()
             ? this->primaryTileset
             : this->secondaryTileset;
-    (*tileset->palettes)[paletteNum][colorIndex] = qRgb(red, green, blue);
-    (*tileset->palettePreviews)[paletteNum][colorIndex] = qRgb(red, green, blue);
+    tileset->palettes[paletteNum][colorIndex] = qRgb(red, green, blue);
+    tileset->palettePreviews[paletteNum][colorIndex] = qRgb(red, green, blue);
     this->refreshColor(colorIndex);
     this->commitEditHistory(paletteNum);
     emit this->changedPaletteColor();
@@ -255,11 +255,11 @@ void PaletteEditor::setColorsFromHistory(PaletteHistoryItem *history, int palett
 
     for (int i = 0; i < 16; i++) {
         if (paletteId < Project::getNumPalettesPrimary()) {
-            (*this->primaryTileset->palettes)[paletteId][i] = history->colors.at(i);
-            (*this->primaryTileset->palettePreviews)[paletteId][i] = history->colors.at(i);
+            this->primaryTileset->palettes[paletteId][i] = history->colors.at(i);
+            this->primaryTileset->palettePreviews[paletteId][i] = history->colors.at(i);
         } else {
-            (*this->secondaryTileset->palettes)[paletteId][i] = history->colors.at(i);
-            (*this->secondaryTileset->palettePreviews)[paletteId][i] = history->colors.at(i);
+            this->secondaryTileset->palettes[paletteId][i] = history->colors.at(i);
+            this->secondaryTileset->palettePreviews[paletteId][i] = history->colors.at(i);
         }
     }
 
@@ -307,11 +307,11 @@ void PaletteEditor::on_actionImport_Palette_triggered()
     int paletteId = this->ui->spinBox_PaletteId->value();
     for (int i = 0; i < 16; i++) {
         if (paletteId < Project::getNumPalettesPrimary()) {
-            (*this->primaryTileset->palettes)[paletteId][i] = palette.at(i);
-            (*this->primaryTileset->palettePreviews)[paletteId][i] = palette.at(i);
+            this->primaryTileset->palettes[paletteId][i] = palette.at(i);
+            this->primaryTileset->palettePreviews[paletteId][i] = palette.at(i);
         } else {
-            (*this->secondaryTileset->palettes)[paletteId][i] = palette.at(i);
-            (*this->secondaryTileset->palettePreviews)[paletteId][i] = palette.at(i);
+            this->secondaryTileset->palettes[paletteId][i] = palette.at(i);
+            this->secondaryTileset->palettePreviews[paletteId][i] = palette.at(i);
         }
     }
 

--- a/src/ui/tileseteditor.cpp
+++ b/src/ui/tileseteditor.cpp
@@ -262,7 +262,7 @@ void TilesetEditor::restoreWindowState() {
 }
 
 void TilesetEditor::initMetatileHistory() {
-    MetatileHistoryItem *commit = new MetatileHistoryItem(0, nullptr, this->metatile->copy());
+    MetatileHistoryItem *commit = new MetatileHistoryItem(0, nullptr, new Metatile(*metatile));
     metatileHistory.push(commit);
 }
 
@@ -375,7 +375,7 @@ void TilesetEditor::onMetatileLayerTileChanged(int x, int y) {
         QPoint(4, 1),
         QPoint(5, 1),
     };
-    Metatile *prevMetatile = this->metatile->copy();
+    Metatile *prevMetatile = new Metatile(*this->metatile);
     QPoint dimensions = this->tileSelector->getSelectionDimensions();
     QList<Tile> tiles = this->tileSelector->getSelectedTiles();
     int selectedTileIndex = 0;
@@ -401,7 +401,8 @@ void TilesetEditor::onMetatileLayerTileChanged(int x, int y) {
     this->metatileLayersItem->draw();
     this->hasUnsavedChanges = true;
 
-    MetatileHistoryItem *commit = new MetatileHistoryItem(metatileSelector->getSelectedMetatile(), prevMetatile, this->metatile->copy());
+    MetatileHistoryItem *commit = new MetatileHistoryItem(metatileSelector->getSelectedMetatile(),
+                                                          prevMetatile, new Metatile(*this->metatile));
     metatileHistory.push(commit);
 }
 
@@ -465,9 +466,10 @@ void TilesetEditor::on_checkBox_yFlip_stateChanged(int checked)
 void TilesetEditor::on_comboBox_metatileBehaviors_activated(const QString &metatileBehavior)
 {
     if (this->metatile) {
-        Metatile *prevMetatile = this->metatile->copy();
+        Metatile *prevMetatile = new Metatile(*this->metatile);
         this->metatile->behavior = static_cast<uint8_t>(project->metatileBehaviorMap[metatileBehavior]);
-        MetatileHistoryItem *commit = new MetatileHistoryItem(metatileSelector->getSelectedMetatile(), prevMetatile, this->metatile->copy());
+        MetatileHistoryItem *commit = new MetatileHistoryItem(metatileSelector->getSelectedMetatile(),
+                                                              prevMetatile, new Metatile(*this->metatile));
         metatileHistory.push(commit);
         this->hasUnsavedChanges = true;
     }
@@ -482,9 +484,10 @@ void TilesetEditor::saveMetatileLabel()
 {
     // Only commit if the field has changed.
     if (this->metatile && this->metatile->label != this->ui->lineEdit_metatileLabel->text()) {
-        Metatile *prevMetatile = this->metatile->copy();
+        Metatile *prevMetatile = new Metatile(*this->metatile);
         this->metatile->label = this->ui->lineEdit_metatileLabel->text();
-        MetatileHistoryItem *commit = new MetatileHistoryItem(metatileSelector->getSelectedMetatile(), prevMetatile, this->metatile->copy());
+        MetatileHistoryItem *commit = new MetatileHistoryItem(metatileSelector->getSelectedMetatile(),
+                                                              prevMetatile, new Metatile(*this->metatile));
         metatileHistory.push(commit);
         this->hasUnsavedChanges = true;
     }
@@ -493,9 +496,10 @@ void TilesetEditor::saveMetatileLabel()
 void TilesetEditor::on_comboBox_layerType_activated(int layerType)
 {
     if (this->metatile) {
-        Metatile *prevMetatile = this->metatile->copy();
+        Metatile *prevMetatile = new Metatile(*this->metatile);
         this->metatile->layerType = static_cast<uint8_t>(layerType);
-        MetatileHistoryItem *commit = new MetatileHistoryItem(metatileSelector->getSelectedMetatile(), prevMetatile, this->metatile->copy());
+        MetatileHistoryItem *commit = new MetatileHistoryItem(metatileSelector->getSelectedMetatile(),
+                                                              prevMetatile, new Metatile(*this->metatile));
         metatileHistory.push(commit);
         this->hasUnsavedChanges = true;
     }
@@ -504,9 +508,10 @@ void TilesetEditor::on_comboBox_layerType_activated(int layerType)
 void TilesetEditor::on_comboBox_encounterType_activated(int encounterType)
 {
     if (this->metatile) {
-        Metatile *prevMetatile = this->metatile->copy();
+        Metatile *prevMetatile = new Metatile(*this->metatile);
         this->metatile->encounterType = static_cast<uint8_t>(encounterType);
-        MetatileHistoryItem *commit = new MetatileHistoryItem(metatileSelector->getSelectedMetatile(), prevMetatile, this->metatile->copy());
+        MetatileHistoryItem *commit = new MetatileHistoryItem(metatileSelector->getSelectedMetatile(),
+                                                              prevMetatile, new Metatile(*this->metatile));
         metatileHistory.push(commit);
         this->hasUnsavedChanges = true;
     }
@@ -515,9 +520,10 @@ void TilesetEditor::on_comboBox_encounterType_activated(int encounterType)
 void TilesetEditor::on_comboBox_terrainType_activated(int terrainType)
 {
     if (this->metatile) {
-        Metatile *prevMetatile = this->metatile->copy();
+        Metatile *prevMetatile = new Metatile(*this->metatile);
         this->metatile->terrainType = static_cast<uint8_t>(terrainType);
-        MetatileHistoryItem *commit = new MetatileHistoryItem(metatileSelector->getSelectedMetatile(), prevMetatile, this->metatile->copy());
+        MetatileHistoryItem *commit = new MetatileHistoryItem(metatileSelector->getSelectedMetatile(),
+                                                              prevMetatile, new Metatile(*this->metatile));
         metatileHistory.push(commit);
         this->hasUnsavedChanges = true;
     }
@@ -811,7 +817,7 @@ void TilesetEditor::on_actionUndo_triggered()
     Metatile *temp = Tileset::getMetatile(commit->metatileId, this->primaryTileset, this->secondaryTileset);
     if (temp) {
         this->metatile = temp;
-        this->metatile->copyInPlace(prev);
+        *this->metatile = *prev;
         this->metatileSelector->select(commit->metatileId);
         this->metatileSelector->draw();
         this->metatileLayersItem->draw();
@@ -828,8 +834,8 @@ void TilesetEditor::on_actionRedo_triggered()
 
     Metatile *temp = Tileset::getMetatile(commit->metatileId, this->primaryTileset, this->secondaryTileset);
     if (temp) {
-        this->metatile = Tileset::getMetatile(commit->metatileId, this->primaryTileset, this->secondaryTileset);
-        this->metatile->copyInPlace(next);
+        this->metatile = temp;
+        *this->metatile = *next;
         this->metatileSelector->select(commit->metatileId);
         this->metatileSelector->draw();
         this->metatileLayersItem->draw();
@@ -905,8 +911,9 @@ void TilesetEditor::importTilesetMetatiles(Tileset *tileset, bool primary)
             break;
         }
 
-        Metatile *prevMetatile = tileset->metatiles->at(i)->copy();
-        MetatileHistoryItem *commit = new MetatileHistoryItem(static_cast<uint16_t>(metatileIdBase + i), prevMetatile, metatiles->at(i)->copy());
+        Metatile *prevMetatile = new Metatile(*tileset->metatiles->at(i));
+        MetatileHistoryItem *commit = new MetatileHistoryItem(static_cast<uint16_t>(metatileIdBase + i),
+                                                              prevMetatile, new Metatile(*metatiles->at(i)));
         metatileHistory.push(commit);
     }
 

--- a/src/ui/tileseteditor.cpp
+++ b/src/ui/tileseteditor.cpp
@@ -361,7 +361,7 @@ void TilesetEditor::onSelectedTilesChanged() {
 }
 
 void TilesetEditor::onMetatileLayerTileChanged(int x, int y) {
-    const QList<QPoint> tileCoords = QList<QPoint>{
+    static const QList<QPoint> tileCoords = QList<QPoint>{
         QPoint(0, 0),
         QPoint(1, 0),
         QPoint(0, 1),
@@ -387,11 +387,11 @@ void TilesetEditor::onMetatileLayerTileChanged(int x, int y) {
             if (tileIndex < maxTileIndex
              && tileCoords.at(tileIndex).x() >= x
              && tileCoords.at(tileIndex).y() >= y){
-                Tile *tile = &(*this->metatile->tiles)[tileIndex];
-                tile->tile = tiles.at(selectedTileIndex).tile;
-                tile->xflip = tiles.at(selectedTileIndex).xflip;
-                tile->yflip = tiles.at(selectedTileIndex).yflip;
-                tile->palette = tiles.at(selectedTileIndex).palette;
+                Tile &tile = this->metatile->tiles[tileIndex];
+                tile.tile = tiles.at(selectedTileIndex).tile;
+                tile.xflip = tiles.at(selectedTileIndex).xflip;
+                tile.yflip = tiles.at(selectedTileIndex).yflip;
+                tile.palette = tiles.at(selectedTileIndex).palette;
             }
             selectedTileIndex++;
         }
@@ -416,7 +416,7 @@ void TilesetEditor::onMetatileLayerSelectionChanged(QPoint selectionOrigin, int 
         for (int i = 0; i < width; i++) {
             int tileIndex = ((x + i) / 2 * 4) + ((y + j) * 2) + ((x + i) % 2);
             if (tileIndex < maxTileIndex) {
-                tiles.append(this->metatile->tiles->at(tileIndex));
+                tiles.append(this->metatile->tiles.at(tileIndex));
                 tileIdxs.append(tileIndex);
             }
         }
@@ -740,7 +740,7 @@ void TilesetEditor::on_actionChange_Metatiles_Count_triggered()
             metatile->encounterType = 0;
             metatile->terrainType = 0;
             for (int i = 0; i < numTiles; i++) {
-                metatile->tiles->append(tile);
+                metatile->tiles.append(tile);
             }
             this->primaryTileset->metatiles->append(metatile);
         }
@@ -760,7 +760,7 @@ void TilesetEditor::on_actionChange_Metatiles_Count_triggered()
             metatile->encounterType = 0;
             metatile->terrainType = 0;
             for (int i = 0; i < numTiles; i++) {
-                metatile->tiles->append(tile);
+                metatile->tiles.append(tile);
             }
             this->secondaryTileset->metatiles->append(metatile);
         }

--- a/src/ui/tileseteditormetatileselector.cpp
+++ b/src/ui/tileseteditormetatileselector.cpp
@@ -4,13 +4,12 @@
 #include <QPainter>
 
 void TilesetEditorMetatileSelector::draw() {
-    if (!this->primaryTileset || !this->primaryTileset->metatiles
-     || !this->secondaryTileset || !this->secondaryTileset->metatiles) {
+    if (!this->primaryTileset || !this->secondaryTileset) {
         this->setPixmap(QPixmap());
     }
 
-    int primaryLength = this->primaryTileset->metatiles->length();
-    int length_ = primaryLength + this->secondaryTileset->metatiles->length();
+    int primaryLength = this->primaryTileset->metatiles.length();
+    int length_ = primaryLength + this->secondaryTileset->metatiles.length();
     int height_ = length_ / this->numMetatilesWide;
     if (length_ % this->numMetatilesWide != 0) {
         height_++;
@@ -63,7 +62,7 @@ void TilesetEditorMetatileSelector::updateSelectedMetatile() {
     if (Tileset::metatileIsValid(metatileId, this->primaryTileset, this->secondaryTileset))
         this->selectedMetatile = metatileId;
     else
-        this->selectedMetatile = Project::getNumMetatilesPrimary() + this->secondaryTileset->metatiles->length() - 1;
+        this->selectedMetatile = Project::getNumMetatilesPrimary() + this->secondaryTileset->metatiles.length() - 1;
     emit selectedMetatileChanged(this->selectedMetatile);
 }
 
@@ -73,10 +72,10 @@ uint16_t TilesetEditorMetatileSelector::getSelectedMetatile() {
 
 uint16_t TilesetEditorMetatileSelector::getMetatileId(int x, int y) {
     int index = y * this->numMetatilesWide + x;
-    if (index < this->primaryTileset->metatiles->length()) {
+    if (index < this->primaryTileset->metatiles.length()) {
         return static_cast<uint16_t>(index);
     } else {
-        return static_cast<uint16_t>(Project::getNumMetatilesPrimary() + index - this->primaryTileset->metatiles->length());
+        return static_cast<uint16_t>(Project::getNumMetatilesPrimary() + index - this->primaryTileset->metatiles.length());
     }
 }
 
@@ -119,10 +118,10 @@ QPoint TilesetEditorMetatileSelector::getMetatileIdCoords(uint16_t metatileId) {
     {
         // Invalid metatile id.
         return QPoint(0, 0);
-    }    
+    }
     int index = metatileId < Project::getNumMetatilesPrimary()
                 ? metatileId
-                : metatileId - Project::getNumMetatilesPrimary() + this->primaryTileset->metatiles->length();
+                : metatileId - Project::getNumMetatilesPrimary() + this->primaryTileset->metatiles.length();
     return QPoint(index % this->numMetatilesWide, index / this->numMetatilesWide);
 }
 

--- a/src/ui/tileseteditortileselector.cpp
+++ b/src/ui/tileseteditortileselector.cpp
@@ -13,14 +13,13 @@ QPoint TilesetEditorTileSelector::getSelectionDimensions() {
 }
 
 void TilesetEditorTileSelector::draw() {
-    if (!this->primaryTileset || !this->primaryTileset->tiles
-     || !this->secondaryTileset || !this->secondaryTileset->tiles) {
+    if (!this->primaryTileset || !this->secondaryTileset) {
         this->setPixmap(QPixmap());
     }
 
     int totalTiles = Project::getNumTilesTotal();
-    int primaryLength = this->primaryTileset->tiles->length();
-    int secondaryLength = this->secondaryTileset->tiles->length();
+    int primaryLength = this->primaryTileset->tiles.length();
+    int secondaryLength = this->secondaryTileset->tiles.length();
     int height = totalTiles / this->numTilesWide;
     QList<QRgb> palette = Tileset::getPalette(this->paletteId, this->primaryTileset, this->secondaryTileset, true);
     QImage image(this->numTilesWide * 16, height * 16, QImage::Format_RGBA8888);
@@ -218,12 +217,11 @@ QPoint TilesetEditorTileSelector::getTileCoordsOnWidget(uint16_t tile) {
 }
 
 QImage TilesetEditorTileSelector::buildPrimaryTilesIndexedImage() {
-    if (!this->primaryTileset || !this->primaryTileset->tiles
-     || !this->secondaryTileset || !this->secondaryTileset->tiles) {
+    if (!this->primaryTileset || !this->secondaryTileset) {
         return QImage();
     }
 
-    int primaryLength = this->primaryTileset->tiles->length();
+    int primaryLength = this->primaryTileset->tiles.length();
     int height = qCeil(primaryLength / static_cast<double>(this->numTilesWide));
     QImage image(this->numTilesWide * 8, height * 8, QImage::Format_RGBA8888);
 
@@ -254,12 +252,11 @@ QImage TilesetEditorTileSelector::buildPrimaryTilesIndexedImage() {
 }
 
 QImage TilesetEditorTileSelector::buildSecondaryTilesIndexedImage() {
-    if (!this->primaryTileset || !this->primaryTileset->tiles
-     || !this->secondaryTileset || !this->secondaryTileset->tiles) {
+    if (!this->primaryTileset || !this->secondaryTileset) {
         return QImage();
     }
 
-    int secondaryLength = this->secondaryTileset->tiles->length();
+    int secondaryLength = this->secondaryTileset->tiles.length();
     int height = qCeil(secondaryLength / static_cast<double>(this->numTilesWide));
     QImage image(this->numTilesWide * 8, height * 8, QImage::Format_RGBA8888);
 


### PR DESCRIPTION
`Metatile` was leaking memory because it had no destructor to free it's `QList<Tile> *`. ...But it doesn't need one if we just get rid of the pointer. Also, I changed it to just use an implicitly defined copy constructor and copy assingment operator.