### PR TITLE
Add details to script api error messages

### DIFF
--- a/src/scripting.cpp
+++ b/src/scripting.cpp
@@ -61,7 +61,11 @@ void Scripting::invokeCallback(CallbackType type, QJSValueList args) {
 
         QJSValue result = callbackFunction.call(args);
         if (result.isError()) {
-            logError(QString("Module %1 encountered an error when calling '%2'").arg(module.toString()).arg(functionName));
+            QFileInfo file(result.property("fileName").toString());
+            logError(QString("Error in custom script '%1' at line %2: '%3'")
+                     .arg(file.fileName())
+                     .arg(result.property("lineNumber").toString())
+                     .arg(result.toString()));
             continue;
         }
     }
@@ -90,7 +94,11 @@ void Scripting::invokeAction(QString actionName) {
 
         QJSValue result = callbackFunction.call(QJSValueList());
         if (result.isError()) {
-            logError(QString("Module %1 encountered an error when calling '%2'").arg(module.toString()).arg(functionName));
+            QFileInfo file(result.property("fileName").toString());
+            logError(QString("Error in custom script '%1' at line %2: '%3'")
+                     .arg(file.fileName())
+                     .arg(result.property("lineNumber").toString())
+                     .arg(result.toString()));
             continue;
         }
     }


### PR DESCRIPTION
The current message for when an script error is encountered is not very helpful. For example, in the following `myscript.js`:

```c
function helperFunction() {
    badVar = 1;
}

export function mainFunction() {
    helperFunction();
}

export function onProjectOpened(projectPath) {
    map.registerAction("mainFunction", "My Action");
}
```

The current error message would be
`[ERROR] Module TypeError: Type error encountered an error when calling 'mainFunction'`
and the new error message would be
`[ERROR] Error in custom script ‘myscript.js' at line 2: 'ReferenceError: badVar is not defined'`