### PR TITLE
Remove unnecessary QObject inheritance

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -15,7 +15,7 @@ enum MapSortOrder {
     Layout  =  2,
 };
 
-class KeyValueConfigBase : public QObject
+class KeyValueConfigBase
 {
 public:
     void save();

--- a/include/core/regionmap.h
+++ b/include/core/regionmap.h
@@ -79,14 +79,10 @@ public:
     QString city_map_name;
 };
 
-class RegionMap : public QObject
+class RegionMap
 {
-    Q_OBJECT
-
 public:
     RegionMap() = default;
-
-    ~RegionMap() {};
 
     Project *project = nullptr;
 

--- a/include/ui/currentselectedmetatilespixmapitem.h
+++ b/include/ui/currentselectedmetatilespixmapitem.h
@@ -5,8 +5,7 @@
 #include "metatileselector.h"
 #include <QGraphicsPixmapItem>
 
-class CurrentSelectedMetatilesPixmapItem : public QObject, public QGraphicsPixmapItem {
-    Q_OBJECT
+class CurrentSelectedMetatilesPixmapItem : public QGraphicsPixmapItem {
 public:
     CurrentSelectedMetatilesPixmapItem(Map *map, MetatileSelector *metatileSelector) {
         this->map = map;

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -575,7 +575,7 @@ void ProjectConfig::onNewConfigFileCreated() {
         form.addRow(new QLabel("Game Version"), baseGameVersionComboBox);
 
         QDialogButtonBox buttonBox(QDialogButtonBox::Ok, Qt::Horizontal, &dialog);
-        connect(&buttonBox, &QDialogButtonBox::accepted, &dialog, &QDialog::accept);
+        QObject::connect(&buttonBox, &QDialogButtonBox::accepted, &dialog, &QDialog::accept);
         form.addRow(&buttonBox);
 
         if (dialog.exec() == QDialog::Accepted) {


### PR DESCRIPTION
We have some classes inheriting `QObject` that don't need to, this removes that.