### PR TITLE
Fix two cursor outline bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ The **"Breaking Changes"** listed below are changes that have been made in the d
 
 ### Fixed
 - Fix cursor tile outline not updating at the end of a dragged selection.
+- Fix cursor tile and player view outlines exiting map bounds while painting.
+- Fix cursor tile and player view outlines not updating immediately when toggled in Collision view.
 - Fix selected space not updating while painting in Collision view.
 
 ## [4.5.0] - 2021-12-26

--- a/include/core/map.h
+++ b/include/core/map.h
@@ -95,6 +95,7 @@ public:
     void setBorderDimensions(int newWidth, int newHeight, bool setNewBlockdata = true);
     void cacheBorder();
     bool hasUnsavedChanges();
+    bool isWithinBounds(int x, int y);
 
     // for memory management
     QVector<Event *> ownedEvents;

--- a/include/editor.h
+++ b/include/editor.h
@@ -177,7 +177,6 @@ private:
     QString getMovementPermissionText(uint16_t collision, uint16_t elevation);
     QString getMetatileDisplayMessage(uint16_t metatileId);
     bool eventLimitReached(Map *, QString);
-    bool isWithinMap(int x, int y);
     bool startDetachedProcess(const QString &command,
                               const QString &workingDirectory = QString(),
                               qint64 *pid = nullptr) const;

--- a/include/editor.h
+++ b/include/editor.h
@@ -177,6 +177,7 @@ private:
     QString getMovementPermissionText(uint16_t collision, uint16_t elevation);
     QString getMetatileDisplayMessage(uint16_t metatileId);
     bool eventLimitReached(Map *, QString);
+    bool isWithinMap(int x, int y);
     bool startDetachedProcess(const QString &command,
                               const QString &workingDirectory = QString(),
                               qint64 *pid = nullptr) const;

--- a/src/core/map.cpp
+++ b/src/core/map.cpp
@@ -335,7 +335,7 @@ void Map::setBorderDimensions(int newWidth, int newHeight, bool setNewBlockdata)
 }
 
 bool Map::getBlock(int x, int y, Block *out) {
-    if (x >= 0 && x < getWidth() && y >= 0 && y < getHeight()) {
+    if (isWithinBounds(x, y)) {
         int i = y * getWidth() + x;
         *out = layout->blockdata.value(i);
         return true;
@@ -469,4 +469,8 @@ void Map::addEvent(Event *event) {
 
 bool Map::hasUnsavedChanges() {
     return !editHistory.isClean() || hasUnsavedDataChanges || !isPersistedToFile;
+}
+
+bool Map::isWithinBounds(int x, int y) {
+    return (x >= 0 && x < this->getWidth() && y >= 0 && y < this->getHeight());
 }

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -1004,14 +1004,10 @@ void Editor::setCursorRectVisible(bool visible) {
         ui->graphicsView_Map->scene()->update();
 }
 
-bool Editor::isWithinMap(int x, int y) {
-    return (x >= 0 && x < map->getWidth() && y >= 0 && y < map->getHeight());
-}
-
 void Editor::onHoveredMapMetatileChanged(const QPoint &pos) {
     int x = pos.x();
     int y = pos.y();
-    if (!this->isWithinMap(x, y))
+    if (!map->isWithinBounds(x, y))
         return;
 
     this->updateCursorRectPos(x, y);
@@ -1043,7 +1039,7 @@ void Editor::onHoveredMapMetatileCleared() {
 }
 
 void Editor::onHoveredMapMovementPermissionChanged(int x, int y) {
-    if (!this->isWithinMap(x, y))
+    if (!map->isWithinBounds(x, y))
         return;
 
     this->updateCursorRectPos(x, y);

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1738,7 +1738,8 @@ void MainWindow::on_actionPlayer_View_Rectangle_triggered()
     bool enabled = ui->actionPlayer_View_Rectangle->isChecked();
     porymapConfig.setShowPlayerView(enabled);
     this->editor->settings->playerViewRectEnabled = enabled;
-    if (this->editor->map_item->has_mouse) {
+    if ((this->editor->map_item && this->editor->map_item->has_mouse)
+     || (this->editor->collision_item && this->editor->collision_item->has_mouse)) {
         this->editor->playerViewRect->setVisible(enabled);
         ui->graphicsView_Map->scene()->update();
     }
@@ -1749,7 +1750,8 @@ void MainWindow::on_actionCursor_Tile_Outline_triggered()
     bool enabled = ui->actionCursor_Tile_Outline->isChecked();
     porymapConfig.setShowCursorTile(enabled);
     this->editor->settings->cursorTileRectEnabled = enabled;
-    if (this->editor->map_item->has_mouse) {
+    if ((this->editor->map_item && this->editor->map_item->has_mouse)
+     || (this->editor->collision_item && this->editor->collision_item->has_mouse)) {
         this->editor->cursorMapTileRect->setVisible(enabled && this->editor->cursorMapTileRect->getActive());
         ui->graphicsView_Map->scene()->update();
     }

--- a/src/ui/collisionpixmapitem.cpp
+++ b/src/ui/collisionpixmapitem.cpp
@@ -14,6 +14,7 @@ void CollisionPixmapItem::hoverMoveEvent(QGraphicsSceneHoverEvent *event) {
 }
 
 void CollisionPixmapItem::hoverEnterEvent(QGraphicsSceneHoverEvent * event) {
+    this->has_mouse = true;
     QPoint pos = Metatile::coordFromPixmapCoord(event->pos());
     emit this->hoveredMapMovementPermissionChanged(pos.x(), pos.y());
 }
@@ -23,6 +24,7 @@ void CollisionPixmapItem::hoverLeaveEvent(QGraphicsSceneHoverEvent *) {
     if (this->settings->betterCursors && this->paintingMode == MapPixmapItem::PaintMode::Metatiles){
         unsetCursor();
     }
+    this->has_mouse = false;
 }
 
 void CollisionPixmapItem::mousePressEvent(QGraphicsSceneMouseEvent *event) {

--- a/src/ui/mappixmapitem.cpp
+++ b/src/ui/mappixmapitem.cpp
@@ -191,8 +191,7 @@ void MapPixmapItem::paintSmartPath(int x, int y, bool fromScriptCall) {
     // Fill the region with the open tile.
     for (int i = 0; i <= 1; i++)
     for (int j = 0; j <= 1; j++) {
-        // Check if in map bounds.
-        if (!(i + x < map->getWidth() && i + x >= 0 && j + y < map->getHeight() && j + y >= 0))
+        if (!map->isWithinBounds(x + i, y + j))
             continue;
         int actualX = i + x;
         int actualY = j + y;
@@ -210,8 +209,7 @@ void MapPixmapItem::paintSmartPath(int x, int y, bool fromScriptCall) {
     // Go back and resolve the edge tiles
     for (int i = -1; i <= 2; i++)
     for (int j = -1; j <= 2; j++) {
-        // Check if in map bounds.
-        if (!(i + x < map->getWidth() && i + x >= 0 && j + y < map->getHeight() && j + y >= 0))
+        if (!map->isWithinBounds(x + i, y + j))
             continue;
         // Ignore the corners, which can't possible be affected by the smart path.
         if ((i == -1 && j == -1) || (i == 2 && j == -1) ||


### PR DESCRIPTION
- Normally the cursor tile and player view outlines disappear when the cursor exits the map. While clicking and dragging these outlines can be forced outside the map bounds on the right and bottom edges. This was because `updateCursorRectPos` was called before the check for map bounds.
- The cursor tile and player view outlines can be toggled with keyboard shortcuts. On the Metatiles tab they will update immediately, but on the Collision tab they will only update once the cursor enters a new space. This is because mainwindow was checking `has_mouse` on `map_item` but not `collision_item`.