### PR TITLE
Preserve invalid metatile selections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The **"Breaking Changes"** listed below are changes that have been made in the d
 
 ### Fixed
 - Fix tileset palette editor crash that could occur when switching maps or tilesets with it open.
+- The metatile selection is no longer reset if it becomes invalid by changing the tileset. Invalid metatiles in the selection will be temporarily replaced with metatile 0.
 - Loading wild encounters will now properly preserve the original order, so saving the file will not give huge diffs.
 
 ## [4.4.0] - 2020-12-20

--- a/include/ui/metatileselector.h
+++ b/include/ui/metatileselector.h
@@ -50,6 +50,7 @@ private:
     QList<uint16_t> *externalSelectedMetatiles;
 
     void updateSelectedMetatiles();
+    void updateExternalSelectedMetatiles();
     uint16_t getMetatileId(int x, int y);
     QPoint getMetatileIdCoords(uint16_t);
     bool shouldAcceptEvent(QGraphicsSceneMouseEvent*);


### PR DESCRIPTION
Old behavior: Selections with invalid metatiles are reset to a single metatile at 0/end of tileset.
New behavior: Selections with invalid metatiles have the invalid metatiles substituted for 0, but the selection's dimensions and actual metatile ids are preserved.

Fixes #336 