### PR TITLE
Automatically disable wild encounter editor if JSON is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The **"Breaking Changes"** listed below are changes that have been made in the d
 - If an object event is inanimate, it will always render using its first frame.
 - Only log "Unknown custom script function" when a registered script function is not present in any script.
 - Unused metatile attribute bits that are set are preserved instead of being cleared.
+- The wild encounter editor is automatically disabled if the encounter JSON data cannot be read
 
 ### Fixed
 - Fix cursor tile outline not updating at the end of a dragged selection.

--- a/include/mainwindow.h
+++ b/include/mainwindow.h
@@ -418,6 +418,7 @@ private:
     void initShortcuts();
     void initExtraShortcuts();
     void setProjectSpecificUIVisibility();
+    void setWildEncountersUIEnabled(bool enabled);
     void loadUserSettings();
     void applyMapListFilter(QString filterText);
     void restoreWindowState();

--- a/include/project.h
+++ b/include/project.h
@@ -244,6 +244,7 @@ signals:
     void reloadProject();
     void uncheckMonitorFilesAction();
     void mapCacheCleared();
+    void disableWildEncountersUI();
 };
 
 #endif // PROJECT_H

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -349,12 +349,15 @@ void MainWindow::markMapEdited() {
     }
 }
 
+void MainWindow::setWildEncountersUIEnabled(bool enabled) {
+    ui->actionUse_Encounter_Json->setChecked(enabled);
+    ui->mainTabBar->setTabEnabled(4, enabled);
+}
+
 void MainWindow::setProjectSpecificUIVisibility()
 {
-    ui->actionUse_Encounter_Json->setChecked(projectConfig.getEncounterJsonActive());
     ui->actionUse_Poryscript->setChecked(projectConfig.getUsePoryScript());
-
-    ui->mainTabBar->setTabEnabled(4, projectConfig.getEncounterJsonActive());
+    this->setWildEncountersUIEnabled(projectConfig.getEncounterJsonActive());
 
     switch (projectConfig.getBaseGameVersion())
     {
@@ -515,6 +518,7 @@ bool MainWindow::openProject(QString dir) {
         editor->project = new Project(this);
         QObject::connect(editor->project, &Project::reloadProject, this, &MainWindow::on_action_Reload_Project_triggered);
         QObject::connect(editor->project, &Project::mapCacheCleared, this, &MainWindow::onMapCacheCleared);
+        QObject::connect(editor->project, &Project::disableWildEncountersUI, [this]() { this->setWildEncountersUIEnabled(false); });
         QObject::connect(editor->project, &Project::uncheckMonitorFilesAction, [this]() { ui->actionMonitor_Project_Files->setChecked(false); });
         on_actionMonitor_Project_Files_triggered(porymapConfig.getMonitorFiles());
         editor->project->set_root(dir);

--- a/src/project.cpp
+++ b/src/project.cpp
@@ -1723,8 +1723,12 @@ bool Project::readWildMonData() {
 
     OrderedJson::object wildMonObj;
     if (!parser.tryParseOrderedJsonFile(&wildMonObj, wildMonJsonFilepath)) {
-        logError(QString("Failed to read wild encounters from %1").arg(wildMonJsonFilepath));
-        return false;
+        // Failing to read wild encounters data is not a critical error, just disable the
+        // encounter editor and log a warning in case the user intended to have this data.
+        projectConfig.setEncounterJsonActive(false);
+        emit disableWildEncountersUI();
+        logWarn(QString("Failed to read wild encounters from %1").arg(wildMonJsonFilepath));
+        return true;
     }
 
     for (OrderedJson subObjectRef : wildMonObj["wild_encounter_groups"].array_items()) {


### PR DESCRIPTION
`use_encounter_json` defaults to `1` in the config for newly opened projects, so if a user opens a project which does not use JSON for encounter data it will fail to open. Now it will launch the project and set `use_encounter_json` to `0` instead.

As an aside, the logging in this case is probably excessive. For example, the following is logged if `use_encounter_json` is set to `1` in the config and `wild_encounters.json` doesn't exist:

```
<date> [ERROR] Could not open '<root>/src/data/wild_encounters.json': No such file or directory
<date> [ERROR] Error: Failed to parse json file <root>/src/data/wild_encounters.json: unexpected end of input
<date> [WARN] Failed to read wild encounters from <root>/src/data/wild_encounters.json
```