### PR TITLE
Preserve unused metatile attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The **"Breaking Changes"** listed below are changes that have been made in the d
 ### Changed
 - If an object event is inanimate, it will always render using its first frame.
 - Only log "Unknown custom script function" when a registered script function is not present in any script.
+- Unused metatile attribute bits that are set are preserved instead of being cleared.
 
 ### Fixed
 - Fix cursor tile outline not updating at the end of a dragged selection.

--- a/include/core/metatile.h
+++ b/include/core/metatile.h
@@ -3,6 +3,7 @@
 #define METATILE_H
 
 #include "tile.h"
+#include "config.h"
 #include <QImage>
 #include <QPoint>
 #include <QString>
@@ -42,10 +43,15 @@ public:
     uint8_t layerType;
     uint8_t encounterType; // FRLG only
     uint8_t terrainType;   // FRLG only
+    uint32_t unusedAttributes;
     QString label;
+
+    void setAttributes(uint32_t data, BaseGameVersion version);
+    uint32_t getAttributes(BaseGameVersion version);
 
     static int getIndexInTileset(int);
     static QPoint coordFromPixmapCoord(const QPointF &pixelCoord);
+    static int getAttributesSize(BaseGameVersion version);
 };
 
 #endif // METATILE_H

--- a/include/core/tile.h
+++ b/include/core/tile.h
@@ -2,18 +2,22 @@
 #ifndef TILE_H
 #define TILE_H
 
+#include <QObject>
 
 class Tile
 {
 public:
     Tile();
     Tile(int tileId, bool xflip, bool yflip, int palette);
+    Tile(uint16_t raw);
 
 public:
     int tileId;
     bool xflip;
     bool yflip;
     int palette;
+
+    uint16_t rawValue() const;
 
     static int getIndexInTileset(int);
 };

--- a/src/core/metatile.cpp
+++ b/src/core/metatile.cpp
@@ -6,7 +6,8 @@ Metatile::Metatile() :
     behavior(0),
     layerType(0),
     encounterType(0),
-    terrainType(0)
+    terrainType(0),
+    unusedAttributes(0)
 {  }
 
 int Metatile::getIndexInTileset(int metatileId) {
@@ -21,4 +22,52 @@ QPoint Metatile::coordFromPixmapCoord(const QPointF &pixelCoord) {
     int x = static_cast<int>(pixelCoord.x()) / 16;
     int y = static_cast<int>(pixelCoord.y()) / 16;
     return QPoint(x, y);
+}
+
+int Metatile::getAttributesSize(BaseGameVersion version) {
+    return (version == BaseGameVersion::pokefirered) ? 4 : 2;
+}
+
+// RSE attributes
+const uint16_t behaviorMask_RSE  = 0x00FF;
+const uint16_t layerTypeMask_RSE = 0xF000;
+const int behaviorShift_RSE = 0;
+const int layerTypeShift_RSE = 12;
+
+// FRLG attributes
+const uint32_t behaviorMask_FRLG  = 0x000001FF;
+const uint32_t terrainTypeMask    = 0x00003E00;
+const uint32_t encounterTypeMask  = 0x07000000;
+const uint32_t layerTypeMask_FRLG = 0x60000000;
+const int behaviorShift_FRLG = 0;
+const int terrainTypeShift = 9;
+const int encounterTypeShift = 24;
+const int layerTypeShift_FRLG = 29;
+
+uint32_t Metatile::getAttributes(BaseGameVersion version) {
+    uint32_t attributes = this->unusedAttributes;
+    if (version == BaseGameVersion::pokefirered) {
+        attributes |= (behavior << behaviorShift_FRLG) & behaviorMask_FRLG;
+        attributes |= (terrainType << terrainTypeShift) & terrainTypeMask;
+        attributes |= (encounterType << encounterTypeShift) & encounterTypeMask;
+        attributes |= (layerType << layerTypeShift_FRLG) & layerTypeMask_FRLG;
+    } else {
+        attributes |= (behavior << behaviorShift_RSE) & behaviorMask_RSE;
+        attributes |= (layerType << layerTypeShift_RSE) & layerTypeMask_RSE;
+    }
+    return attributes;
+}
+
+void Metatile::setAttributes(uint32_t data, BaseGameVersion version) {
+    if (version == BaseGameVersion::pokefirered) {
+        this->behavior = (data & behaviorMask_FRLG) >> behaviorShift_FRLG;
+        this->terrainType = (data & terrainTypeMask) >> terrainTypeShift;
+        this->encounterType = (data & encounterTypeMask) >> encounterTypeShift;
+        this->layerType = (data & layerTypeMask_FRLG) >> layerTypeShift_FRLG;
+        this->unusedAttributes = data & ~(behaviorMask_FRLG | terrainTypeMask | layerTypeMask_FRLG | encounterTypeMask);
+    } else {
+        this->behavior = (data & behaviorMask_RSE) >> behaviorShift_RSE;
+        this->layerType = (data & layerTypeMask_RSE) >> layerTypeShift_RSE;
+        this->unusedAttributes = data & ~(behaviorMask_RSE | layerTypeMask_RSE);
+    }
 }

--- a/src/core/metatileparser.cpp
+++ b/src/core/metatileparser.cpp
@@ -72,10 +72,9 @@ QList<Metatile*> MetatileParser::parse(QString filepath, bool *error, bool prima
         QList<Tile> tiles;
         for (int j = 0; j < 8; j++) {
             int metatileOffset = 4 + i * metatileSize + j * 2;
-            uint16_t word = static_cast<uint16_t>(
+            Tile tile(static_cast<uint16_t>(
                         static_cast<unsigned char>(in.at(metatileOffset)) |
-                        (static_cast<unsigned char>(in.at(metatileOffset + 1)) << 8));
-            Tile tile(word & 0x3ff, (word >> 10) & 1, (word >> 11) & 1, (word >> 12) & 0xf);
+                       (static_cast<unsigned char>(in.at(metatileOffset + 1)) << 8)));
             tiles.append(tile);
         }
 

--- a/src/core/tile.cpp
+++ b/src/core/tile.cpp
@@ -15,6 +15,21 @@
         palette(palette)
     {  }
 
+ Tile::Tile(uint16_t raw) :
+        tileId(raw & 0x3FF),
+        xflip((raw >> 10) & 1),
+        yflip((raw >> 11) & 1),
+        palette((raw >> 12) & 0xF)
+    {  }
+
+uint16_t Tile::rawValue() const {
+    return static_cast<uint16_t>(
+            (this->tileId & 0x3FF)
+         | ((this->xflip & 1) << 10)
+         | ((this->yflip & 1) << 11)
+         | ((this->palette & 0xF) << 12));
+}
+
 int Tile::getIndexInTileset(int tileId) {
     if (tileId < Project::getNumTilesPrimary()) {
         return tileId;

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1313,11 +1313,6 @@ void MainWindow::on_actionNew_Tileset_triggered() {
                     tile.tileId = ((i % 2) == 1) ? 1 : 2;
                 mt->tiles.append(tile);
             }
-            mt->behavior = 0;
-            mt->layerType = 0;
-            mt->encounterType = 0;
-            mt->terrainType = 0;
-
             newSet.metatiles.append(mt);
         }
         for(int i = 0; i < 16; ++i) {

--- a/src/project.cpp
+++ b/src/project.cpp
@@ -1558,9 +1558,9 @@ void Project::loadTilesetMetatiles(Tileset* tileset) {
             Metatile *metatile = new Metatile;
             int index = i * (2 * 4 * num_layers);
             for (int j = 0; j < 4 * num_layers; j++) {
-                Tile tile(static_cast<unsigned char>(data[index++])
-                       | (static_cast<unsigned char>(data[index++]) << 8));
-                metatile->tiles.append(tile);
+                uint16_t tileRaw = static_cast<unsigned char>(data[index++]);
+                tileRaw |= static_cast<unsigned char>(data[index++]) << 8;
+                metatile->tiles.append(Tile(tileRaw));
             }
             metatiles.append(metatile);
         }

--- a/src/project.cpp
+++ b/src/project.cpp
@@ -1054,13 +1054,9 @@ void Project::saveTilesetMetatiles(Tileset *tileset) {
         for (Metatile *metatile : tileset->metatiles) {
             int numTiles = projectConfig.getTripleLayerMetatilesEnabled() ? 12 : 8;
             for (int i = 0; i < numTiles; i++) {
-                Tile tile = metatile->tiles.at(i);
-                uint16_t value = static_cast<uint16_t>((tile.tileId & 0x3ff)
-                                                    | ((tile.xflip & 1) << 10)
-                                                    | ((tile.yflip & 1) << 11)
-                                                    | ((tile.palette & 0xf) << 12));
-                data.append(static_cast<char>(value & 0xff));
-                data.append(static_cast<char>((value >> 8) & 0xff));
+                uint16_t tile = metatile->tiles.at(i).rawValue();
+                data.append(static_cast<char>(tile));
+                data.append(static_cast<char>(tile >> 8));
             }
         }
         metatiles_file.write(data);
@@ -1562,13 +1558,8 @@ void Project::loadTilesetMetatiles(Tileset* tileset) {
             Metatile *metatile = new Metatile;
             int index = i * (2 * 4 * num_layers);
             for (int j = 0; j < 4 * num_layers; j++) {
-                uint16_t word = data[index++] & 0xff;
-                word += (data[index++] & 0xff) << 8;
-                Tile tile;
-                tile.tileId = word & 0x3ff;
-                tile.xflip = (word >> 10) & 1;
-                tile.yflip = (word >> 11) & 1;
-                tile.palette = (word >> 12) & 0xf;
+                Tile tile(static_cast<unsigned char>(data[index++])
+                       | (static_cast<unsigned char>(data[index++]) << 8));
                 metatile->tiles.append(tile);
             }
             metatiles.append(metatile);

--- a/src/ui/tileseteditor.cpp
+++ b/src/ui/tileseteditor.cpp
@@ -758,11 +758,7 @@ void TilesetEditor::on_actionChange_Metatiles_Count_triggered()
         }
         while (this->primaryTileset->metatiles.length() < numPrimaryMetatiles) {
             Tile tile(0, false, false, 0);
-            Metatile *metatile = new Metatile;
-            metatile->behavior = 0;
-            metatile->layerType = 0;
-            metatile->encounterType = 0;
-            metatile->terrainType = 0;
+            Metatile *metatile = new Metatile();
             for (int i = 0; i < numTiles; i++) {
                 metatile->tiles.append(tile);
             }
@@ -773,11 +769,7 @@ void TilesetEditor::on_actionChange_Metatiles_Count_triggered()
         }
         while (this->secondaryTileset->metatiles.length() < numSecondaryMetatiles) {
             Tile tile(0, false, false, 0);
-            Metatile *metatile = new Metatile;
-            metatile->behavior = 0;
-            metatile->layerType = 0;
-            metatile->encounterType = 0;
-            metatile->terrainType = 0;
+            Metatile *metatile = new Metatile();
             for (int i = 0; i < numTiles; i++) {
                 metatile->tiles.append(tile);
             }


### PR DESCRIPTION
All Gen III games have unused bits in their metatile attributes. Currently Porymap ignores these bits during reading/writing, meaning if users have set them for some purpose in their project then Porymap will clear them. Now Porymap will preserve these bits.

Also moves the logic for separating attributes to `metatile.cpp`, because the work to do this was being duplicated. Same for the fields of `Tile`.