### PR TITLE
Various minor API improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,17 +12,17 @@ The **"Breaking Changes"** listed below are changes that have been made in the d
 
 ### Added
 - Add Copy/Paste for metatiles in the Tileset Editor.
-- Add new features to the scripting API, including the ability to set overlay opacity, get/set map header properties, read tile pixel data, and set blocks using a raw value.
+- Add new features to the scripting API, including the ability to set overlay opacity, get/set map header properties, read tile pixel data, and set blocks or metatile attributes using a raw value.
 - Add button to copy the full metatile label to the clipboard in the Tileset Editor.
 - Add option to not open the most recent project on launch.
 - Add color picker to palette editor for taking colors from the screen.
 
 ### Changed
+- Overhauled the region map editor, adding support for tilemaps, and significant customization. Also now supports pokefirered.
 - If an object event is inanimate, it will always render using its first frame.
 - Only log "Unknown custom script function" when a registered script function is not present in any script.
 - Unused metatile attribute bits that are set are preserved instead of being cleared.
 - The wild encounter editor is automatically disabled if the encounter JSON data cannot be read
-- Overhauled the region map editor, adding support for tilemaps, and significant customization. Also now supports pokefirered.
 - Metatiles are always rendered accurately with 3 layers, and the unused layer is not assumed to be transparent.
 - `object_event_graphics_info.h` can now be parsed correctly if it uses structs with attributes.
 - Palette editor ui is updated a bit to allow hex and rgb value input.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ The **"Breaking Changes"** listed below are changes that have been made in the d
 - Fix collision values of 2 or 3 not rendering properly.
 - Fix the map music dropdown being empty when importing a map from Advance Map.
 - Fixed a bug where saving the tileset editor would reselect the main editor's first selected metatile.
+- Fix crashes / unexpected behavior if certain scripting API functions are given invalid palette or tile numbers.
 
 ## [4.5.0] - 2021-12-26
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,7 @@ The **"Breaking Changes"** listed below are changes that have been made in the d
 
 ### Added
 - Add Copy/Paste for metatiles in the Tileset Editor.
-- Add ability to set the opacity of the scripting overlay.
-- Add ability to get/set map header properties and read tile pixel data via the API.
+- Add new features to the scripting API, including the ability to set overlay opacity, get/set map header properties, read tile pixel data, and set blocks using a raw value.
 - Add button to copy the full metatile label to the clipboard in the Tileset Editor.
 - Add option to not open the most recent project on launch.
 - Add color picker to palette editor for taking colors from the screen.
@@ -33,6 +32,7 @@ The **"Breaking Changes"** listed below are changes that have been made in the d
 - Fix cursor tile and player view outlines exiting map bounds while painting.
 - Fix cursor tile and player view outlines not updating immediately when toggled in Collision view.
 - Fix selected space not updating while painting in Collision view.
+- Fix collision values of 2 or 3 not rendering properly.
 - Fix the map music dropdown being empty when importing a map from Advance Map.
 - Fixed a bug where saving the tileset editor would reselect the main editor's first selected metatile.
 

--- a/docsrc/manual/scripting-capabilities.rst
+++ b/docsrc/manual/scripting-capabilities.rst
@@ -190,8 +190,18 @@ The following functions are related to editing the map's blocks or retrieving in
    :param number x: x coordinate of the block
    :param number y: y coordinate of the block
    :param number metatileId: the metatile id of the block
-   :param number collision: the collision of the block (``0`` = passable, ``1`` = impassable)
+   :param number collision: the collision of the block (``0`` = passable, ``1-3`` = impassable)
    :param number elevation: the elevation of the block
+   :param boolean forceRedraw: Force the map view to refresh. Defaults to ``true``. Redrawing the map view is expensive, so set to ``false`` when making many consecutive map edits, and then redraw the map once using ``map.redraw()``.
+   :param boolean commitChanges: Commit the changes to the map's edit/undo history. Defaults to ``true``. When making many related map edits, it can be useful to set this to ``false``, and then commit all of them together with ``map.commit()``.
+
+.. js:function:: map.setBlock(x, y, rawValue, forceRedraw = true, commitChanges = true)
+
+   Sets a block in the currently-opened map. This is an overloaded function that takes the raw value of a block instead of each of the block's properties individually.
+
+   :param number x: x coordinate of the block
+   :param number y: y coordinate of the block
+   :param number rawValue: the 16 bit value of the block. Bits ``0-9`` will be the metatile id, bits ``10-11`` will be the collision, and bits ``12-15`` will be the elevation.
    :param boolean forceRedraw: Force the map view to refresh. Defaults to ``true``. Redrawing the map view is expensive, so set to ``false`` when making many consecutive map edits, and then redraw the map once using ``map.redraw()``.
    :param boolean commitChanges: Commit the changes to the map's edit/undo history. Defaults to ``true``. When making many related map edits, it can be useful to set this to ``false``, and then commit all of them together with ``map.commit()``.
 
@@ -215,7 +225,7 @@ The following functions are related to editing the map's blocks or retrieving in
 
 .. js:function:: map.getCollision(x, y)
 
-   Gets the collision of a block in the currently-opened map. (``0`` = passable, ``1`` = impassable)
+   Gets the collision of a block in the currently-opened map. (``0`` = passable, ``1-3`` = impassable)
 
    :param number x: x coordinate of the block
    :param number y: y coordinate of the block
@@ -223,7 +233,7 @@ The following functions are related to editing the map's blocks or retrieving in
 
 .. js:function:: map.setCollision(x, y, collision, forceRedraw = true, commitChanges = true)
 
-   Sets the collision of a block in the currently-opened map. (``0`` = passable, ``1`` = impassable)
+   Sets the collision of a block in the currently-opened map. (``0`` = passable, ``1-3`` = impassable)
 
    :param number x: x coordinate of the block
    :param number y: y coordinate of the block

--- a/docsrc/manual/scripting-capabilities.rst
+++ b/docsrc/manual/scripting-capabilities.rst
@@ -1124,7 +1124,7 @@ The following functions are related to tilesets and how they are rendered. The f
    :param number tileEnd: index of the last tile to set. Defaults to ``-1`` (the last tile)
    :param boolean forceRedraw: Force the map view to refresh. Defaults to ``true``. Redrawing the map view is expensive, so set to ``false`` when making many consecutive map edits, and then redraw the map once using ``map.redraw()``.
 
-..js:function:: map.getTilePixels(tileId)
+.. js:function:: map.getTilePixels(tileId)
 
    Gets the pixel data for the specified tile. The pixel data is an array of indexes indicating which palette color each pixel uses. Tiles are 8x8, so the pixel array will be 64 elements long.
 

--- a/docsrc/manual/scripting-capabilities.rst
+++ b/docsrc/manual/scripting-capabilities.rst
@@ -1054,6 +1054,22 @@ The following functions are related to tilesets and how they are rendered. The f
    :param number metatileId: id of target metatile
    :param number behavior: the behavior
 
+.. js:function:: map.getMetatileAttributes(metatileId)
+
+   Gets the raw attributes value for the specified metatile.
+
+   :param number metatileId: id of target metatile
+   :returns number: the raw attributes value
+
+.. js:function:: map.setMetatileAttributes(metatileId, attributes)
+
+   Sets the raw attributes value for the specified metatile.
+   
+   **Warning:** This function writes directly to the tileset. There is no undo for this. Porymap will not limit the value of existing attributes to their usual range.
+
+   :param number metatileId: id of target metatile
+   :param number attributes: the raw attributes value
+
 .. js:function:: map.getMetatileTile(metatileId, tileIndex)
 
    Gets the tile at the specified index of the metatile.

--- a/include/core/tile.h
+++ b/include/core/tile.h
@@ -18,6 +18,7 @@ public:
     int palette;
 
     uint16_t rawValue() const;
+    void sanitize();
 
     static int getIndexInTileset(int);
 };

--- a/include/core/tile.h
+++ b/include/core/tile.h
@@ -8,17 +8,15 @@ class Tile
 {
 public:
     Tile();
-    Tile(int tileId, bool xflip, bool yflip, int palette);
+    Tile(uint16_t tileId, uint16_t xflip, uint16_t yflip, uint16_t palette);
     Tile(uint16_t raw);
 
 public:
-    int tileId;
-    bool xflip;
-    bool yflip;
-    int palette;
-
+    uint16_t tileId:10;
+    uint16_t xflip:1;
+    uint16_t yflip:1;
+    uint16_t palette:4;
     uint16_t rawValue() const;
-    void sanitize();
 
     static int getIndexInTileset(int);
 };

--- a/include/mainwindow.h
+++ b/include/mainwindow.h
@@ -46,7 +46,8 @@ public:
     Q_INVOKABLE QJSValue getBlock(int x, int y);
     void tryRedrawMapArea(bool forceRedraw);
     void tryCommitMapChanges(bool commitChanges);
-    Q_INVOKABLE void setBlock(int x, int y, int tile, int collision, int elevation, bool forceRedraw = true, bool commitChanges = true);
+    Q_INVOKABLE void setBlock(int x, int y, int metatileId, int collision, int elevation, bool forceRedraw = true, bool commitChanges = true);
+    Q_INVOKABLE void setBlock(int x, int y, int rawValue, bool forceRedraw = true, bool commitChanges = true);
     Q_INVOKABLE void setBlocksFromSelection(int x, int y, bool forceRedraw = true, bool commitChanges = true);
     Q_INVOKABLE int getMetatileId(int x, int y);
     Q_INVOKABLE void setMetatileId(int x, int y, int metatileId, bool forceRedraw = true, bool commitChanges = true);

--- a/include/mainwindow.h
+++ b/include/mainwindow.h
@@ -167,6 +167,8 @@ public:
     Q_INVOKABLE void setMetatileTerrainType(int metatileId, int terrainType);
     Q_INVOKABLE int getMetatileBehavior(int metatileId);
     Q_INVOKABLE void setMetatileBehavior(int metatileId, int behavior);
+    Q_INVOKABLE int getMetatileAttributes(int metatileId);
+    Q_INVOKABLE void setMetatileAttributes(int metatileId, int attributes);
     Q_INVOKABLE QJSValue getMetatileTile(int metatileId, int tileIndex);
     Q_INVOKABLE void setMetatileTile(int metatileId, int tileIndex, int tileId, bool xflip, bool yflip, int palette, bool forceRedraw = true);
     Q_INVOKABLE void setMetatileTile(int metatileId, int tileIndex, QJSValue tileObj, bool forceRedraw = true);

--- a/src/core/map.cpp
+++ b/src/core/map.cpp
@@ -344,6 +344,7 @@ bool Map::getBlock(int x, int y, Block *out) {
 }
 
 void Map::setBlock(int x, int y, Block block, bool enableScriptCallback) {
+    if (!isWithinBounds(x, y)) return;
     int i = y * getWidth() + x;
     if (i < layout->blockdata.size()) {
         Block prevBlock = layout->blockdata.at(i);

--- a/src/core/tile.cpp
+++ b/src/core/tile.cpp
@@ -30,6 +30,17 @@ uint16_t Tile::rawValue() const {
          | ((this->palette & 0xF) << 12));
 }
 
+void Tile::sanitize() {
+    if (tileId < 0 || tileId >= Project::getNumTilesTotal()) {
+        logWarn(QString("Resetting tile's invalid tile id '%1' to 0.").arg(tileId));
+        tileId = 0;
+    }
+    if (palette < 0 || palette >= Project::getNumPalettesTotal()) {
+        logWarn(QString("Resetting tile's invalid palette id '%1' to 0.").arg(palette));
+        palette = 0;
+    }
+}
+
 int Tile::getIndexInTileset(int tileId) {
     if (tileId < Project::getNumTilesPrimary()) {
         return tileId;

--- a/src/core/tile.cpp
+++ b/src/core/tile.cpp
@@ -8,7 +8,7 @@
         palette(0)
     {  }
 
- Tile::Tile(int tileId, bool xflip, bool yflip, int palette) :
+ Tile::Tile(uint16_t tileId, uint16_t xflip, uint16_t yflip, uint16_t palette) :
         tileId(tileId),
         xflip(xflip),
         yflip(yflip),
@@ -28,17 +28,6 @@ uint16_t Tile::rawValue() const {
          | ((this->xflip & 1) << 10)
          | ((this->yflip & 1) << 11)
          | ((this->palette & 0xF) << 12));
-}
-
-void Tile::sanitize() {
-    if (tileId < 0 || tileId >= Project::getNumTilesTotal()) {
-        logWarn(QString("Resetting tile's invalid tile id '%1' to 0.").arg(tileId));
-        tileId = 0;
-    }
-    if (palette < 0 || palette >= Project::getNumPalettesTotal()) {
-        logWarn(QString("Resetting tile's invalid palette id '%1' to 0.").arg(palette));
-        palette = 0;
-    }
 }
 
 int Tile::getIndexInTileset(int tileId) {

--- a/src/core/tileset.cpp
+++ b/src/core/tileset.cpp
@@ -120,6 +120,12 @@ QList<QRgb> Tileset::getPalette(int paletteId, Tileset *primaryTileset, Tileset 
             ? primaryTileset
             : secondaryTileset;
     auto palettes = useTruePalettes ? tileset->palettes : tileset->palettePreviews;
+
+    if (paletteId < 0 || paletteId >= palettes.length()){
+        logError(QString("Invalid tileset palette id '%1' requested.").arg(paletteId));
+        return paletteTable;
+    }
+
     for (int i = 0; i < palettes.at(paletteId).length(); i++) {
         paletteTable.append(palettes.at(paletteId).at(i));
     }

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -1075,7 +1075,7 @@ QString Editor::getMovementPermissionText(uint16_t collision, uint16_t elevation
     } else if (collision == 0) {
         message = QString("Collision: Passable, Elevation: %1").arg(elevation);
     } else {
-        message = QString("Collision: Impassable, Elevation: %1").arg(elevation);
+        message = QString("Collision: Impassable (%1), Elevation: %2").arg(collision).arg(elevation);
     }
     return message;
 }

--- a/src/mainwindow_scriptapi.cpp
+++ b/src/mainwindow_scriptapi.cpp
@@ -961,6 +961,22 @@ void MainWindow::setMetatileBehavior(int metatileId, int behavior) {
     this->saveMetatileAttributesByMetatileId(metatileId);
 }
 
+int MainWindow::getMetatileAttributes(int metatileId) {
+    Metatile * metatile = this->getMetatile(metatileId);
+    if (!metatile)
+        return -1;
+    return metatile->getAttributes(projectConfig.getBaseGameVersion());
+}
+
+void MainWindow::setMetatileAttributes(int metatileId, int attributes) {
+    Metatile * metatile = this->getMetatile(metatileId);
+    uint32_t u_attributes = static_cast<uint32_t>(attributes);
+    if (!metatile)
+        return;
+    metatile->setAttributes(u_attributes, projectConfig.getBaseGameVersion());
+    this->saveMetatileAttributesByMetatileId(metatileId);
+}
+
 int MainWindow::calculateTileBounds(int * tileStart, int * tileEnd) {
     int maxNumTiles = this->getNumTilesInMetatile();
     if (*tileEnd >= maxNumTiles || *tileEnd < 0)

--- a/src/mainwindow_scriptapi.cpp
+++ b/src/mainwindow_scriptapi.cpp
@@ -991,11 +991,8 @@ void MainWindow::setMetatileTiles(int metatileId, QJSValue tilesObj, int tileSta
     // Write to metatile using as many of the given Tiles as possible
     int numTileObjs = qMin(tilesObj.property("length").toInt(), numTiles);
     int i = 0;
-    for (; i < numTileObjs; i++, tileStart++) {
-        Tile tile = Scripting::toTile(tilesObj.property(i));
-        tile.sanitize();
-        metatile->tiles[tileStart] = tile;
-    }
+    for (; i < numTileObjs; i++, tileStart++)
+        metatile->tiles[tileStart] = Scripting::toTile(tilesObj.property(i));
 
     // Fill remainder of specified length with empty Tiles
     for (; i < numTiles; i++, tileStart++)
@@ -1014,7 +1011,6 @@ void MainWindow::setMetatileTiles(int metatileId, int tileId, bool xflip, bool y
 
     // Write to metatile using Tiles of the specified value
     Tile tile = Tile(tileId, xflip, yflip, palette);
-    tile.sanitize();
     for (int i = tileStart; i <= tileEnd; i++)
         metatile->tiles[i] = tile;
 

--- a/src/mainwindow_scriptapi.cpp
+++ b/src/mainwindow_scriptapi.cpp
@@ -991,8 +991,11 @@ void MainWindow::setMetatileTiles(int metatileId, QJSValue tilesObj, int tileSta
     // Write to metatile using as many of the given Tiles as possible
     int numTileObjs = qMin(tilesObj.property("length").toInt(), numTiles);
     int i = 0;
-    for (; i < numTileObjs; i++, tileStart++)
-        metatile->tiles[tileStart] = Scripting::toTile(tilesObj.property(i));
+    for (; i < numTileObjs; i++, tileStart++) {
+        Tile tile = Scripting::toTile(tilesObj.property(i));
+        tile.sanitize();
+        metatile->tiles[tileStart] = tile;
+    }
 
     // Fill remainder of specified length with empty Tiles
     for (; i < numTiles; i++, tileStart++)
@@ -1011,6 +1014,7 @@ void MainWindow::setMetatileTiles(int metatileId, int tileId, bool xflip, bool y
 
     // Write to metatile using Tiles of the specified value
     Tile tile = Tile(tileId, xflip, yflip, palette);
+    tile.sanitize();
     for (int i = tileStart; i <= tileEnd; i++)
         metatile->tiles[i] = tile;
 

--- a/src/mainwindow_scriptapi.cpp
+++ b/src/mainwindow_scriptapi.cpp
@@ -50,10 +50,18 @@ void MainWindow::tryCommitMapChanges(bool commitChanges) {
     }
 }
 
-void MainWindow::setBlock(int x, int y, int tile, int collision, int elevation, bool forceRedraw, bool commitChanges) {
+void MainWindow::setBlock(int x, int y, int metatileId, int collision, int elevation, bool forceRedraw, bool commitChanges) {
     if (!this->editor || !this->editor->map)
         return;
-    this->editor->map->setBlock(x, y, Block(tile, collision, elevation));
+    this->editor->map->setBlock(x, y, Block(metatileId, collision, elevation));
+    this->tryCommitMapChanges(commitChanges);
+    this->tryRedrawMapArea(forceRedraw);
+}
+
+void MainWindow::setBlock(int x, int y, int rawValue, bool forceRedraw, bool commitChanges) {
+    if (!this->editor || !this->editor->map)
+        return;
+    this->editor->map->setBlock(x, y, Block(static_cast<uint16_t>(rawValue)));
     this->tryCommitMapChanges(commitChanges);
     this->tryRedrawMapArea(forceRedraw);
 }

--- a/src/scripting.cpp
+++ b/src/scripting.cpp
@@ -239,17 +239,17 @@ QJSValue Scripting::position(int x, int y) {
 }
 
 Tile Scripting::toTile(QJSValue obj) {
-    if (!obj.hasProperty("tileId")
-     || !obj.hasProperty("xflip")
-     || !obj.hasProperty("yflip")
-     || !obj.hasProperty("palette")) {
-        return Tile();
-    }
     Tile tile = Tile();
-    tile.tileId = obj.property("tileId").toInt();
-    tile.xflip = obj.property("xflip").toBool();
-    tile.yflip = obj.property("yflip").toBool();
-    tile.palette = obj.property("palette").toInt();
+
+    if (obj.hasProperty("tileId"))
+        tile.tileId = obj.property("tileId").toInt();
+    if (obj.hasProperty("xflip"))
+        tile.xflip = obj.property("xflip").toBool();
+    if (obj.hasProperty("yflip"))
+        tile.yflip = obj.property("yflip").toBool();
+    if (obj.hasProperty("palette"))
+        tile.palette = obj.property("palette").toInt();
+
     return tile;
 }
 

--- a/src/ui/imageproviders.cpp
+++ b/src/ui/imageproviders.cpp
@@ -8,7 +8,7 @@ QImage getCollisionMetatileImage(Block block) {
 }
 
 QImage getCollisionMetatileImage(int collision, int elevation) {
-    int x = collision * 16;
+    int x = (collision != 0) * 16;
     int y = elevation * 16;
     QPixmap collisionImage = QPixmap(":/images/collisions.png").copy(x, y, 16, 16);
     return collisionImage.toImage();

--- a/src/ui/imageproviders.cpp
+++ b/src/ui/imageproviders.cpp
@@ -66,13 +66,13 @@ QImage getMetatileImage(
             tile = metatile->tiles.value(tileOffset + (l * 4));
         } else {
             // "Vanilla" metatiles only have 8 tiles, but render 12.
-            // The remaining 4 tiles are rendered either as tile 0 or 0x3014 (invalid) depending on layer type.
+            // The remaining 4 tiles are rendered either as tile 0 or 0x3014 (tile 20, palette 3) depending on layer type.
             switch (layerType)
             {
             default:
             case METATILE_LAYER_MIDDLE_TOP:
                 if (l == 0)
-                    tile = Tile(0x3014, false, false, 0);
+                    tile = Tile(0x3014);
                 else // Tiles are on layers 1 and 2
                     tile = metatile->tiles.value(tileOffset + ((l - 1) * 4));
                 break;

--- a/src/ui/movementpermissionsselector.cpp
+++ b/src/ui/movementpermissionsselector.cpp
@@ -16,7 +16,7 @@ uint16_t MovementPermissionsSelector::getSelectedElevation() {
 }
 
 void MovementPermissionsSelector::select(uint16_t collision, uint16_t elevation) {
-    SelectablePixmapItem::select(collision, elevation, 0, 0);
+    SelectablePixmapItem::select(collision != 0, elevation, 0, 0);
 }
 
 void MovementPermissionsSelector::hoverMoveEvent(QGraphicsSceneHoverEvent *event) {

--- a/src/ui/overlay.cpp
+++ b/src/ui/overlay.cpp
@@ -26,9 +26,11 @@ void OverlayImage::render(QPainter *painter, int x, int y) {
 void Overlay::renderItems(QPainter *painter) {
     if (this->hidden) return;
 
+    qreal oldOpacity = painter->opacity();
     painter->setOpacity(this->opacity);
     for (auto item : this->items)
         item->render(painter, this->x, this->y);
+    painter->setOpacity(oldOpacity);
 }
 
 void Overlay::clearItems() {


### PR DESCRIPTION
- Collision is a 2 bit value, and `setBlock` / `setCollision` allow users to assign any value in this range. Porymap incorrectly renders collisions of 2 or 3 as the entire collision/elevation image. The games treat any nonzero collision value as "impassable," and now so does Porymap.
- Adds an overload of `setBlock` that takes the raw value given by `getBlock` or `onBlockChanged`, so you could more easily for instance disable drawing by doing:
```js
export function onBlockChanged(x, y, prevBlock, newBlock) {
    if (prevBlock.rawValue != newBlock.rawValue)
        map.setBlock(x, y, prevBlock.rawValue);
}
```
- Fixes a bug that allowed negative coordinates in `setBlock`
- The scripting API functions `createImage`, `addTileImage`, and both versions of `setMetatileTile` and `setMetatileTiles` can crash Porymap or give unexpected behavior if given a bad palette or tile number. These are fixed by making tile properties unsigned values of the correct width, and an explicit check in `Tileset::getPalette`.
- Fixes the unused layer of `METATILE_LAYER_MIDDLE_TOP` rendering with an incorrect palette
- Fixes a bug with `map.setOverlayOpacity` that caused some UI elements like the cursor rectangle to also change opacity.
- Adds `map.getMetatileAttributes` and `map.setMetatileAttributes` for reading/writing the raw metatile attributes value (giving users access to the unused attribute bits)