### PR TITLE
Fix API crashes on bad palette ids / tile numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ The **"Breaking Changes"** listed below are changes that have been made in the d
 - Fix selected space not updating while painting in Collision view.
 - Fix the map music dropdown being empty when importing a map from Advance Map.
 - Fixed a bug where saving the tileset editor would reselect the main editor's first selected metatile.
+- Fix crashes / unexpected behavior if certain scripting API functions are given invalid palette or tile numbers.
 
 ## [4.5.0] - 2021-12-26
 ### Added

--- a/include/core/tile.h
+++ b/include/core/tile.h
@@ -18,6 +18,7 @@ public:
     int palette;
 
     uint16_t rawValue() const;
+    void sanitize();
 
     static int getIndexInTileset(int);
 };

--- a/src/core/tile.cpp
+++ b/src/core/tile.cpp
@@ -30,6 +30,17 @@ uint16_t Tile::rawValue() const {
          | ((this->palette & 0xF) << 12));
 }
 
+void Tile::sanitize() {
+    if (tileId < 0 || tileId >= Project::getNumTilesTotal()) {
+        logWarn(QString("Resetting tile's invalid tile id '%1' to 0.").arg(tileId));
+        tileId = 0;
+    }
+    if (palette < 0 || palette >= Project::getNumPalettesTotal()) {
+        logWarn(QString("Resetting tile's invalid palette id '%1' to 0.").arg(palette));
+        palette = 0;
+    }
+}
+
 int Tile::getIndexInTileset(int tileId) {
     if (tileId < Project::getNumTilesPrimary()) {
         return tileId;

--- a/src/core/tileset.cpp
+++ b/src/core/tileset.cpp
@@ -120,6 +120,12 @@ QList<QRgb> Tileset::getPalette(int paletteId, Tileset *primaryTileset, Tileset 
             ? primaryTileset
             : secondaryTileset;
     auto palettes = useTruePalettes ? tileset->palettes : tileset->palettePreviews;
+
+    if (paletteId < 0 || paletteId >= palettes.length()){
+        logError(QString("Invalid tileset palette id '%1' requested.").arg(paletteId));
+        return paletteTable;
+    }
+
     for (int i = 0; i < palettes.at(paletteId).length(); i++) {
         paletteTable.append(palettes.at(paletteId).at(i));
     }

--- a/src/mainwindow_scriptapi.cpp
+++ b/src/mainwindow_scriptapi.cpp
@@ -983,8 +983,11 @@ void MainWindow::setMetatileTiles(int metatileId, QJSValue tilesObj, int tileSta
     // Write to metatile using as many of the given Tiles as possible
     int numTileObjs = qMin(tilesObj.property("length").toInt(), numTiles);
     int i = 0;
-    for (; i < numTileObjs; i++, tileStart++)
-        metatile->tiles[tileStart] = Scripting::toTile(tilesObj.property(i));
+    for (; i < numTileObjs; i++, tileStart++) {
+        Tile tile = Scripting::toTile(tilesObj.property(i));
+        tile.sanitize();
+        metatile->tiles[tileStart] = tile;
+    }
 
     // Fill remainder of specified length with empty Tiles
     for (; i < numTiles; i++, tileStart++)
@@ -1003,6 +1006,7 @@ void MainWindow::setMetatileTiles(int metatileId, int tileId, bool xflip, bool y
 
     // Write to metatile using Tiles of the specified value
     Tile tile = Tile(tileId, xflip, yflip, palette);
+    tile.sanitize();
     for (int i = tileStart; i <= tileEnd; i++)
         metatile->tiles[i] = tile;
 

--- a/src/scripting.cpp
+++ b/src/scripting.cpp
@@ -239,17 +239,17 @@ QJSValue Scripting::position(int x, int y) {
 }
 
 Tile Scripting::toTile(QJSValue obj) {
-    if (!obj.hasProperty("tileId")
-     || !obj.hasProperty("xflip")
-     || !obj.hasProperty("yflip")
-     || !obj.hasProperty("palette")) {
-        return Tile();
-    }
     Tile tile = Tile();
-    tile.tileId = obj.property("tileId").toInt();
-    tile.xflip = obj.property("xflip").toBool();
-    tile.yflip = obj.property("yflip").toBool();
-    tile.palette = obj.property("palette").toInt();
+
+    if (obj.hasProperty("tileId"))
+        tile.tileId = obj.property("tileId").toInt();
+    if (obj.hasProperty("xflip"))
+        tile.xflip = obj.property("xflip").toBool();
+    if (obj.hasProperty("yflip"))
+        tile.yflip = obj.property("yflip").toBool();
+    if (obj.hasProperty("palette"))
+        tile.palette = obj.property("palette").toInt();
+
     return tile;
 }
 

--- a/src/ui/overlay.cpp
+++ b/src/ui/overlay.cpp
@@ -26,9 +26,11 @@ void OverlayImage::render(QPainter *painter, int x, int y) {
 void Overlay::renderItems(QPainter *painter) {
     if (this->hidden) return;
 
+    qreal oldOpacity = painter->opacity();
     painter->setOpacity(this->opacity);
     for (auto item : this->items)
         item->render(painter, this->x, this->y);
+    painter->setOpacity(oldOpacity);
 }
 
 void Overlay::clearItems() {


### PR DESCRIPTION
The scripting API functions `createImage`, `addTileImage`, and both versions of `setMetatileTile` and `setMetatileTiles` can crash Porymap or give unexpected behavior if given a bad palette or tile number.