### PR TITLE
Autosave

### DIFF
--- a/forms/preferenceeditor.ui
+++ b/forms/preferenceeditor.ui
@@ -84,6 +84,23 @@
          </property>
         </widget>
        </item>
+       <item row="1" column="1">
+        <widget class="QCheckBox" name="checkBox_AutoSaveOnMapChange">
+         <property name="layoutDirection">
+          <enum>Qt::LeftToRight</enum>
+         </property>
+         <property name="text">
+          <string/>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="0">
+        <widget class="QLabel" name="label_AutoSaveOnMapChange">
+         <property name="text">
+          <string>Auto-Save when changing maps</string>
+         </property>
+        </widget>
+       </item>
       </layout>
      </widget>
     </item>

--- a/forms/preferenceeditor.ui
+++ b/forms/preferenceeditor.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>600</width>
-    <height>480</height>
+    <height>640</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -36,69 +36,131 @@
       <property name="title">
        <string>Auto-Save</string>
       </property>
-      <layout class="QGridLayout" name="gridLayout_3">
-       <item row="0" column="1">
-        <widget class="QSpinBox" name="spinBox_AutoSaveDelay">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
+      <layout class="QVBoxLayout" name="verticalLayout_2">
+       <item>
+        <widget class="QLabel" name="label_AutoSaveWarning">
+         <property name="text">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;WARNING&lt;/span&gt;: It is not recommended to enable auto-save if you are not using G&lt;span style=&quot; font-weight:600;&quot;&gt;it&lt;/span&gt; to commit changes to your project. Auto-save does &lt;span style=&quot; font-weight:600;&quot;&gt;NOT&lt;/span&gt; create a backup.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
          </property>
-         <property name="buttonSymbols">
-          <enum>QAbstractSpinBox::UpDownArrows</enum>
-         </property>
-         <property name="specialValueText">
-          <string>Off</string>
-         </property>
-         <property name="accelerated">
+         <property name="wordWrap">
           <bool>true</bool>
          </property>
-         <property name="correctionMode">
-          <enum>QAbstractSpinBox::CorrectToNearestValue</enum>
+        </widget>
+       </item>
+       <item>
+        <widget class="QCheckBox" name="checkBox_AutoSaveEnabled">
+         <property name="text">
+          <string>Enable Auto-Save</string>
          </property>
-         <property name="showGroupSeparator" stdset="0">
+        </widget>
+       </item>
+       <item>
+        <widget class="QFrame" name="frame_AutoSaveOptions">
+         <property name="enabled">
           <bool>false</bool>
          </property>
-         <property name="suffix">
-          <string>ms</string>
+         <property name="minimumSize">
+          <size>
+           <width>0</width>
+           <height>0</height>
+          </size>
          </property>
-         <property name="maximum">
-          <number>1200000</number>
+         <property name="frameShape">
+          <enum>QFrame::StyledPanel</enum>
          </property>
-         <property name="singleStep">
-          <number>500</number>
+         <property name="frameShadow">
+          <enum>QFrame::Raised</enum>
          </property>
-         <property name="stepType">
-          <enum>QAbstractSpinBox::DefaultStepType</enum>
-         </property>
-         <property name="value">
-          <number>0</number>
-         </property>
-        </widget>
-       </item>
-       <item row="0" column="0">
-        <widget class="QLabel" name="label_AutoSaveDelay">
-         <property name="text">
-          <string>Auto-Save Delay</string>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="1">
-        <widget class="QCheckBox" name="checkBox_AutoSaveOnMapChange">
-         <property name="layoutDirection">
-          <enum>Qt::LeftToRight</enum>
-         </property>
-         <property name="text">
-          <string/>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="0">
-        <widget class="QLabel" name="label_AutoSaveOnMapChange">
-         <property name="text">
-          <string>Auto-Save when changing maps</string>
-         </property>
+         <layout class="QGridLayout" name="gridLayout_4">
+          <property name="leftMargin">
+           <number>9</number>
+          </property>
+          <property name="topMargin">
+           <number>9</number>
+          </property>
+          <property name="rightMargin">
+           <number>9</number>
+          </property>
+          <property name="bottomMargin">
+           <number>9</number>
+          </property>
+          <item row="1" column="0">
+           <widget class="QLabel" name="label_AutoSaveOnMapChange">
+            <property name="toolTip">
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When enabled, maps will be saved when switching to a different map in the editor.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            </property>
+            <property name="text">
+             <string>Auto-Save when changing maps</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="0">
+           <widget class="QLabel" name="label_AutoSaveDelay">
+            <property name="toolTip">
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Controls the amount of time (in milliseconds) to wait before saving a dirty map.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            </property>
+            <property name="text">
+             <string>Auto-Save Delay</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QSpinBox" name="spinBox_AutoSaveDelay">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="toolTip">
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The amount of time in milliseconds before a dirty map will be saved. Subsequent edits within this time period will reset the timer. Setting to 0ms disables the auto-save timer.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            </property>
+            <property name="buttonSymbols">
+             <enum>QAbstractSpinBox::UpDownArrows</enum>
+            </property>
+            <property name="specialValueText">
+             <string>0ms (Off)</string>
+            </property>
+            <property name="accelerated">
+             <bool>true</bool>
+            </property>
+            <property name="correctionMode">
+             <enum>QAbstractSpinBox::CorrectToNearestValue</enum>
+            </property>
+            <property name="showGroupSeparator" stdset="0">
+             <bool>false</bool>
+            </property>
+            <property name="suffix">
+             <string>ms</string>
+            </property>
+            <property name="maximum">
+             <number>1200000</number>
+            </property>
+            <property name="singleStep">
+             <number>500</number>
+            </property>
+            <property name="stepType">
+             <enum>QAbstractSpinBox::DefaultStepType</enum>
+            </property>
+            <property name="value">
+             <number>0</number>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QCheckBox" name="checkBox_AutoSaveOnMapChange">
+            <property name="toolTip">
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When enabled, maps will be saved when switching to a different map in the editor.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            </property>
+            <property name="layoutDirection">
+             <enum>Qt::LeftToRight</enum>
+            </property>
+            <property name="text">
+             <string/>
+            </property>
+           </widget>
+          </item>
+         </layout>
         </widget>
        </item>
       </layout>
@@ -138,8 +200,8 @@
            <rect>
             <x>0</x>
             <y>0</y>
-            <width>570</width>
-            <height>307</height>
+            <width>582</width>
+            <height>338</height>
            </rect>
           </property>
           <layout class="QGridLayout" name="gridLayout_2">
@@ -259,5 +321,22 @@
   </widget>
  </widget>
  <resources/>
- <connections/>
+ <connections>
+  <connection>
+   <sender>checkBox_AutoSaveEnabled</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>frame_AutoSaveOptions</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>299</x>
+     <y>123</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>299</x>
+     <y>178</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
 </ui>

--- a/forms/preferenceeditor.ui
+++ b/forms/preferenceeditor.ui
@@ -32,6 +32,62 @@
      </widget>
     </item>
     <item>
+     <widget class="QGroupBox" name="groupBox_AutoSave">
+      <property name="title">
+       <string>Auto-Save</string>
+      </property>
+      <layout class="QGridLayout" name="gridLayout_3">
+       <item row="0" column="1">
+        <widget class="QSpinBox" name="spinBox_AutoSaveDelay">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="buttonSymbols">
+          <enum>QAbstractSpinBox::UpDownArrows</enum>
+         </property>
+         <property name="specialValueText">
+          <string>Off</string>
+         </property>
+         <property name="accelerated">
+          <bool>true</bool>
+         </property>
+         <property name="correctionMode">
+          <enum>QAbstractSpinBox::CorrectToNearestValue</enum>
+         </property>
+         <property name="showGroupSeparator" stdset="0">
+          <bool>false</bool>
+         </property>
+         <property name="suffix">
+          <string>ms</string>
+         </property>
+         <property name="maximum">
+          <number>1200000</number>
+         </property>
+         <property name="singleStep">
+          <number>500</number>
+         </property>
+         <property name="stepType">
+          <enum>QAbstractSpinBox::DefaultStepType</enum>
+         </property>
+         <property name="value">
+          <number>0</number>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="0">
+        <widget class="QLabel" name="label_AutoSaveDelay">
+         <property name="text">
+          <string>Auto-Save Delay</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+    </item>
+    <item>
      <widget class="QGroupBox" name="groupBox_TextEditor">
       <property name="title">
        <string>Preferred Text Editor</string>
@@ -65,8 +121,8 @@
            <rect>
             <x>0</x>
             <y>0</y>
-            <width>582</width>
-            <height>372</height>
+            <width>570</width>
+            <height>307</height>
            </rect>
           </property>
           <layout class="QGridLayout" name="gridLayout_2">

--- a/include/config.h
+++ b/include/config.h
@@ -68,6 +68,7 @@ public:
     void setTextEditorOpenFolder(const QString &command);
     void setTextEditorGotoLine(const QString &command);
     void setAutoSaveDelay(int delay);
+    void setAutoSaveOnMapChange(bool enabled);
     QString getRecentProject();
     MapSortOrder getMapSortOrder();
     bool getPrettyCursors();
@@ -85,6 +86,7 @@ public:
     QString getTextEditorOpenFolder();
     QString getTextEditorGotoLine();
     int getAutoSaveDelay();
+    bool getAutoSaveOnMapChange();
 protected:
     virtual QString getConfigFilepath() override;
     virtual void parseConfigKeyValue(QString key, QString value) override;
@@ -118,6 +120,7 @@ private:
     QString textEditorOpenFolder;
     QString textEditorGotoLine;
     int autoSaveDelay;
+    bool autoSaveOnMapChange;
 };
 
 extern PorymapConfig porymapConfig;

--- a/include/config.h
+++ b/include/config.h
@@ -49,6 +49,7 @@ public:
         this->theme = "default";
         this->textEditorOpenFolder = "";
         this->textEditorGotoLine = "";
+        this->autoSaveDelay = 0;
     }
     void setRecentProject(QString project);
     void setMapSortOrder(MapSortOrder order);
@@ -66,6 +67,7 @@ public:
     void setTheme(QString theme);
     void setTextEditorOpenFolder(const QString &command);
     void setTextEditorGotoLine(const QString &command);
+    void setAutoSaveDelay(int delay);
     QString getRecentProject();
     MapSortOrder getMapSortOrder();
     bool getPrettyCursors();
@@ -82,6 +84,7 @@ public:
     QString getTheme();
     QString getTextEditorOpenFolder();
     QString getTextEditorGotoLine();
+    int getAutoSaveDelay();
 protected:
     virtual QString getConfigFilepath() override;
     virtual void parseConfigKeyValue(QString key, QString value) override;
@@ -114,6 +117,7 @@ private:
     QString theme;
     QString textEditorOpenFolder;
     QString textEditorGotoLine;
+    int autoSaveDelay;
 };
 
 extern PorymapConfig porymapConfig;

--- a/include/config.h
+++ b/include/config.h
@@ -49,7 +49,9 @@ public:
         this->theme = "default";
         this->textEditorOpenFolder = "";
         this->textEditorGotoLine = "";
+        this->autoSaveEnabled = false;
         this->autoSaveDelay = 0;
+        this->autoSaveOnMapChange = false;
     }
     void setRecentProject(QString project);
     void setMapSortOrder(MapSortOrder order);
@@ -67,6 +69,7 @@ public:
     void setTheme(QString theme);
     void setTextEditorOpenFolder(const QString &command);
     void setTextEditorGotoLine(const QString &command);
+    void setAutoSaveEnabled(bool enabled);
     void setAutoSaveDelay(int delay);
     void setAutoSaveOnMapChange(bool enabled);
     QString getRecentProject();
@@ -85,6 +88,7 @@ public:
     QString getTheme();
     QString getTextEditorOpenFolder();
     QString getTextEditorGotoLine();
+    bool getAutoSaveEnabled();
     int getAutoSaveDelay();
     bool getAutoSaveOnMapChange();
 protected:
@@ -119,6 +123,7 @@ private:
     QString theme;
     QString textEditorOpenFolder;
     QString textEditorGotoLine;
+    bool autoSaveEnabled;
     int autoSaveDelay;
     bool autoSaveOnMapChange;
 };

--- a/include/editor.h
+++ b/include/editor.h
@@ -157,6 +157,9 @@ public slots:
     void openProjectInTextEditor() const;
     void maskNonVisibleConnectionTiles();
 
+protected:
+    void timerEvent(QTimerEvent *event) override;
+
 private:
     void setConnectionItemsVisible(bool);
     void setBorderItemsVisible(bool, qreal = 1);
@@ -179,6 +182,8 @@ private:
     bool startDetachedProcess(const QString &command,
                               const QString &workingDirectory = QString(),
                               qint64 *pid = nullptr) const;
+
+    int autoSaveTimerId = 0;
 
 private slots:
     void onMapStartPaint(QGraphicsSceneMouseEvent *event, MapPixmapItem *item);

--- a/include/editor.h
+++ b/include/editor.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <qvector.h>
 #ifndef EDITOR_H
 #define EDITOR_H
 
@@ -47,7 +48,8 @@ public:
     Map *map = nullptr;
     Settings *settings;
     void saveProject();
-    void save();
+    void save(Map *map_);
+    void save() { save(map); }
     void closeProject();
     bool setMap(QString map_name);
     void saveUiFields();
@@ -157,9 +159,6 @@ public slots:
     void openProjectInTextEditor() const;
     void maskNonVisibleConnectionTiles();
 
-protected:
-    void timerEvent(QTimerEvent *event) override;
-
 private:
     void setConnectionItemsVisible(bool);
     void setBorderItemsVisible(bool, qreal = 1);
@@ -183,7 +182,7 @@ private:
                               const QString &workingDirectory = QString(),
                               qint64 *pid = nullptr) const;
 
-    int autoSaveTimerId = 0;
+    QHash<QUndoStack *, QPointer<QTimer>> autoSaveTimers;
 
 private slots:
     void onMapStartPaint(QGraphicsSceneMouseEvent *event, MapPixmapItem *item);
@@ -209,6 +208,7 @@ private slots:
     void onWheelZoom(int);
 
 signals:
+    void saved(Map *map = nullptr);
     void objectsChanged();
     void selectedObjectsChanged();
     void loadMapRequested(QString, QString);

--- a/include/ui/preferenceeditor.h
+++ b/include/ui/preferenceeditor.h
@@ -1,5 +1,5 @@
-#ifndef PREFERENCES_H
-#define PREFERENCES_H
+#ifndef PREFERENCEEDITOR_H
+#define PREFERENCEEDITOR_H
 
 #include <QMainWindow>
 
@@ -34,4 +34,4 @@ private slots:
     void dialogButtonClicked(QAbstractButton *button);
 };
 
-#endif // PREFERENCES_H
+#endif // PREFERENCEEDITOR_H

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -199,6 +199,12 @@ void PorymapConfig::parseConfigKeyValue(QString key, QString value) {
             logWarn(QString("Invalid config value for auto_save_delay: '%1'. Must be a non-negative integer.").arg(value));
             this->autoSaveDelay = 0;
         }
+    } else if (key == "auto_save_on_map_change") {
+        bool ok;
+        this->autoSaveOnMapChange = value.toInt(&ok);
+        if (!ok) {
+            logWarn(QString("Invalid config value for auto_save_on_map_change: '%1'. Must be 0 or 1.").arg(value));
+        }
     } else {
         logWarn(QString("Invalid config key found in config file %1: '%2'").arg(this->getConfigFilepath()).arg(key));
     }
@@ -230,6 +236,7 @@ QMap<QString, QString> PorymapConfig::getKeyValueMap() {
     map.insert("text_editor_open_directory", this->textEditorOpenFolder);
     map.insert("text_editor_goto_line", this->textEditorGotoLine);
     map.insert("auto_save_delay", QString("%1").arg(this->autoSaveDelay));
+    map.insert("auto_save_on_map_change", this->autoSaveOnMapChange ? "1" : "0");
     return map;
 }
 
@@ -340,6 +347,11 @@ void PorymapConfig::setAutoSaveDelay(int delay) {
     this->save();
 }
 
+void PorymapConfig::setAutoSaveOnMapChange(bool enabled) {
+    this->autoSaveOnMapChange = enabled;
+    this->save();
+}
+
 QString PorymapConfig::getRecentProject() {
     return this->recentProject;
 }
@@ -428,6 +440,10 @@ QString PorymapConfig::getTextEditorGotoLine() {
 
 int PorymapConfig::getAutoSaveDelay() {
     return this->autoSaveDelay;
+}
+
+bool PorymapConfig::getAutoSaveOnMapChange() {
+    return this->autoSaveOnMapChange;
 }
 
 const QMap<BaseGameVersion, QString> baseGameVersionMap = {

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -192,6 +192,13 @@ void PorymapConfig::parseConfigKeyValue(QString key, QString value) {
         this->textEditorOpenFolder = value;
     } else if (key == "text_editor_goto_line") {
         this->textEditorGotoLine = value;
+    } else if (key == "auto_save_delay") {
+        bool ok;
+        this->autoSaveDelay = value.toInt(&ok);
+        if (!ok || this->autoSaveDelay < 0) {
+            logWarn(QString("Invalid config value for auto_save_delay: '%1'. Must be a non-negative integer.").arg(value));
+            this->autoSaveDelay = 0;
+        }
     } else {
         logWarn(QString("Invalid config key found in config file %1: '%2'").arg(this->getConfigFilepath()).arg(key));
     }
@@ -222,6 +229,7 @@ QMap<QString, QString> PorymapConfig::getKeyValueMap() {
     map.insert("theme", this->theme);
     map.insert("text_editor_open_directory", this->textEditorOpenFolder);
     map.insert("text_editor_goto_line", this->textEditorGotoLine);
+    map.insert("auto_save_delay", QString("%1").arg(this->autoSaveDelay));
     return map;
 }
 
@@ -327,6 +335,11 @@ void PorymapConfig::setTextEditorGotoLine(const QString &command) {
     this->save();
 }
 
+void PorymapConfig::setAutoSaveDelay(int delay) {
+    this->autoSaveDelay = delay;
+    this->save();
+}
+
 QString PorymapConfig::getRecentProject() {
     return this->recentProject;
 }
@@ -411,6 +424,10 @@ QString PorymapConfig::getTextEditorOpenFolder() {
 
 QString PorymapConfig::getTextEditorGotoLine() {
     return this->textEditorGotoLine;
+}
+
+int PorymapConfig::getAutoSaveDelay() {
+    return this->autoSaveDelay;
 }
 
 const QMap<BaseGameVersion, QString> baseGameVersionMap = {

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -192,6 +192,12 @@ void PorymapConfig::parseConfigKeyValue(QString key, QString value) {
         this->textEditorOpenFolder = value;
     } else if (key == "text_editor_goto_line") {
         this->textEditorGotoLine = value;
+    } else if (key == "auto_save_enabled") {
+        bool ok;
+        this->autoSaveEnabled = value.toInt(&ok);
+        if (!ok) {
+            logWarn(QString("Invalid config value for auto_save_enabled: '%1'. Must be 0 or 1.").arg(value));
+        }
     } else if (key == "auto_save_delay") {
         bool ok;
         this->autoSaveDelay = value.toInt(&ok);
@@ -235,6 +241,7 @@ QMap<QString, QString> PorymapConfig::getKeyValueMap() {
     map.insert("theme", this->theme);
     map.insert("text_editor_open_directory", this->textEditorOpenFolder);
     map.insert("text_editor_goto_line", this->textEditorGotoLine);
+    map.insert("auto_save_enabled", this->autoSaveEnabled ? "1" : "0");
     map.insert("auto_save_delay", QString("%1").arg(this->autoSaveDelay));
     map.insert("auto_save_on_map_change", this->autoSaveOnMapChange ? "1" : "0");
     return map;
@@ -342,6 +349,10 @@ void PorymapConfig::setTextEditorGotoLine(const QString &command) {
     this->save();
 }
 
+void PorymapConfig::setAutoSaveEnabled(bool enabled) {
+    this->autoSaveEnabled = enabled;
+}
+
 void PorymapConfig::setAutoSaveDelay(int delay) {
     this->autoSaveDelay = delay;
     this->save();
@@ -436,6 +447,10 @@ QString PorymapConfig::getTextEditorOpenFolder() {
 
 QString PorymapConfig::getTextEditorGotoLine() {
     return this->textEditorGotoLine;
+}
+
+bool PorymapConfig::getAutoSaveEnabled() {
+    return this->autoSaveEnabled;
 }
 
 int PorymapConfig::getAutoSaveDelay() {

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -38,19 +38,15 @@ Editor::Editor(Ui::MainWindow* ui)
             selectNewEvents = false;
         }
 
-        // Set auto-save timer if enabled.
-        if (!editGroup.isClean()) {
-            if (autoSaveTimerId) {
-                killTimer(autoSaveTimerId);
-                autoSaveTimerId = 0;
-            }
-
-            if (porymapConfig.getAutoSaveDelay() > 0) {
-                autoSaveTimerId = startTimer(porymapConfig.getAutoSaveDelay());
-            }
-        } else if (autoSaveTimerId) {
+        // Reset the auto-save timer if it is active.
+        if (autoSaveTimerId) {
             killTimer(autoSaveTimerId);
             autoSaveTimerId = 0;
+        }
+
+        // Set the auto-save timer if it is enabled.
+        if (!editGroup.isClean() && porymapConfig.getAutoSaveDelay() > 0) {
+            autoSaveTimerId = startTimer(porymapConfig.getAutoSaveDelay());
         }
     });
 }
@@ -1062,6 +1058,10 @@ bool Editor::setMap(QString map_name) {
     }
 
     if (autoSaveTimerId) {
+        killTimer(autoSaveTimerId);
+        autoSaveTimerId = 0;
+        saveProject();
+    } else if (porymapConfig.getAutoSaveOnMapChange()) {
         save();
     }
 

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -44,7 +44,7 @@ Editor::Editor(Ui::MainWindow* ui)
             delete timer;
 
         // Start the auto-save timer if it is enabled.
-        if (!editGroup.isClean() && porymapConfig.getAutoSaveDelay() > 0) {
+        if (!editGroup.isClean() && porymapConfig.getAutoSaveEnabled() && porymapConfig.getAutoSaveDelay() > 0) {
             timer = new QTimer(editGroup.activeStack());
             timer->setSingleShot(true);
             autoSaveTimers.insert(editGroup.activeStack(), timer);
@@ -1059,7 +1059,7 @@ bool Editor::setMap(QString map_name) {
         return false;
     }
 
-    if (porymapConfig.getAutoSaveOnMapChange()) {
+    if (porymapConfig.getAutoSaveEnabled() && porymapConfig.getAutoSaveOnMapChange()) {
         save();
     }
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -244,6 +244,7 @@ void MainWindow::initExtraSignals() {
 
 void MainWindow::initEditor() {
     this->editor = new Editor(ui);
+    connect(this->editor, &Editor::saved, this, &MainWindow::updateMapList);
     connect(this->editor, &Editor::objectsChanged, this, &MainWindow::updateObjects);
     connect(this->editor, &Editor::selectedObjectsChanged, this, &MainWindow::updateSelectedObjects);
     connect(this->editor, &Editor::loadMapRequested, this, &MainWindow::onLoadMapRequested);
@@ -1380,7 +1381,6 @@ void MainWindow::updateMapList() {
 void MainWindow::on_action_Save_Project_triggered()
 {
     editor->saveProject();
-    updateMapList();
 }
 
 void MainWindow::duplicate() {
@@ -1598,7 +1598,6 @@ void MainWindow::paste() {
 
 void MainWindow::on_action_Save_triggered() {
     editor->save();
-    updateMapList();
 }
 
 void MainWindow::on_tabWidget_2_currentChanged(int index)

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -3064,17 +3064,21 @@ void MainWindow::closeSupplementaryWindows() {
 void MainWindow::closeEvent(QCloseEvent *event) {
     if (isProjectOpen()) {
         if (projectHasUnsavedChanges || (editor->map && editor->map->hasUnsavedChanges())) {
-            QMessageBox::StandardButton result = QMessageBox::question(
-                this, "porymap", "The project has been modified, save changes?",
-                QMessageBox::No | QMessageBox::Yes | QMessageBox::Cancel, QMessageBox::Yes);
-
-            if (result == QMessageBox::Yes) {
+            if (porymapConfig.getAutoSaveEnabled()) {
                 editor->saveProject();
-            } else if (result == QMessageBox::No) {
-                logWarn("Closing porymap with unsaved changes.");
-            } else if (result == QMessageBox::Cancel) {
-                event->ignore();
-                return;
+            } else {
+                QMessageBox::StandardButton result = QMessageBox::question(
+                    this, "porymap", "The project has been modified, save changes?",
+                    QMessageBox::No | QMessageBox::Yes | QMessageBox::Cancel, QMessageBox::Yes);
+
+                if (result == QMessageBox::Yes) {
+                    editor->saveProject();
+                } else if (result == QMessageBox::No) {
+                    logWarn("Closing porymap with unsaved changes.");
+                } else if (result == QMessageBox::Cancel) {
+                    event->ignore();
+                    return;
+                }
             }
         }
         projectConfig.save();

--- a/src/ui/preferenceeditor.cpp
+++ b/src/ui/preferenceeditor.cpp
@@ -41,6 +41,7 @@ void PreferenceEditor::populateFields() {
     themeSelector->addItems(themes);
     themeSelector->setCurrentText(porymapConfig.getTheme());
 
+    ui->checkBox_AutoSaveEnabled->setChecked(porymapConfig.getAutoSaveEnabled());
     ui->spinBox_AutoSaveDelay->setValue(porymapConfig.getAutoSaveDelay());
     ui->checkBox_AutoSaveOnMapChange->setChecked(porymapConfig.getAutoSaveOnMapChange());
 
@@ -55,6 +56,7 @@ void PreferenceEditor::saveFields() {
         emit themeChanged(theme);
     }
 
+    porymapConfig.setAutoSaveEnabled(ui->checkBox_AutoSaveEnabled->isChecked());
     porymapConfig.setAutoSaveDelay(ui->spinBox_AutoSaveDelay->value());
     porymapConfig.setAutoSaveOnMapChange(ui->checkBox_AutoSaveOnMapChange->isChecked());
 

--- a/src/ui/preferenceeditor.cpp
+++ b/src/ui/preferenceeditor.cpp
@@ -42,9 +42,9 @@ void PreferenceEditor::populateFields() {
     themeSelector->setCurrentText(porymapConfig.getTheme());
 
     ui->spinBox_AutoSaveDelay->setValue(porymapConfig.getAutoSaveDelay());
+    ui->checkBox_AutoSaveOnMapChange->setChecked(porymapConfig.getAutoSaveOnMapChange());
 
     ui->lineEdit_TextEditorOpenFolder->setText(porymapConfig.getTextEditorOpenFolder());
-
     ui->lineEdit_TextEditorGotoLine->setText(porymapConfig.getTextEditorGotoLine());
 }
 
@@ -56,16 +56,16 @@ void PreferenceEditor::saveFields() {
     }
 
     porymapConfig.setAutoSaveDelay(ui->spinBox_AutoSaveDelay->value());
+    porymapConfig.setAutoSaveOnMapChange(ui->checkBox_AutoSaveOnMapChange->isChecked());
 
     porymapConfig.setTextEditorOpenFolder(ui->lineEdit_TextEditorOpenFolder->text());
-
     porymapConfig.setTextEditorGotoLine(ui->lineEdit_TextEditorGotoLine->text());
 
     emit preferencesSaved();
 }
 
 void PreferenceEditor::dialogButtonClicked(QAbstractButton *button) {
-    auto buttonRole = ui->buttonBox->buttonRole(button);
+    const auto buttonRole = ui->buttonBox->buttonRole(button);
     if (buttonRole == QDialogButtonBox::AcceptRole) {
         saveFields();
         close();

--- a/src/ui/preferenceeditor.cpp
+++ b/src/ui/preferenceeditor.cpp
@@ -18,6 +18,7 @@ PreferenceEditor::PreferenceEditor(QWidget *parent) :
     auto *formLayout = new QFormLayout(ui->groupBox_Themes);
     themeSelector = new NoScrollComboBox(ui->groupBox_Themes);
     formLayout->addRow("Themes", themeSelector);
+    ui->spinBox_AutoSaveDelay->setRange(0, INT_MAX);
     setAttribute(Qt::WA_DeleteOnClose);
     connect(ui->buttonBox, &QDialogButtonBox::clicked,
             this, &PreferenceEditor::dialogButtonClicked);
@@ -30,7 +31,7 @@ PreferenceEditor::~PreferenceEditor()
 }
 
 void PreferenceEditor::populateFields() {
-    QStringList themes = { "default" };
+    QStringList themes("default");
     QRegularExpression re(":/themes/([A-z0-9_-]+).qss");
     QDirIterator it(":/themes", QDirIterator::Subdirectories);
     while (it.hasNext()) {
@@ -39,6 +40,8 @@ void PreferenceEditor::populateFields() {
     }
     themeSelector->addItems(themes);
     themeSelector->setCurrentText(porymapConfig.getTheme());
+
+    ui->spinBox_AutoSaveDelay->setValue(porymapConfig.getAutoSaveDelay());
 
     ui->lineEdit_TextEditorOpenFolder->setText(porymapConfig.getTextEditorOpenFolder());
 
@@ -51,6 +54,8 @@ void PreferenceEditor::saveFields() {
         porymapConfig.setTheme(theme);
         emit themeChanged(theme);
     }
+
+    porymapConfig.setAutoSaveDelay(ui->spinBox_AutoSaveDelay->value());
 
     porymapConfig.setTextEditorOpenFolder(ui->lineEdit_TextEditorOpenFolder->text());
 


### PR DESCRIPTION
Adds an auto-save feature which is configured in the `PreferenceEditor`. Auto-save can be set up to save a map after a set delay, when changing maps, or both. Auto-save doesn't create any temporary files, it saves directly to the project files. Due to this, there is a prominent warning in the preferences not to enable auto-save if the user is not using git.

![Screenshot_2021-05-25_11-02-51](https://user-images.githubusercontent.com/58710639/119521029-c710e400-bd48-11eb-92cf-acc82a7d3097.png)