### PR TITLE
Clean up loadTilesetMetatiles

### DIFF
--- a/src/project.cpp
+++ b/src/project.cpp
@@ -1078,8 +1078,8 @@ void Project::saveTilesetMetatiles(Tileset *tileset) {
     QFile metatiles_file(tileset->metatiles_path);
     if (metatiles_file.open(QIODevice::WriteOnly | QIODevice::Truncate)) {
         QByteArray data;
+        int numTiles = projectConfig.getTripleLayerMetatilesEnabled() ? 12 : 8;
         for (Metatile *metatile : tileset->metatiles) {
-            int numTiles = projectConfig.getTripleLayerMetatilesEnabled() ? 12 : 8;
             for (int i = 0; i < numTiles; i++) {
                 uint16_t tile = metatile->tiles.at(i).rawValue();
                 data.append(static_cast<char>(tile));

--- a/src/project.cpp
+++ b/src/project.cpp
@@ -1583,14 +1583,14 @@ void Project::loadTilesetMetatiles(Tileset* tileset) {
     QFile metatiles_file(tileset->metatiles_path);
     if (metatiles_file.open(QIODevice::ReadOnly)) {
         QByteArray data = metatiles_file.readAll();
-        int metatile_data_length = projectConfig.getTripleLayerMetatilesEnabled() ? 24 : 16;
-        int num_metatiles = data.length() / metatile_data_length;
-        int num_layers = projectConfig.getTripleLayerMetatilesEnabled() ? 3 : 2;
+        int tilesPerMetatile = projectConfig.getTripleLayerMetatilesEnabled() ? 12 : 8;
+        int bytesPerMetatile = 2 * tilesPerMetatile;
+        int num_metatiles = data.length() / bytesPerMetatile;
         QList<Metatile*> metatiles;
         for (int i = 0; i < num_metatiles; i++) {
             Metatile *metatile = new Metatile;
-            int index = i * (2 * 4 * num_layers);
-            for (int j = 0; j < 4 * num_layers; j++) {
+            int index = i * bytesPerMetatile;
+            for (int j = 0; j < tilesPerMetatile; j++) {
                 uint16_t tileRaw = static_cast<unsigned char>(data[index++]);
                 tileRaw |= static_cast<unsigned char>(data[index++]) << 8;
                 metatile->tiles.append(Tile(tileRaw));


### PR DESCRIPTION
This is sort of a do-nothing PR, but it was bothering me that `loadTilesetMetatiles` unnecessarily called `getTripleLayerMetatilesEnabled` twice (and for every metatile in `saveTilesetMetatiles`), and had a bunch of raw values without clear meaning.