### PR TITLE
Project::addNewMapToGroup() leaks

### DIFF
--- a/include/project.h
+++ b/include/project.h
@@ -101,7 +101,6 @@ public:
     void deleteFile(QString path);
 
     bool readMapGroups();
-    Map* addNewMapToGroup(QString mapName, int groupNum);
     Map* addNewMapToGroup(QString, int, Map*, bool);
     QString getNewMapName();
     QString getProjectTitle();

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1105,10 +1105,10 @@ void MainWindow::onAddNewMapToLayoutClick(QAction* triggeredAction)
 void MainWindow::onNewMapCreated() {
     QString newMapName = this->newmapprompt->map->name;
     int newMapGroup = this->newmapprompt->group;
-    Map *newMap_ = this->newmapprompt->map;
+    Map *newMap = this->newmapprompt->map;
     bool existingLayout = this->newmapprompt->existingLayout;
 
-    Map *newMap = editor->project->addNewMapToGroup(newMapName, newMapGroup, newMap_, existingLayout);
+    newMap = editor->project->addNewMapToGroup(newMapName, newMapGroup, newMap, existingLayout);
 
     logInfo(QString("Created a new map named %1.").arg(newMapName));
 
@@ -1132,6 +1132,7 @@ void MainWindow::onNewMapCreated() {
     }
 
     disconnect(this->newmapprompt, &NewMapPopup::applied, this, &MainWindow::onNewMapCreated);
+    delete newMap;
 }
 
 void MainWindow::openNewMapPopupWindow(int type, QVariant data) {

--- a/src/project.cpp
+++ b/src/project.cpp
@@ -1836,29 +1836,6 @@ bool Project::readMapGroups() {
     return true;
 }
 
-Map* Project::addNewMapToGroup(QString mapName, int groupNum) {
-    // Setup new map in memory, but don't write to file until map is actually saved later.
-    mapNames.append(mapName);
-    mapGroups.insert(mapName, groupNum);
-    groupedMapNames[groupNum].append(mapName);
-
-    Map *map = new Map;
-    map->isPersistedToFile = false;
-    map->setName(mapName);
-    mapConstantsToMapNames.insert(map->constantName, map->name);
-    mapNamesToMapConstants.insert(map->name, map->constantName);
-    setNewMapHeader(map, mapLayoutsTable.size() + 1);
-    setNewMapLayout(map);
-    loadMapTilesets(map);
-    setNewMapBlockdata(map);
-    setNewMapBorder(map);
-    setNewMapEvents(map);
-    setNewMapConnections(map);
-    mapCache.insert(mapName, map);
-
-    return map;
-}
-
 Map* Project::addNewMapToGroup(QString mapName, int groupNum, Map *newMap, bool existingLayout) {
     mapNames.append(mapName);
     mapGroups.insert(mapName, groupNum);

--- a/src/project.cpp
+++ b/src/project.cpp
@@ -1856,7 +1856,6 @@ Map* Project::addNewMapToGroup(QString mapName, int groupNum, Map *newMap, bool 
     loadMapTilesets(newMap);
     setNewMapEvents(newMap);
     setNewMapConnections(newMap);
-    mapCache.insert(mapName, newMap);
 
     return newMap;
 }

--- a/src/project.cpp
+++ b/src/project.cpp
@@ -99,18 +99,20 @@ QString Project::getProjectTitle() {
 }
 
 void Project::clearMapCache() {
-    for (QString mapName : mapCache.keys()) {
-        Map *map = mapCache.take(mapName);
-        if (map) delete map;
+    for (auto *map : mapCache.values()) {
+        if (map)
+            delete map;
     }
+    mapCache.clear();
     emit mapCacheCleared();
 }
 
 void Project::clearTilesetCache() {
-    for (QString tilesetName : tilesetCache.keys()) {
-        Tileset *tileset = tilesetCache.take(tilesetName);
-        if (tileset) delete tileset;
+    for (auto *tileset : tilesetCache.values()) {
+        if (tileset)
+            delete tileset;
     }
+    tilesetCache.clear();
 }
 
 Map* Project::loadMap(QString map_name) {
@@ -1223,12 +1225,8 @@ void Project::writeBlockdata(QString path, const Blockdata &blockdata) {
 }
 
 void Project::saveAllMaps() {
-    QList<QString> keys = mapCache.keys();
-    for (int i = 0; i < keys.length(); i++) {
-        QString key = keys.value(i);
-        Map* map = mapCache.value(key);
+    for (auto *map : mapCache.values())
         saveMap(map);
-    }
 }
 
 void Project::saveMap(Map *map) {
@@ -1866,26 +1864,24 @@ Map* Project::addNewMapToGroup(QString mapName, int groupNum, Map *newMap, bool 
     mapGroups.insert(mapName, groupNum);
     groupedMapNames[groupNum].append(mapName);
 
-    Map *map = new Map;
-    map = newMap;
+    newMap->isPersistedToFile = false;
+    newMap->setName(mapName);
 
-    map->isPersistedToFile = false;
-    map->setName(mapName);
-
-    mapConstantsToMapNames.insert(map->constantName, map->name);
-    mapNamesToMapConstants.insert(map->name, map->constantName);
+    mapConstantsToMapNames.insert(newMap->constantName, newMap->name);
+    mapNamesToMapConstants.insert(newMap->name, newMap->constantName);
     if (!existingLayout) {
-        mapLayouts.insert(map->layoutId, map->layout);
-        mapLayoutsTable.append(map->layoutId);
-        setNewMapBlockdata(map);
-        setNewMapBorder(map);
+        mapLayouts.insert(newMap->layoutId, newMap->layout);
+        mapLayoutsTable.append(newMap->layoutId);
+        setNewMapBlockdata(newMap);
+        setNewMapBorder(newMap);
     }
 
-    loadMapTilesets(map);
-    setNewMapEvents(map);
-    setNewMapConnections(map);
+    loadMapTilesets(newMap);
+    setNewMapEvents(newMap);
+    setNewMapConnections(newMap);
+    mapCache.insert(mapName, newMap);
 
-    return map;
+    return newMap;
 }
 
 QString Project::getNewMapName() {


### PR DESCRIPTION
`Project::addNewMapToGroup()` was leaking 2 `Map *`'s, first by default constructing a `new Map` and then immediately overwriting the pointer with the `Map *newMap` passed as an argument (constructed by `newmapprompt`), and second by not giving ownership of resulting pointer to anything. Initially I solved the second by inserting it into the `mapCache`, but this lead to a crash when loading the resulting map because it never gets properly initialized (the call to `loadMapTilesets()` doesn't actually do anything because the new map has unsaved changes). That should eventually be fixed, but in the meantime this fixes those memory leaks by just deleting the partially initialized `Map` after the relevant data gets saved to files.

Also, I removed an unused `Project::addNewMapToGroup()` overload as it seems like old, leftover code.