### PR TITLE
Fix selected collision space not updating during paint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The **"Breaking Changes"** listed below are changes that have been made in the d
 
 ### Fixed
 - Fix cursor tile outline not updating at the end of a dragged selection.
+- Fix selected space not updating while painting in Collision view.
 
 ## [4.5.0] - 2021-12-26
 ### Added

--- a/include/ui/collisionpixmapitem.h
+++ b/include/ui/collisionpixmapitem.h
@@ -27,6 +27,7 @@ public:
 
 private:
     unsigned actionId_ = 0;
+    QPoint previousPos;
 
 signals:
     void mouseEvent(QGraphicsSceneMouseEvent *, CollisionPixmapItem *);
@@ -35,6 +36,7 @@ signals:
 
 protected:
     void hoverMoveEvent(QGraphicsSceneHoverEvent*);
+    void hoverEnterEvent(QGraphicsSceneHoverEvent*);
     void hoverLeaveEvent(QGraphicsSceneHoverEvent*);
     void mousePressEvent(QGraphicsSceneMouseEvent*);
     void mouseMoveEvent(QGraphicsSceneMouseEvent*);

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -1173,10 +1173,11 @@ void Editor::mouseEvent_map(QGraphicsSceneMouseEvent *event, MapPixmapItem *item
                 } else {
                     item->floodFill(event);
                 }
-            } else if (event->type() == QEvent::GraphicsSceneMouseRelease) {
-                // Update the tile rectangle at the end of a click-drag selection
-                this->updateCursorRectPos(pos.x(), pos.y());
             } else {
+                if (event->type() == QEvent::GraphicsSceneMouseRelease) {
+                    // Update the tile rectangle at the end of a click-drag selection
+                    this->updateCursorRectPos(pos.x(), pos.y());
+                }
                 this->setSmartPathCursorMode(event);
                 this->setStraightPathCursorMode(event);
                 if (this->cursorMapTileRect->getStraightPathMode()) {

--- a/src/ui/collisionpixmapitem.cpp
+++ b/src/ui/collisionpixmapitem.cpp
@@ -3,12 +3,19 @@
 #include "metatile.h"
 
 void CollisionPixmapItem::hoverMoveEvent(QGraphicsSceneHoverEvent *event) {
-    int x = static_cast<int>(event->pos().x()) / 16;
-    int y = static_cast<int>(event->pos().y()) / 16;
-    emit this->hoveredMapMovementPermissionChanged(x, y);
+    QPoint pos = Metatile::coordFromPixmapCoord(event->pos());
+    if (pos != this->previousPos) {
+        this->previousPos = pos;
+        emit this->hoveredMapMovementPermissionChanged(pos.x(), pos.y());
+    }
     if (this->settings->betterCursors && this->paintingMode == MapPixmapItem::PaintMode::Metatiles) {
         setCursor(this->settings->mapCursor);
     }
+}
+
+void CollisionPixmapItem::hoverEnterEvent(QGraphicsSceneHoverEvent * event) {
+    QPoint pos = Metatile::coordFromPixmapCoord(event->pos());
+    emit this->hoveredMapMovementPermissionChanged(pos.x(), pos.y());
 }
 
 void CollisionPixmapItem::hoverLeaveEvent(QGraphicsSceneHoverEvent *) {
@@ -26,6 +33,11 @@ void CollisionPixmapItem::mousePressEvent(QGraphicsSceneMouseEvent *event) {
 }
 
 void CollisionPixmapItem::mouseMoveEvent(QGraphicsSceneMouseEvent *event) {
+    QPoint pos = Metatile::coordFromPixmapCoord(event->pos());
+    if (pos != this->previousPos) {
+        this->previousPos = pos;
+        emit this->hoveredMapMovementPermissionChanged(pos.x(), pos.y());
+    }
     emit mouseEvent(event, this);
 }
 


### PR DESCRIPTION
Fixes the selected space not updating while painting in collision view. This bug existed in previous releases but was made more noticeable by the changes to the cursor tile outline. Previously it could be noticed by looking at the information printed in the bottom bar (the "X: #, Y: #, Collision:" information). While painting in metatile view this information updates, but in collision view it doesn't. Now it could also be noticed by the tile outline not updating.

Tacking on a fix to a bug introduced by #401... whoops. Mouse releases shouldn't be excluded from the rest of the block there.