### PR TITLE
Only log completely absent script functions as an error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The **"Breaking Changes"** listed below are changes that have been made in the d
 ## [Unreleased]
 ### Changed
 - If an object event is inanimate, it will always render using its first frame.
+- Only log "Unknown custom script function" when a registered script function is not present in any script.
 
 ## [4.5.0] - 2021-12-26
 ### Added

--- a/src/scripting.cpp
+++ b/src/scripting.cpp
@@ -94,18 +94,20 @@ void Scripting::invokeAction(QString actionName) {
     if (!instance) return;
     if (!instance->registeredActions.contains(actionName)) return;
 
+    bool foundFunction = false;
     QString functionName = instance->registeredActions.value(actionName);
     for (QJSValue module : instance->modules) {
         QJSValue callbackFunction = module.property(functionName);
-        if (callbackFunction.isUndefined() || !callbackFunction.isCallable()) {
-            logError(QString("Unknown custom script function '%1'").arg(functionName));
+        if (callbackFunction.isUndefined() || !callbackFunction.isCallable())
             continue;
-        }
+        foundFunction = true;
         if (tryErrorJS(callbackFunction)) continue;
 
         QJSValue result = callbackFunction.call(QJSValueList());
         if (tryErrorJS(result)) continue;
     }
+    if (!foundFunction)
+        logError(QString("Unknown custom script function '%1'").arg(functionName));
 }
 
 void Scripting::cb_ProjectOpened(QString projectPath) {


### PR DESCRIPTION
Porymap tries to call registered script functions in every module. Currently it will log an error for every script module it doesn't find the function in. This can result in spurious error logs, as usually scripts won't share function names. Now Porymap will only log an error if it can't find the function in any loaded script modules.