### PR TITLE
Add Options to Count Metatiles to Tileset Editor

### DIFF
--- a/forms/tileseteditor.ui
+++ b/forms/tileseteditor.ui
@@ -527,6 +527,8 @@
     <addaction name="actionImport_Primary_Metatiles"/>
     <addaction name="actionImport_Secondary_Metatiles"/>
     <addaction name="actionChange_Metatiles_Count"/>
+    <addaction name="actionShow_Unused"/>
+    <addaction name="actionShow_Counts"/>
     <addaction name="actionChange_Palettes"/>
     <addaction name="separator"/>
     <addaction name="actionExport_Primary_Tiles_Image"/>
@@ -570,6 +572,22 @@
   <action name="actionChange_Palettes">
    <property name="text">
     <string>Palette Editor</string>
+   </property>
+  </action>
+  <action name="actionShow_Unused">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Display Unused Metatiles</string>
+   </property>
+  </action>
+  <action name="actionShow_Counts">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Display Metatile Usage Counts</string>
    </property>
   </action>
   <action name="actionUndo">

--- a/forms/tileseteditor.ui
+++ b/forms/tileseteditor.ui
@@ -527,9 +527,11 @@
     <addaction name="actionImport_Primary_Metatiles"/>
     <addaction name="actionImport_Secondary_Metatiles"/>
     <addaction name="actionChange_Metatiles_Count"/>
+    <addaction name="actionChange_Palettes"/>
+    <addaction name="separator"/>
     <addaction name="actionShow_Unused"/>
     <addaction name="actionShow_Counts"/>
-    <addaction name="actionChange_Palettes"/>
+    <addaction name="actionShow_UnusedTiles"/>
     <addaction name="separator"/>
     <addaction name="actionExport_Primary_Tiles_Image"/>
     <addaction name="actionExport_Secondary_Tiles_Image"/>
@@ -580,6 +582,14 @@
    </property>
    <property name="text">
     <string>Display Unused Metatiles</string>
+   </property>
+  </action>
+  <action name="actionShow_UnusedTiles">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Display Unused Tiles</string>
    </property>
   </action>
   <action name="actionShow_Counts">

--- a/include/core/map.h
+++ b/include/core/map.h
@@ -35,7 +35,6 @@ public:
 public:
     QString name;
     QString constantName;
-    QString group_num;
     QString song;
     QString layoutId;
     QString location;

--- a/include/core/maplayout.h
+++ b/include/core/maplayout.h
@@ -35,6 +35,11 @@ public:
         Blockdata blocks;
         QSize dimensions;
     } lastCommitMapBlocks; // to track map changes
+
+    int getWidth();
+    int getHeight();
+    int getBorderWidth();
+    int getBorderHeight();
 };
 
 #endif // MAPLAYOUT_H

--- a/include/project.h
+++ b/include/project.h
@@ -95,7 +95,8 @@ public:
     QMap<QString, QStringList> tilesetLabels;
 
     Blockdata readBlockdata(QString);
-    bool loadBlockdata(Map*);
+    bool loadBlockdata(MapLayout*);
+    bool loadLayoutBorder(MapLayout*);
 
     void saveTextFile(QString path, QString text);
     void appendTextFile(QString path, QString text);
@@ -122,8 +123,9 @@ public:
     QMap<QString, bool> getTopLevelMapFields();
     bool loadMapData(Map*);
     bool readMapLayouts();
+    bool loadLayout(MapLayout *);
     bool loadMapLayout(Map*);
-    bool loadMapTilesets(Map*);
+    bool loadLayoutTilesets(MapLayout*);
     void loadTilesetAssets(Tileset*);
     void loadTilesetTiles(Tileset*, QImage);
     void loadTilesetMetatiles(Tileset*);
@@ -181,8 +183,6 @@ public:
     QString getMapScriptsFilePath(const QString &mapName) const;
     QStringList getEventScriptsFilePaths() const;
     QCompleter *getEventScriptLabelCompleter(QStringList additionalScriptLabels);
-
-    bool loadMapBorder(Map *map);
 
     void saveMapHealEvents(Map *map);
 

--- a/include/ui/tileseteditor.h
+++ b/include/ui/tileseteditor.h
@@ -77,6 +77,7 @@ private slots:
 
     void on_actionShow_Unused_toggled(bool checked);
     void on_actionShow_Counts_toggled(bool checked);
+    void on_actionShow_UnusedTiles_toggled(bool checked);
 
     void on_actionUndo_triggered();
 
@@ -123,6 +124,7 @@ private:
     void saveMetatileLabel();
     void closeEvent(QCloseEvent*);
     void countMetatileUsage();
+    void countTileUsage();
 
     Ui::TilesetEditor *ui;
     History<MetatileHistoryItem*> metatileHistory;

--- a/include/ui/tileseteditor.h
+++ b/include/ui/tileseteditor.h
@@ -75,6 +75,9 @@ private slots:
 
     void on_actionChange_Palettes_triggered();
 
+    void on_actionShow_Unused_toggled(bool checked);
+    void on_actionShow_Counts_toggled(bool checked);
+
     void on_actionUndo_triggered();
 
     void on_actionRedo_triggered();
@@ -119,6 +122,7 @@ private:
     void refresh();
     void saveMetatileLabel();
     void closeEvent(QCloseEvent*);
+    void countMetatileUsage();
 
     Ui::TilesetEditor *ui;
     History<MetatileHistoryItem*> metatileHistory;

--- a/include/ui/tileseteditormetatileselector.h
+++ b/include/ui/tileseteditormetatileselector.h
@@ -8,20 +8,19 @@
 class TilesetEditorMetatileSelector: public SelectablePixmapItem {
     Q_OBJECT
 public:
-    TilesetEditorMetatileSelector(Tileset *primaryTileset, Tileset *secondaryTileset, Map *map): SelectablePixmapItem(32, 32, 1, 1) {
-        this->primaryTileset = primaryTileset;
-        this->secondaryTileset = secondaryTileset;
-        this->numMetatilesWide = 8;
-        this->map = map;
-        setAcceptHoverEvents(true);
-    }
+    TilesetEditorMetatileSelector(Tileset *primaryTileset, Tileset *secondaryTileset, Map *map);
     Map *map = nullptr;
     void draw();
     bool select(uint16_t metatileId);
-    void setTilesets(Tileset*, Tileset*);
+    void setTilesets(Tileset*, Tileset*, bool draw = true);
     uint16_t getSelectedMetatile();
     void updateSelectedMetatile();
     QPoint getMetatileIdCoordsOnWidget(uint16_t metatileId);
+
+    // 
+    QVector<uint16_t> usedMetatiles;
+    bool selectorShowUnused = false;
+    bool selectorShowCounts = false;
 
 protected:
     void mousePressEvent(QGraphicsSceneMouseEvent*);
@@ -38,6 +37,10 @@ private:
     uint16_t getMetatileId(int x, int y);
     QPoint getMetatileIdCoords(uint16_t);
     bool shouldAcceptEvent(QGraphicsSceneMouseEvent*);
+
+    void drawFilters();
+    void drawUnused();
+    void drawCounts();
 
 signals:
     void hoveredMetatileChanged(uint16_t);

--- a/include/ui/tileseteditormetatileselector.h
+++ b/include/ui/tileseteditormetatileselector.h
@@ -17,7 +17,6 @@ public:
     void updateSelectedMetatile();
     QPoint getMetatileIdCoordsOnWidget(uint16_t metatileId);
 
-    // 
     QVector<uint16_t> usedMetatiles;
     bool selectorShowUnused = false;
     bool selectorShowCounts = false;

--- a/include/ui/tileseteditortileselector.h
+++ b/include/ui/tileseteditortileselector.h
@@ -31,6 +31,9 @@ public:
     QImage buildPrimaryTilesIndexedImage();
     QImage buildSecondaryTilesIndexedImage();
 
+    QVector<uint16_t> usedTiles;
+    bool showUnused = false;
+
 protected:
     void mousePressEvent(QGraphicsSceneMouseEvent*);
     void mouseMoveEvent(QGraphicsSceneMouseEvent*);
@@ -58,6 +61,8 @@ private:
     QPoint getTileCoords(uint16_t);
     QList<QRgb> getCurPaletteTable();
     QList<Tile> buildSelectedTiles(int, int, QList<Tile>);
+
+    void drawUnused();
 
 signals:
     void hoveredTileChanged(uint16_t);

--- a/src/core/map.cpp
+++ b/src/core/map.cpp
@@ -63,19 +63,19 @@ QString Map::bgEventsLabelFromName(QString mapName)
 }
 
 int Map::getWidth() {
-    return layout->width.toInt(nullptr, 0);
+    return layout->getWidth();
 }
 
 int Map::getHeight() {
-    return layout->height.toInt(nullptr, 0);
+    return layout->getHeight();
 }
 
 int Map::getBorderWidth() {
-    return layout->border_width.toInt(nullptr, 0);
+    return layout->getBorderWidth();
 }
 
 int Map::getBorderHeight() {
-    return layout->border_height.toInt(nullptr, 0);
+    return layout->getBorderHeight();
 }
 
 bool Map::mapBlockChanged(int i, const Blockdata &cache) {

--- a/src/core/maplayout.cpp
+++ b/src/core/maplayout.cpp
@@ -14,3 +14,19 @@ QString MapLayout::layoutConstantFromName(QString mapName) {
 
     return constantName;
 }
+
+int MapLayout::getWidth() {
+    return width.toInt(nullptr, 0);
+}
+
+int MapLayout::getHeight() {
+    return height.toInt(nullptr, 0);
+}
+
+int MapLayout::getBorderWidth() {
+    return border_width.toInt(nullptr, 0);
+}
+
+int MapLayout::getBorderHeight() {
+    return border_height.toInt(nullptr, 0);
+}

--- a/src/project.cpp
+++ b/src/project.cpp
@@ -1089,11 +1089,6 @@ void Project::saveTilesetPalettes(Tileset *tileset) {
 }
 
 bool Project::loadLayoutTilesets(MapLayout *layout) {
-    // TODO: investigate where to put this now
-    // if (map->hasUnsavedChanges()) {
-    //     return true;
-    // }
-
     layout->tileset_primary = getTileset(layout->tileset_primary_label);
     if (!layout->tileset_primary) {
         QString defaultTileset = tilesetLabels["primary"].value(0, "gTileset_General");

--- a/src/project.cpp
+++ b/src/project.cpp
@@ -1145,10 +1145,6 @@ Tileset* Project::loadTileset(QString label, Tileset *tileset) {
 }
 
 bool Project::loadBlockdata(MapLayout *layout) {
-    // if (map->hasUnsavedChanges()) {
-    //     return true;
-    // }
-
     QString path = QString("%1/%2").arg(root).arg(layout->blockdata_path);
     layout->blockdata = readBlockdata(path);
     layout->lastCommitMapBlocks.blocks = layout->blockdata;
@@ -1175,10 +1171,6 @@ void Project::setNewMapBlockdata(Map *map) {
 }
 
 bool Project::loadLayoutBorder(MapLayout *layout) {
-    // if (map->hasUnsavedChanges()) {
-    //     return true;
-    // }
-
     QString path = QString("%1/%2").arg(root).arg(layout->border_path);
     layout->border = readBlockdata(path);
     int borderLength = layout->getBorderWidth() * layout->getBorderHeight();
@@ -1860,7 +1852,6 @@ Map* Project::addNewMapToGroup(QString mapName, int groupNum, Map *newMap, bool 
         setNewMapBorder(newMap);
     }
 
-    //loadMapTilesets(newMap);
     loadLayoutTilesets(newMap->layout);
     setNewMapEvents(newMap);
     setNewMapConnections(newMap);

--- a/src/ui/newmappopup.cpp
+++ b/src/ui/newmappopup.cpp
@@ -260,7 +260,6 @@ void NewMapPopup::on_pushButton_NewMap_Accept_clicked() {
     if (this->existingLayout) {
         project->loadMapLayout(newMap);
     }
-    newMap->group_num = QString::number(group);
     map = newMap;
     emit applied();
     this->close();

--- a/src/ui/tileseteditormetatileselector.cpp
+++ b/src/ui/tileseteditormetatileselector.cpp
@@ -3,6 +3,15 @@
 #include "project.h"
 #include <QPainter>
 
+TilesetEditorMetatileSelector::TilesetEditorMetatileSelector(Tileset *primaryTileset, Tileset *secondaryTileset, Map *map)
+  : SelectablePixmapItem(32, 32, 1, 1) {
+    this->setTilesets(primaryTileset, secondaryTileset, false);
+    this->numMetatilesWide = 8;
+    this->map = map;
+    setAcceptHoverEvents(true);
+    this->usedMetatiles.resize(Project::getNumMetatilesTotal());
+}
+
 void TilesetEditorMetatileSelector::draw() {
     if (!this->primaryTileset || !this->secondaryTileset) {
         this->setPixmap(QPixmap());
@@ -39,6 +48,8 @@ void TilesetEditorMetatileSelector::draw() {
     painter.end();
     this->setPixmap(QPixmap::fromImage(image));
     this->drawSelection();
+
+    drawFilters();
 }
 
 bool TilesetEditorMetatileSelector::select(uint16_t metatileId) {
@@ -50,10 +61,11 @@ bool TilesetEditorMetatileSelector::select(uint16_t metatileId) {
     return true;
 }
 
-void TilesetEditorMetatileSelector::setTilesets(Tileset *primaryTileset, Tileset *secondaryTileset) {
+void TilesetEditorMetatileSelector::setTilesets(Tileset *primaryTileset, Tileset *secondaryTileset, bool draw) {
     this->primaryTileset = primaryTileset;
     this->secondaryTileset = secondaryTileset;
-    this->draw();
+
+    if (draw) this->draw();
 }
 
 void TilesetEditorMetatileSelector::updateSelectedMetatile() {
@@ -130,4 +142,93 @@ QPoint TilesetEditorMetatileSelector::getMetatileIdCoordsOnWidget(uint16_t metat
     pos.rx() = (pos.x() * this->cellWidth) + (this->cellWidth / 2);
     pos.ry() = (pos.y() * this->cellHeight) + (this->cellHeight / 2);
     return pos;
+}
+
+void TilesetEditorMetatileSelector::drawFilters() {
+    if (selectorShowUnused) {
+        drawUnused();
+    }
+    if (selectorShowCounts) {
+        drawCounts();
+    }
+}
+
+void TilesetEditorMetatileSelector::drawUnused() {
+    // setup the circle with a line through it image to layer above unused metatiles
+    QPixmap redX(32, 32);
+    redX.fill(Qt::transparent);
+
+    QPen whitePen(Qt::white);
+    whitePen.setWidth(1);
+    QPen redPen(Qt::magenta);
+    redPen.setWidth(1);
+
+    QPainter oPainter(&redX);
+
+    oPainter.setPen(whitePen);
+    oPainter.drawEllipse(QRect(1, 1, 30, 30));
+    oPainter.setPen(redPen);
+    oPainter.drawEllipse(QRect(2, 2, 28, 28));
+    oPainter.drawEllipse(QRect(3, 3, 26, 26));
+
+    oPainter.setPen(whitePen);
+    oPainter.drawEllipse(QRect(4, 4, 24, 24));
+
+    whitePen.setWidth(5);
+    oPainter.setPen(whitePen);
+    oPainter.drawLine(0, 0, 31, 31);
+
+    redPen.setWidth(3);
+    oPainter.setPen(redPen);
+    oPainter.drawLine(2, 2, 29, 29);
+
+    oPainter.end();
+
+    // draw symbol on unused metatiles
+    QPixmap metatilesPixmap = this->pixmap();
+
+    QPainter unusedPainter(&metatilesPixmap);
+
+    for (int tile = 0; tile < this->usedMetatiles.size(); tile++) {
+        if (!usedMetatiles[tile]) {
+            unusedPainter.drawPixmap((tile % 8) * 32, (tile / 8) * 32, redX);
+        }
+    }
+
+    unusedPainter.end();
+
+    this->setPixmap(metatilesPixmap);
+}
+
+void TilesetEditorMetatileSelector::drawCounts() {
+    QPen blackPen(Qt::black);
+    blackPen.setWidth(1);
+
+    QPixmap metatilesPixmap = this->pixmap();
+
+    QPainter countPainter(&metatilesPixmap);
+    countPainter.setPen(blackPen);
+
+    for (int tile = 0; tile < this->usedMetatiles.size(); tile++) {
+        int count = usedMetatiles[tile];
+        QString countText = QString::number(count);
+        if (count > 1000) countText = ">1k";
+        countPainter.drawText((tile % 8) * 32, (tile / 8) * 32 + 32, countText);
+    }
+
+    // write in white and black for contrast
+    QPen whitePen(Qt::white);
+    whitePen.setWidth(1);
+    countPainter.setPen(whitePen);
+
+    for (int tile = 0; tile < this->usedMetatiles.size(); tile++) {
+        int count = usedMetatiles[tile];
+        QString countText = QString::number(count);
+        if (count > 1000) countText = ">1k";
+        countPainter.drawText((tile % 8) * 32 + 1, (tile / 8) * 32 + 32 - 1, countText);
+    }
+
+    countPainter.end();
+
+    this->setPixmap(metatilesPixmap);
 }

--- a/src/ui/tileseteditormetatileselector.cpp
+++ b/src/ui/tileseteditormetatileselector.cpp
@@ -160,14 +160,14 @@ void TilesetEditorMetatileSelector::drawUnused() {
 
     QPen whitePen(Qt::white);
     whitePen.setWidth(1);
-    QPen redPen(Qt::magenta);
-    redPen.setWidth(1);
+    QPen pinkPen(Qt::magenta);
+    pinkPen.setWidth(1);
 
     QPainter oPainter(&redX);
 
     oPainter.setPen(whitePen);
     oPainter.drawEllipse(QRect(1, 1, 30, 30));
-    oPainter.setPen(redPen);
+    oPainter.setPen(pinkPen);
     oPainter.drawEllipse(QRect(2, 2, 28, 28));
     oPainter.drawEllipse(QRect(3, 3, 26, 26));
 
@@ -178,8 +178,8 @@ void TilesetEditorMetatileSelector::drawUnused() {
     oPainter.setPen(whitePen);
     oPainter.drawLine(0, 0, 31, 31);
 
-    redPen.setWidth(3);
-    oPainter.setPen(redPen);
+    pinkPen.setWidth(3);
+    oPainter.setPen(pinkPen);
     oPainter.drawLine(2, 2, 29, 29);
 
     oPainter.end();
@@ -188,6 +188,7 @@ void TilesetEditorMetatileSelector::drawUnused() {
     QPixmap metatilesPixmap = this->pixmap();
 
     QPainter unusedPainter(&metatilesPixmap);
+    unusedPainter.setOpacity(0.5);
 
     for (int tile = 0; tile < this->usedMetatiles.size(); tile++) {
         if (!usedMetatiles[tile]) {

--- a/src/ui/tileseteditortileselector.cpp
+++ b/src/ui/tileseteditortileselector.cpp
@@ -52,6 +52,8 @@ void TilesetEditorTileSelector::draw() {
     if (!this->externalSelection || (this->externalSelectionWidth == 1 && this->externalSelectionHeight == 1)) {
         this->drawSelection();
     }
+
+    if (showUnused) drawUnused();
 }
 
 void TilesetEditorTileSelector::select(uint16_t tile) {
@@ -285,4 +287,54 @@ QImage TilesetEditorTileSelector::buildSecondaryTilesIndexedImage() {
     QList<QRgb> palette = Tileset::getPalette(this->paletteId, this->primaryTileset, this->secondaryTileset, true);
     indexedImage.setColorTable(palette.toVector());
     return indexedImage;
+}
+
+void TilesetEditorTileSelector::drawUnused() {
+    // setup the circle with a line through it image to layer above unused metatiles
+    QPixmap redX(16, 16);
+    redX.fill(Qt::transparent);
+
+    QBitmap mask(16, 16);
+
+    QPen whitePen(Qt::white);
+    whitePen.setWidth(1);
+    QPen pinkPen(Qt::magenta);
+    pinkPen.setWidth(1);
+
+    QPainter oPainter(&redX);
+
+    oPainter.setPen(whitePen);
+    oPainter.drawEllipse(QRect(1, 1, 14, 14));
+    oPainter.setPen(pinkPen);
+    oPainter.drawEllipse(QRect(2, 2, 12, 12));
+    oPainter.drawEllipse(QRect(3, 3, 10, 10));
+
+    oPainter.setPen(whitePen);
+    oPainter.drawEllipse(QRect(4, 4, 8, 8));
+
+    whitePen.setWidth(3);
+    oPainter.setPen(whitePen);
+    oPainter.drawLine(0, 0, 15, 15);
+
+    pinkPen.setWidth(1);
+    oPainter.setPen(pinkPen);
+    oPainter.drawLine(2, 2, 13, 13);
+
+    oPainter.end();
+
+    // draw symbol on unused metatiles
+    QPixmap tilesPixmap = this->pixmap();
+
+    QPainter unusedPainter(&tilesPixmap);
+    unusedPainter.setOpacity(0.5);
+
+    for (int tile = 0; tile < this->usedTiles.size(); tile++) {
+        if (!usedTiles[tile]) {
+            unusedPainter.drawPixmap((tile % 16) * 16, (tile / 16) * 16, redX);
+        }
+    }
+
+    unusedPainter.end();
+
+    this->setPixmap(tilesPixmap);
 }


### PR DESCRIPTION
Tools > Tileset Editor > Tools > {Display Unused Metatiles, Display Metatile Usage Counts, Display Unused Tiles}

- count the total number of usages across all maps of specific metatiles
- display the count and/or display unused metatiles
- this does not account for metatiles used in code (most of these are labeled)
- unused tiles