### PR TITLE
Stop repeated parsing of event_objects.h and songs.h

### DIFF
--- a/include/core/event.h
+++ b/include/core/event.h
@@ -83,7 +83,7 @@ public:
     OrderedJson::object buildSignEventJSON();
     OrderedJson::object buildHiddenItemEventJSON();
     OrderedJson::object buildSecretBaseEventJSON();
-    void setPixmapFromSpritesheet(QImage, int, int, int, bool);
+    void setPixmapFromSpritesheet(QImage, int, int, bool);
     int getPixelX();
     int getPixelY();
     QMap<QString, bool> getExpectedFields();
@@ -99,7 +99,6 @@ public:
     int frame = 0;
     bool hFlip = false;
     bool usingSprite;
-    bool inanimate;
 
     DraggablePixmapItem *pixmapItem = nullptr;
     void setPixmapItem(DraggablePixmapItem *item) { pixmapItem = item; }

--- a/include/project.h
+++ b/include/project.h
@@ -51,6 +51,8 @@ public:
     QMap<QString, QString> mapSecToMapHoverName;
     QMap<QString, int> mapSectionNameToValue;
     QMap<int, QString> mapSectionValueToName;
+    QStringList gfxNames;
+    QStringList songNames;
     QStringList itemNames;
     QStringList flagNames;
     QStringList varNames;
@@ -151,7 +153,6 @@ public:
     void saveTilesetPalettes(Tileset*);
 
     QString defaultSong;
-    QStringList getSongNames();
     QStringList getVisibilities();
     QMap<QString, QStringList> getTilesetLabels();
     bool readTilesetProperties();
@@ -173,9 +174,10 @@ public:
     bool readHealLocations();
     bool readMiscellaneousConstants();
     bool readEventScriptLabels();
+    bool readObjEventGfxConstants();
+    bool readSongNames();
 
     void loadEventPixmaps(QList<Event*> objects);
-    QMap<QString, int> getEventObjGfxConstants();
     QString fixPalettePath(QString path);
     QString fixGraphicPath(QString path);
 

--- a/include/project.h
+++ b/include/project.h
@@ -18,6 +18,14 @@
 #include <QVariant>
 #include <QFileSystemWatcher>
 
+struct EventGraphics
+{
+    QImage spritesheet;
+    int spriteWidth;
+    int spriteHeight;
+    bool inanimate;
+};
+
 static QString NONE_MAP_CONSTANT = "MAP_NONE";
 static QString NONE_MAP_NAME = "None";
 
@@ -51,6 +59,7 @@ public:
     QMap<QString, QString> mapSecToMapHoverName;
     QMap<QString, int> mapSectionNameToValue;
     QMap<int, QString> mapSectionValueToName;
+    QMap<QString, EventGraphics*> eventGraphicsMap;
     QStringList gfxNames;
     QStringList songNames;
     QStringList itemNames;
@@ -176,8 +185,10 @@ public:
     bool readEventScriptLabels();
     bool readObjEventGfxConstants();
     bool readSongNames();
+    bool readEventGraphics();
 
-    void loadEventPixmaps(QList<Event*> objects);
+    void setEventPixmap(Event * event, bool forceLoad = false);
+
     QString fixPalettePath(QString path);
     QString fixGraphicPath(QString path);
 

--- a/src/core/editcommands.cpp
+++ b/src/core/editcommands.cpp
@@ -322,7 +322,7 @@ void EventCreate::redo() {
 
     map->addEvent(event);
 
-    editor->project->loadEventPixmaps(map->getAllEvents());
+    editor->project->setEventPixmap(event);
     editor->addMapEvent(event);
 
     // select this event
@@ -388,8 +388,7 @@ void EventDelete::redo() {
 void EventDelete::undo() {
     for (Event *event : selectedEvents) {
         map->addEvent(event);
-
-        editor->project->loadEventPixmaps(map->getAllEvents());
+        editor->project->setEventPixmap(event);
         editor->addMapEvent(event);
     }
 
@@ -431,11 +430,7 @@ void EventDuplicate::redo() {
 
     for (Event *event : selectedEvents) {
         map->addEvent(event);
-    }
-
-    editor->project->loadEventPixmaps(map->getAllEvents());
-
-    for (Event *event : selectedEvents) {
+        editor->project->setEventPixmap(event);
         editor->addMapEvent(event);
     }
 

--- a/src/core/event.cpp
+++ b/src/core/event.cpp
@@ -71,7 +71,7 @@ Event* Event::createNewObjectEvent(Project *project)
     Event *event = new Event;
     event->put("event_group_type", "object_event_group");
     event->put("event_type", EventType::Object);
-    event->put("sprite", project->getEventObjGfxConstants().keys().first());
+    event->put("sprite", project->gfxNames.first());
     event->put("movement_type", project->movementTypes.first());
     if (projectConfig.getObjectEventInConnectionEnabled()) {
         event->put("in_connection", false);

--- a/src/core/event.cpp
+++ b/src/core/event.cpp
@@ -26,8 +26,7 @@ Event::Event(const Event& toCopy) :
     spriteHeight(toCopy.spriteHeight),
     frame(toCopy.frame),
     hFlip(toCopy.hFlip),
-    usingSprite(toCopy.usingSprite),
-    inanimate(toCopy.inanimate)
+    usingSprite(toCopy.usingSprite)
 {  }
 
 Event::Event(QJsonObject obj, QString type) : Event()
@@ -410,13 +409,14 @@ OrderedJson::object Event::buildSecretBaseEventJSON()
     return secretBaseObj;
 }
 
-void Event::setPixmapFromSpritesheet(QImage spritesheet, int spriteWidth, int spriteHeight, int frame, bool hFlip)
+void Event::setPixmapFromSpritesheet(QImage spritesheet, int spriteWidth, int spriteHeight, bool inanimate)
 {
-    // Set first palette color fully transparent.
+    int frame = inanimate ? 0 : this->frame;
     QImage img = spritesheet.copy(frame * spriteWidth % spritesheet.width(), 0, spriteWidth, spriteHeight);
-    if (hFlip) {
+    if (this->hFlip && !inanimate) {
         img = img.transformed(QTransform().scale(-1, 1));
     }
+    // Set first palette color fully transparent.
     img.setColor(0, qRgba(0, 0, 0, 0));
     pixmap = QPixmap::fromImage(img);
     this->spriteWidth = spriteWidth;
@@ -428,8 +428,6 @@ void Event::setFrameFromMovement(QString facingDir) {
     // defaults
     this->frame = 0;
     this->hFlip = false;
-    if (this->inanimate)
-        return;
     if (facingDir == "DIR_NORTH") {
         this->frame = 1;
         this->hFlip = false;

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -1498,10 +1498,7 @@ void Editor::displayMapEvents() {
 
     QList<Event *> events = map->getAllEvents();
     for (Event *event : events) {
-        event->setFrameFromMovement(project->facingDirections.value(event->get("movement_type")));
-    }
-    project->loadEventPixmaps(events);
-    for (Event *event : events) {
+        project->setEventPixmap(event);
         addMapEvent(event);
     }
     //objects_group->setFiltersChildEvents(false);
@@ -1971,7 +1968,7 @@ QList<DraggablePixmapItem *> Editor::getObjects() {
 }
 
 void Editor::redrawObject(DraggablePixmapItem *item) {
-    if (item) {
+    if (item && item->event && !item->event->pixmap.isNull()) {
         qreal opacity = item->event->usingSprite ? 1.0 : 0.7;
         item->setOpacity(opacity);
         item->setPixmap(item->event->pixmap.copy(item->event->frame * item->event->spriteWidth % item->event->pixmap.width(), 0, item->event->spriteWidth, item->event->spriteHeight));

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -941,7 +941,9 @@ bool MainWindow::loadDataStructures() {
                 && project->readMiscellaneousConstants()
                 && project->readSpeciesIconPaths()
                 && project->readWildMonData()
-                && project->readEventScriptLabels();
+                && project->readEventScriptLabels()
+                && project->readObjEventGfxConstants()
+                && project->readSongNames();
 
     return success && loadProjectCombos();
 }
@@ -960,7 +962,7 @@ bool MainWindow::loadProjectCombos() {
     const QSignalBlocker blocker7(ui->comboBox_Type);
 
     ui->comboBox_Song->clear();
-    ui->comboBox_Song->addItems(project->getSongNames());
+    ui->comboBox_Song->addItems(project->songNames);
     ui->comboBox_Location->clear();
     ui->comboBox_Location->addItems(project->mapSectionValueToName.values());
 
@@ -1954,8 +1956,6 @@ void MainWindow::updateSelectedObjects() {
         delete button;
     openScriptButtons.clear();
 
-    QMap<QString, int> event_obj_gfx_constants = editor->project->getEventObjGfxConstants();
-
     QList<EventPropertiesFrame *> frames;
 
     bool inConnectionEnabled = projectConfig.getObjectEventInConnectionEnabled();
@@ -2043,7 +2043,7 @@ void MainWindow::updateSelectedObjects() {
         if (event_type == EventType::Object) {
 
             frame->ui->sprite->setVisible(true);
-            frame->ui->comboBox_sprite->addItems(event_obj_gfx_constants.keys());
+            frame->ui->comboBox_sprite->addItems(editor->project->gfxNames);
             frame->ui->comboBox_sprite->setCurrentIndex(frame->ui->comboBox_sprite->findText(item->event->get("sprite")));
             connect(frame->ui->comboBox_sprite, &QComboBox::currentTextChanged, item, &DraggablePixmapItem::set_sprite);
             connect(frame->ui->comboBox_sprite, &QComboBox::currentTextChanged, this, &MainWindow::markMapEdited);

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -943,6 +943,7 @@ bool MainWindow::loadDataStructures() {
                 && project->readWildMonData()
                 && project->readEventScriptLabels()
                 && project->readObjEventGfxConstants()
+                && project->readEventGraphics()
                 && project->readSongNames();
 
     return success && loadProjectCombos();
@@ -2171,8 +2172,8 @@ void MainWindow::updateSelectedObjects() {
                     combo->addItem(value);
                 }
                 connect(combo, static_cast<void (QComboBox::*)(const QString &)>(&QComboBox::currentTextChanged),
-                        this, [this, item](QString value){
-                            item->event->setFrameFromMovement(editor->project->facingDirections.value(value));
+                        this, [item](QString value){
+                            item->event->put("movement_type", value);
                             item->updatePixmap();
                 });
                 combo->addItems(editor->project->movementTypes);

--- a/src/mainwindow_scriptapi.cpp
+++ b/src/mainwindow_scriptapi.cpp
@@ -1078,8 +1078,7 @@ QString MainWindow::getSong() {
 void MainWindow::setSong(QString song) {
     if (!this->ui || !this->editor || !this->editor->project)
         return;
-    QStringList songs = this->editor->project->getSongNames();
-    if (!songs.contains(song)) {
+    if (!this->editor->project->songNames.contains(song)) {
         logError(QString("Unknown song '%1'").arg(song));
         return;
     }

--- a/src/ui/draggablepixmapitem.cpp
+++ b/src/ui/draggablepixmapitem.cpp
@@ -26,10 +26,7 @@ void DraggablePixmapItem::emitPositionChanged() {
 }
 
 void DraggablePixmapItem::updatePixmap() {
-    QList<Event*> objects;
-    objects.append(event);
-    event->pixmap = QPixmap();
-    editor->project->loadEventPixmaps(objects);
+    editor->project->setEventPixmap(event, true);
     this->updatePosition();
     editor->redrawObject(this);
     emit spriteChanged(event->pixmap);

--- a/src/ui/mapimageexporter.cpp
+++ b/src/ui/mapimageexporter.cpp
@@ -368,8 +368,8 @@ QPixmap MapImageExporter::getFormattedMapPixmap(Map *map, bool ignoreBorder) {
     // draw events
     QPainter eventPainter(&pixmap);
     QList<Event*> events = map->getAllEvents();
-    editor->project->loadEventPixmaps(events);
     for (Event *event : events) {
+        editor->project->setEventPixmap(event);
         QString group = event->get("event_group_type");
         if ((showObjects && group == "object_event_group")
          || (showWarps && group == "warp_event_group")

--- a/src/ui/newmappopup.cpp
+++ b/src/ui/newmappopup.cpp
@@ -116,7 +116,7 @@ void NewMapPopup::setDefaultValues(int groupNum, QString mapSec) {
     ui->comboBox_NewMap_Group->addItems(project->groupNames);
     ui->comboBox_NewMap_Group->setCurrentText(project->groupNames.at(groupNum));
 
-    ui->comboBox_Song->addItems(project->getSongNames());
+    ui->comboBox_Song->addItems(project->songNames);
 
     if (existingLayout) {
         ui->spinBox_NewMap_Width->setValue(project->mapLayouts.value(layoutId)->width.toInt(nullptr, 0));


### PR DESCRIPTION
Any time the `OBJ_EVENT_GFX` or `MUS`/`SE` constants are needed Porymap parses them in their entirety from the file in the project. Now it only parses them once when the project is loaded and they're subsequently read from memory.