### PR TITLE
Log more script errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The **"Breaking Changes"** listed below are changes that have been made in the d
 
 ### Changed
 - New events will be placed in the center of the current view of the map.
+- Scripting API errors are more detailed and logged in more situations.
 
 ### Fixed
 - Fix tileset palette editor crash that could occur when switching maps or tilesets with it open.

--- a/docsrc/manual/scripting-capabilities.rst
+++ b/docsrc/manual/scripting-capabilities.rst
@@ -72,7 +72,7 @@ The grass-randomizer script above happens implicitly when the user paints on the
 
 .. code-block:: js
 
-	function applyNightTint() {
+	export function applyNightTint() {
 	    // Apply night palette tinting...
 	}
 
@@ -556,7 +556,7 @@ These are some miscellaneous functions that can be very useful when building cus
 
 .. js:function:: map.registerAction(functionName, actionName, shortcut = "")
 
-   Registers a JavaScript function to an action that can be manually triggered in Porymap's ``Tools`` menu. Optionally, a keyboard shortcut (e.g. ``"Ctrl+P"``) can also be specified, assuming it doesn't collide with any existing shortcuts used by Porymap.
+   Registers a JavaScript function to an action that can be manually triggered in Porymap's ``Tools`` menu. Optionally, a keyboard shortcut (e.g. ``"Ctrl+P"``) can also be specified, assuming it doesn't collide with any existing shortcuts used by Porymap. The function specified by ``functionName`` must have the ``export`` keyword.
 
    :param string functionName: name of the JavaScript function
    :param string actionName: name of the action that will be displayed in the ``Tools`` menu

--- a/include/scripting.h
+++ b/include/scripting.h
@@ -30,6 +30,7 @@ public:
     static void cb_ProjectClosed(QString projectPath);
     static void cb_MetatileChanged(int x, int y, Block prevBlock, Block newBlock);
     static void cb_MapOpened(QString mapName);
+    static bool tryErrorJS(QJSValue js);
 
 private:
     QJSEngine *engine;

--- a/include/ui/overlay.h
+++ b/include/ui/overlay.h
@@ -79,7 +79,7 @@ public:
     void clearItems();
     void addText(QString text, int x, int y, QString color = "#000000", int fontSize = 12);
     void addRect(int x, int y, int width, int height, QString color = "#000000", bool filled = false);
-    void addImage(int x, int y, QString filepath);
+    bool addImage(int x, int y, QString filepath);
 private:
     QList<OverlayItem*> items;
 };

--- a/src/mainwindow_scriptapi.cpp
+++ b/src/mainwindow_scriptapi.cpp
@@ -507,7 +507,7 @@ void MainWindow::setTimeout(QJSValue callback, int milliseconds) {
 }
 
 void MainWindow::invokeCallback(QJSValue callback) {
-    callback.call();
+    Scripting::tryErrorJS(callback.call());
 }
 
 void MainWindow::log(QString message) {

--- a/src/mainwindow_scriptapi.cpp
+++ b/src/mainwindow_scriptapi.cpp
@@ -241,8 +241,8 @@ void MainWindow::addFilledRect(int x, int y, int width, int height, QString colo
 void MainWindow::addImage(int x, int y, QString filepath) {
     if (!this->ui || !this->ui->graphicsView_Map)
         return;
-    this->ui->graphicsView_Map->overlay.addImage(x, y, filepath);
-    this->ui->graphicsView_Map->scene()->update();
+    if (this->ui->graphicsView_Map->overlay.addImage(x, y, filepath))
+        this->ui->graphicsView_Map->scene()->update();
 }
 
 void MainWindow::refreshAfterPaletteChange(Tileset *tileset) {

--- a/src/ui/overlay.cpp
+++ b/src/ui/overlay.cpp
@@ -1,4 +1,5 @@
 #include "overlay.h"
+#include "log.h"
 
 void OverlayText::render(QPainter *painter) {
     QFont font = painter->font();
@@ -40,6 +41,12 @@ void Overlay::addRect(int x, int y, int width, int height, QString color, bool f
     this->items.append(new OverlayRect(x, y, width, height, QColor(color), filled));
 }
 
-void Overlay::addImage(int x, int y, QString filepath) {
-    this->items.append(new OverlayImage(x, y, QImage(filepath)));
+bool Overlay::addImage(int x, int y, QString filepath) {
+    QImage image = QImage(filepath);
+    if (image.isNull()) {
+        logError(QString("Failed to load image '%1'").arg(filepath));
+        return false;
+    }
+    this->items.append(new OverlayImage(x, y, image));
+    return true;
 }


### PR DESCRIPTION
Log script errors in more situations. This handles 3 notable cases:
1. If an error occurs in a function called by `setTimeout`.
2. If Porymap is unable to find the function specified by the name given to `registerAction` (e.g. if it was not exported).
3. If `addImage` fails to load the image at the given filepath.

The manual was also updated so that it indicates functions registered as actions need to be exported, and the changelog updated to refer to the changes here and in <https://github.com/huderlem/porymap/pull/360>