### PR TITLE
Render unused metatile layer as it appears in-game

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The **"Breaking Changes"** listed below are changes that have been made in the d
 - Unused metatile attribute bits that are set are preserved instead of being cleared.
 - The wild encounter editor is automatically disabled if the encounter JSON data cannot be read
 - Overhauled the region map editor, adding support for tilemaps, and significant customization. Also now supports pokefirered.
+- Metatiles are always rendered accurately with 3 layers, and the unused layer is not assumed to be transparent.
 
 ### Fixed
 - Fix cursor tile outline not updating at the end of a dragged selection.

--- a/src/mainwindow_scriptapi.cpp
+++ b/src/mainwindow_scriptapi.cpp
@@ -794,6 +794,23 @@ QList<int> MainWindow::getMetatileLayerOrder() {
 void MainWindow::setMetatileLayerOrder(QList<int> order) {
     if (!this->editor || !this->editor->map)
         return;
+
+    const int numLayers = 3;
+    int size = order.size();
+    if (size < numLayers) {
+        logError(QString("Metatile layer order has insufficient elements (%1), needs at least %2.").arg(size).arg(numLayers));
+        return;
+    }
+    bool invalid = false;
+    for (int i = 0; i < numLayers; i++) {
+        int layer = order.at(i);
+        if (layer < 0 || layer >= numLayers) {
+            logError(QString("'%1' is not a valid metatile layer order value, must be in range 0-%2.").arg(layer).arg(numLayers - 1));
+            invalid = true;
+        }
+    }
+    if (invalid) return;
+
     this->editor->map->metatileLayerOrder = order;
     this->refreshAfterPalettePreviewChange();
 }

--- a/src/ui/imageproviders.cpp
+++ b/src/ui/imageproviders.cpp
@@ -56,7 +56,7 @@ QImage getMetatileImage(
     for (int layer = 0; layer < numLayers; layer++)
     for (int y = 0; y < 2; y++)
     for (int x = 0; x < 2; x++) {
-        int l = layerOrder.size() >= numLayers ? (layerOrder[layer] % numLayers) : layer;
+        int l = layerOrder.size() >= numLayers ? layerOrder[layer] : layer;
         int bottomLayer = layerOrder.size() >= numLayers ? layerOrder[0] : 0;
 
         // Get the tile to render next


### PR DESCRIPTION
Fixes #403 

If we really care about it, this layer calculation:

```c
int l = layerOrder.size() >= numLayers ? (layerOrder[layer] % numLayers) : layer;
int bottomLayer = layerOrder.size() >= numLayers ? layerOrder[0] : 0;
```
could also technically be in the outer loop, since it doesn't depend on x/y 