### PR TITLE
Add missing signal blocker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ The **"Breaking Changes"** listed below are changes that have been made in the d
 - If an object event is inanimate, it will always render using its first frame.
 - Only log "Unknown custom script function" when a registered script function is not present in any script.
 
+### Fixed
+- Fix maps being incorrectly marked as having unsaved changes when switching maps.
+
 ## [4.5.0] - 2021-12-26
 ### Added
 - WSL project paths are now supported. (For example, \wsl$\Ubuntu-20.04\home\huderlem\pokeemerald)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,6 @@ The **"Breaking Changes"** listed below are changes that have been made in the d
 - If an object event is inanimate, it will always render using its first frame.
 - Only log "Unknown custom script function" when a registered script function is not present in any script.
 
-### Fixed
-- Fix maps being incorrectly marked as having unsaved changes when switching maps.
-
 ## [4.5.0] - 2021-12-26
 ### Added
 - WSL project paths are now supported. (For example, \wsl$\Ubuntu-20.04\home\huderlem\pokeemerald)

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -759,6 +759,7 @@ void MainWindow::displayMapProperties() {
     const QSignalBlocker blockerA(ui->checkBox_AllowRunning);
     const QSignalBlocker blockerB(ui->checkBox_AllowBiking);
     const QSignalBlocker blockerC(ui->spinBox_FloorNumber);
+    const QSignalBlocker blockerD(ui->checkBox_AllowEscapeRope);
 
     ui->checkBox_Visibility->setChecked(false);
     ui->checkBox_ShowLocation->setChecked(false);


### PR DESCRIPTION
`checkBox_AllowEscapeRope` was missing a signal blocker when displaying map properties. Adding map header properties to the API exposed this as a bug (maps incorrectly marked as dirty when switching if the checkbox changes state) because now it receives a signal that needs to be blocked.