### PR TITLE
Fix missing music when importing from Advance Map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The **"Breaking Changes"** listed below are changes that have been made in the d
 - Fix cursor tile and player view outlines exiting map bounds while painting.
 - Fix cursor tile and player view outlines not updating immediately when toggled in Collision view.
 - Fix selected space not updating while painting in Collision view.
+- Fix the map music dropdown being empty when importing a map from Advance Map.
 
 ## [4.5.0] - 2021-12-26
 ### Added

--- a/src/ui/newmappopup.cpp
+++ b/src/ui/newmappopup.cpp
@@ -156,6 +156,8 @@ void NewMapPopup::setDefaultValuesImportMap(MapLayout *mapLayout) {
     ui->comboBox_NewMap_Group->addItems(project->groupNames);
     ui->comboBox_NewMap_Group->setCurrentText(project->groupNames.at(0));
 
+    ui->comboBox_Song->addItems(project->songNames);
+
     ui->spinBox_NewMap_Width->setValue(mapLayout->width.toInt(nullptr, 0));
     ui->spinBox_NewMap_Height->setValue(mapLayout->height.toInt(nullptr, 0));
     ui->comboBox_NewMap_Primary_Tileset->setCurrentText(mapLayout->tileset_primary_label);


### PR DESCRIPTION
Closes #433. A couple of related issues I think this bug points out:
- Porymap probably shouldn't allow users to have empty text fields for map header data (song, location, weather, map type, battle scene), either in the new map prompt or when editing the header later.
- mapjson should still output something for empty fields, or error (there's already [an open issue](https://github.com/pret/pokeemerald/issues/1261) for this)
- `setDefaultValues` and `setDefaultValuesImportMap` should probably share more code so mistakes like this are less likely