### PR TITLE
Assume objects with no type field are not clones

### DIFF
--- a/src/project.cpp
+++ b/src/project.cpp
@@ -218,7 +218,7 @@ bool Project::loadMapData(Map* map) {
         QJsonObject event = objectEventsArr[i].toObject();
         // If clone objects are not enabled then no type field is present
         QString type = hasCloneObjects ? event["type"].toString() : "object";
-        if (type == "object") {
+        if (type.isEmpty() || type == "object") {
             Event *object = new Event(event, EventType::Object);
             object->put("map_name", map->name);
             object->put("sprite", event["graphics_id"].toString());


### PR DESCRIPTION
Without this, if someone were to port the "clone object" feature to pokeemerald they'd have to add this field to every object themselves.

This has the additional benefit of not treating all of pokefirered's objects as invalid while waiting for <https://github.com/pret/pokefirered/pull/484> to be merged.