### PR TITLE
Sync map group label comment format

### DIFF
--- a/src/project.cpp
+++ b/src/project.cpp
@@ -798,7 +798,7 @@ void Project::saveMapConstantsHeader() {
 
     int groupNum = 0;
     for (QStringList mapNames : groupedMapNames) {
-        text += QString("// Map Group %1\n").arg(groupNum);
+        text += "// " + groupNames.at(groupNum) + "\n";
         int maxLength = 0;
         for (QString mapName : mapNames) {
             QString mapConstantName = mapNamesToMapConstants.value(mapName);


### PR DESCRIPTION
This PR (<https://github.com/pret/pokeemerald/pull/1423>) and it's equivalent in pokefirered/pokeruby changed the format of map group label comments in `map_groups.h`. Porymap needs to follow this format or it and mapjson will keep undoing each other's changes here.