### PR TITLE
Don't change frame for inanimate objects

### DIFF
--- a/include/core/event.h
+++ b/include/core/event.h
@@ -99,6 +99,7 @@ public:
     int frame = 0;
     bool hFlip = false;
     bool usingSprite;
+    bool inanimate;
 
     DraggablePixmapItem *pixmapItem = nullptr;
     void setPixmapItem(DraggablePixmapItem *item) { pixmapItem = item; }

--- a/src/core/event.cpp
+++ b/src/core/event.cpp
@@ -26,7 +26,8 @@ Event::Event(const Event& toCopy) :
     spriteHeight(toCopy.spriteHeight),
     frame(toCopy.frame),
     hFlip(toCopy.hFlip),
-    usingSprite(toCopy.usingSprite)
+    usingSprite(toCopy.usingSprite),
+    inanimate(toCopy.inanimate)
 {  }
 
 Event::Event(QJsonObject obj, QString type) : Event()
@@ -427,6 +428,8 @@ void Event::setFrameFromMovement(QString facingDir) {
     // defaults
     this->frame = 0;
     this->hFlip = false;
+    if (this->inanimate)
+        return;
     if (facingDir == "DIR_NORTH") {
         this->frame = 1;
         this->hFlip = false;

--- a/src/project.cpp
+++ b/src/project.cpp
@@ -2441,6 +2441,7 @@ void Project::loadEventPixmaps(QList<Event*> objects) {
         object->spriteWidth = 16;
         object->spriteHeight = 16;
         object->usingSprite = false;
+        object->inanimate = true;
         QString event_type = object->get("event_type");
         if (event_type == EventType::Object) {
             object->pixmap = QPixmap(":/images/Entities_16x16.png").copy(0, 0, 16, 16);
@@ -2457,6 +2458,7 @@ void Project::loadEventPixmaps(QList<Event*> objects) {
         if (event_type == EventType::Object) {
             QString info_label = pointerHash[object->get("sprite")].replace("&", "");
             QStringList gfx_info = parser.readCArray("src/data/object_events/object_event_graphics_info.h", info_label);
+            object->inanimate = (gfx_info.value(8) == "TRUE");
             QString pic_label = gfx_info.value(14);
             QString dimensions_label = gfx_info.value(11);
             QString subsprites_label = gfx_info.value(12);


### PR DESCRIPTION
Objects with the "inanimate" flag set should ignore their movement type when considering if the frame should change. This can be demonstrated with the "breakable rock"; in Porymap setting its facing direction with the movement type would change the object's frame, while in-game it would stay on the first frame. Porymap now reflects the in-game behavior.

Fixes #371 