### PR TITLE
Fix cursor tile rect not updating for selections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ The **"Breaking Changes"** listed below are changes that have been made in the d
 - If an object event is inanimate, it will always render using its first frame.
 - Only log "Unknown custom script function" when a registered script function is not present in any script.
 
+### Fixed
+- Fix cursor tile outline not updating at the end of a dragged selection.
+
 ## [4.5.0] - 2021-12-26
 ### Added
 - WSL project paths are now supported. (For example, \wsl$\Ubuntu-20.04\home\huderlem\pokeemerald)

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -993,7 +993,6 @@ void Editor::updateCursorRectPos(int x, int y) {
         this->cursorMapTileRect->updateLocation(x, y);
     if (ui->graphicsView_Map->scene())
         ui->graphicsView_Map->scene()->update();
-    Scripting::cb_BlockHoverChanged(x, y);
 }
 
 void Editor::setCursorRectVisible(bool visible) {
@@ -1023,6 +1022,7 @@ void Editor::onHoveredMapMetatileChanged(const QPoint &pos) {
                               .arg(pos.y())
                               .arg(QString::number(zoomLevels[this->scaleIndex], 'g', 2)));
     }
+    Scripting::cb_BlockHoverChanged(pos.x(), pos.y());
 }
 
 void Editor::onHoveredMapMetatileCleared() {
@@ -1047,6 +1047,7 @@ void Editor::onHoveredMapMovementPermissionChanged(int x, int y) {
                             .arg(this->getMovementPermissionText(collision, elevation));
         this->ui->statusBar->showMessage(message);
     }
+    Scripting::cb_BlockHoverChanged(x, y);
 }
 
 void Editor::onHoveredMapMovementPermissionCleared() {
@@ -1172,6 +1173,9 @@ void Editor::mouseEvent_map(QGraphicsSceneMouseEvent *event, MapPixmapItem *item
                 } else {
                     item->floodFill(event);
                 }
+            } else if (event->type() == QEvent::GraphicsSceneMouseRelease) {
+                // Update the tile rectangle at the end of a click-drag selection
+                this->updateCursorRectPos(pos.x(), pos.y());
             } else {
                 this->setSmartPathCursorMode(event);
                 this->setStraightPathCursorMode(event);


### PR DESCRIPTION
Fixes a bug that was introduced when the cursor tile rectangle was moved to the foreground. The rectangle doesn't update position when the mouse is released at the end of a click-dragged map selection in paint mode. 

Prior to the bug the rectangle was updated for every mouse event. Currently it's only updated when the mouse enters a new map space. Now it's also updated for mouse releases in paint mode. `cb_BlockHoverChanged` was moved out of `updateCursorRectPos ` so that it won't get called a second time when releasing the mouse.