### PR TITLE
Add scale to API's createImage, add getPorymapVersion

### DIFF
--- a/docsrc/manual/scripting-capabilities.rst
+++ b/docsrc/manual/scripting-capabilities.rst
@@ -1167,6 +1167,12 @@ The following functions are related to settings.
 
    :returns string: ``"pokeruby"``, ``"pokefirered"``, or ``"pokeemerald"``
 
+.. js:function:: map.getPorymapVersion()
+
+   Gets the current version of Porymap (``MAJOR.MINOR.PATCH``).
+
+   :returns {major, minor, patch}: the version object
+
 .. js:function:: map.getCustomScripts()
 
    Gets the list of paths to custom scripts.

--- a/docsrc/manual/scripting-capabilities.rst
+++ b/docsrc/manual/scripting-capabilities.rst
@@ -682,18 +682,18 @@ The following functions are related to an overlay that is drawn on top of the ma
    :param number layer: the layer id. Defaults to ``0``
    :param boolean useCache: whether the image should be saved/loaded using the cache. Defaults to ``true``. Reading images from a file is slow. Setting ``useCache`` to ``true`` will save the image to memory so that the next time the filepath is encountered the image can be loaded from memory rather than the file.
 
-.. js:function:: map.createImage(x, y, filepath, width = -1, height = -1, offset = 0, xflip = false, yflip = false, paletteId = -1, setTransparency = false, layer = 0, useCache = true)
+.. js:function:: map.createImage(x, y, filepath, width = -1, height = -1, offset = 0, hScale = 1, vScale = 1, paletteId = -1, setTransparency = false, layer = 0, useCache = true)
 
    Creates an image item on the specified overlay layer. This differs from ``map.addImage`` by allowing the new image to be a transformation of the image file.
 
    :param number x: the x pixel coordinate of the image's top-left corner (relative to the layer's position)
    :param number y: the y pixel coordinate of the image's top-left corner (relative to the layer's position)
    :param string filepath: the image's filepath
-   :param number width: the image width. If ``-1``, use the full width of the original image. Defaults to ``-1``
-   :param number height: the image height. If ``-1``, use the full height of the original image. Defaults to ``-1``
+   :param number width: the width in pixels of the area to read in the image. If ``-1``, use the full width of the original image. Defaults to ``-1``
+   :param number height: the height in pixels of the area to read in the image. If ``-1``, use the full height of the original image. Defaults to ``-1``
    :param number offset: the pixel offset into the original image where data should be read from. Defaults to ``0``
-   :param boolean xflip: whether the image should be a horizontal flip of the original image. Defaults to ``false``
-   :param boolean yflip: whether the image should be a vertical flip of the original image. Defaults to ``false``
+   :param number hScale: the horizontal scale for the image. Negative values will be a horizontal flip of the original image. Defaults to ``1``
+   :param number vScale: the vertical scale for the image. Negative values will be a vertical flip of the original image. Defaults to ``1``
    :param number paletteId: the id of which currently loaded tileset palette to use for the image. If ``-1``, use the original image's palette. Defaults to ``-1``
    :param boolean setTransparency: whether the color at index 0 should be overwritten with transparent pixels. Defaults to ``false``
    :param number layer: the layer id. Defaults to ``0``

--- a/forms/aboutporymap.ui
+++ b/forms/aboutporymap.ui
@@ -16,7 +16,7 @@
   <widget class="QWidget" name="centralwidget">
    <layout class="QVBoxLayout" name="verticalLayout">
     <item>
-     <widget class="QLabel" name="label">
+     <widget class="QLabel" name="label_Title">
       <property name="font">
        <font>
         <family>Segoe UI</family>
@@ -39,7 +39,7 @@
      </widget>
     </item>
     <item>
-     <widget class="QLabel" name="label_3">
+     <widget class="QLabel" name="label_Version">
       <property name="sizePolicy">
        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
         <horstretch>0</horstretch>
@@ -61,7 +61,7 @@
      </widget>
     </item>
     <item>
-     <widget class="QLabel" name="label_2">
+     <widget class="QLabel" name="label_Description">
       <property name="font">
        <font>
         <family>Segoe UI</family>
@@ -76,7 +76,7 @@
      </widget>
     </item>
     <item>
-     <widget class="QLabel" name="label_4">
+     <widget class="QLabel" name="label_Manual">
       <property name="text">
        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Official Documentation: &lt;a href=&quot;https://huderlem.github.io/porymap/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;https://huderlem.github.io/porymap/&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
       </property>

--- a/include/mainwindow.h
+++ b/include/mainwindow.h
@@ -177,6 +177,7 @@ public:
     Q_INVOKABLE int getNumTilesInMetatile();
     Q_INVOKABLE int getNumMetatileLayers();
     Q_INVOKABLE QString getBaseGameVersion();
+    Q_INVOKABLE QJSValue getPorymapVersion();
     Q_INVOKABLE QList<QString> getCustomScripts();
     Q_INVOKABLE int getMainTab();
     Q_INVOKABLE void setMainTab(int index);

--- a/include/mainwindow.h
+++ b/include/mainwindow.h
@@ -96,7 +96,7 @@ public:
     Q_INVOKABLE void addImage(int x, int y, QString filepath, int layer = 0, bool useCache = true);
     Q_INVOKABLE void createImage(int x, int y, QString filepath,
                                  int width = -1, int height = -1, unsigned offset = 0,
-                                 bool xflip = false, bool yflip = false, int paletteId = -1, bool setTransparency = false,
+                                 qreal hScale = 1, qreal vScale = 1, int paletteId = -1, bool setTransparency = false,
                                  int layer = 0, bool useCache = true);
     Q_INVOKABLE void addTileImage(int x, int y, int tileId, bool xflip, bool yflip, int paletteId, bool setTransparency = false, int layer = 0);
     Q_INVOKABLE void addTileImage(int x, int y, QJSValue tileObj, bool setTransparency = false, int layer = 0);

--- a/include/scripting.h
+++ b/include/scripting.h
@@ -29,6 +29,7 @@ public:
     static QJSValue fromBlock(Block block);
     static QJSValue fromTile(Tile tile);
     static Tile toTile(QJSValue obj);
+    static QJSValue version(QList<int> versionNums);
     static QJSValue dimensions(int width, int height);
     static QJSValue position(int x, int y);
     static QJSEngine *getEngine();

--- a/include/ui/aboutporymap.h
+++ b/include/ui/aboutporymap.h
@@ -1,6 +1,8 @@
 #ifndef ABOUTPORYMAP_H
 #define ABOUTPORYMAP_H
 
+#include <QString>
+#include <QRegularExpression>
 #include <QMainWindow>
 
 namespace Ui {
@@ -12,6 +14,7 @@ class AboutPorymap : public QMainWindow
 public:
     explicit AboutPorymap(QWidget *parent = nullptr);
     ~AboutPorymap();
+    QList<int> getVersionNumbers();
 private:
     Ui::AboutPorymap *ui;
 };

--- a/include/ui/overlay.h
+++ b/include/ui/overlay.h
@@ -95,7 +95,7 @@ public:
     void clearItems();
     void addText(QString text, int x, int y, QString color = "#000000", int fontSize = 12);
     void addRect(int x, int y, int width, int height, QString color = "#000000", bool filled = false);
-    bool addImage(int x, int y, QString filepath, bool useCache = true, int width = -1, int height = -1, unsigned offset = 0, bool xflip = false, bool yflip = false, QList<QRgb> palette = QList<QRgb>(), bool setTransparency = false);
+    bool addImage(int x, int y, QString filepath, bool useCache = true, int width = -1, int height = -1, unsigned offset = 0, qreal hScale = 1, qreal vScale = 1, QList<QRgb> palette = QList<QRgb>(), bool setTransparency = false);
     bool addImage(int x, int y, QImage image);
 private:
     QList<OverlayItem*> items;

--- a/src/mainwindow_scriptapi.cpp
+++ b/src/mainwindow_scriptapi.cpp
@@ -4,6 +4,7 @@
 #include "editcommands.h"
 #include "config.h"
 #include "imageproviders.h"
+#include "aboutporymap.h"
 
 QJSValue MainWindow::getBlock(int x, int y) {
     if (!this->editor || !this->editor->map)
@@ -1049,6 +1050,13 @@ int MainWindow::getNumMetatileLayers() {
 
 QString MainWindow::getBaseGameVersion() {
     return projectConfig.getBaseGameVersionString();
+}
+
+QJSValue MainWindow::getPorymapVersion() {
+    AboutPorymap *window = new AboutPorymap(this);
+    QJSValue version = Scripting::version(window->getVersionNumbers());
+    delete window;
+    return version;
 }
 
 QList<QString> MainWindow::getCustomScripts() {

--- a/src/mainwindow_scriptapi.cpp
+++ b/src/mainwindow_scriptapi.cpp
@@ -401,14 +401,14 @@ void MainWindow::addImage(int x, int y, QString filepath, int layer, bool useCac
         this->ui->graphicsView_Map->scene()->update();
 }
 
-void MainWindow::createImage(int x, int y, QString filepath, int width, int height, unsigned offset, bool xflip, bool yflip, int paletteId, bool setTransparency, int layer, bool useCache) {
+void MainWindow::createImage(int x, int y, QString filepath, int width, int height, unsigned offset, qreal hScale, qreal vScale, int paletteId, bool setTransparency, int layer, bool useCache) {
     if (!this->ui || !this->ui->graphicsView_Map || !this->editor || !this->editor->map || !this->editor->map->layout
      || !this->editor->map->layout->tileset_primary || !this->editor->map->layout->tileset_secondary)
         return;
     QList<QRgb> palette;
     if (paletteId != -1)
         palette = Tileset::getPalette(paletteId, this->editor->map->layout->tileset_primary, this->editor->map->layout->tileset_secondary);
-    if (this->ui->graphicsView_Map->getOverlay(layer)->addImage(x, y, filepath, useCache, width, height, offset, xflip, yflip, palette, setTransparency))
+    if (this->ui->graphicsView_Map->getOverlay(layer)->addImage(x, y, filepath, useCache, width, height, offset, hScale, vScale, palette, setTransparency))
         this->ui->graphicsView_Map->scene()->update();
 }
 

--- a/src/scripting.cpp
+++ b/src/scripting.cpp
@@ -238,6 +238,14 @@ QJSValue Scripting::position(int x, int y) {
     return obj;
 }
 
+QJSValue Scripting::version(QList<int> versionNums) {
+    QJSValue obj = instance->engine->newObject();
+    obj.setProperty("major", versionNums.at(0));
+    obj.setProperty("minor", versionNums.at(1));
+    obj.setProperty("patch", versionNums.at(2));
+    return obj;
+}
+
 Tile Scripting::toTile(QJSValue obj) {
     if (!obj.hasProperty("tileId")
      || !obj.hasProperty("xflip")

--- a/src/ui/aboutporymap.cpp
+++ b/src/ui/aboutporymap.cpp
@@ -12,3 +12,14 @@ AboutPorymap::~AboutPorymap()
 {
     delete ui;
 }
+
+// Returns the Porymap version number as a list of ints with the order {major, minor, patch}
+QList<int> AboutPorymap::getVersionNumbers()
+{
+    // Get the version string "#.#.#"
+    QRegularExpression regex("Version (\\d+)\\.(\\d+)\\.(\\d+)");
+    QRegularExpressionMatch match = regex.match(ui->label_Version->text());
+    if (!match.hasMatch())
+        return QList<int>({0, 0, 0});
+    return QList<int>({match.captured(1).toInt(), match.captured(2).toInt(), match.captured(3).toInt()});
+}

--- a/src/ui/overlay.cpp
+++ b/src/ui/overlay.cpp
@@ -96,7 +96,7 @@ void Overlay::addRect(int x, int y, int width, int height, QString color, bool f
     this->items.append(new OverlayRect(x, y, width, height, QColor(color), filled));
 }
 
-bool Overlay::addImage(int x, int y, QString filepath, bool useCache, int width, int height, unsigned offset, bool xflip, bool yflip, QList<QRgb> palette, bool setTransparency) {
+bool Overlay::addImage(int x, int y, QString filepath, bool useCache, int width, int height, unsigned offset, qreal hScale, qreal vScale, QList<QRgb> palette, bool setTransparency) {
     QImage image = useCache ? Scripting::getImage(filepath) : QImage(filepath);
     if (image.isNull()) {
         logError(QString("Failed to load image '%1'").arg(filepath));
@@ -124,8 +124,8 @@ bool Overlay::addImage(int x, int y, QString filepath, bool useCache, int width,
     if (width != fullWidth || height != fullHeight)
         image = image.copy(offset % fullWidth, offset / fullWidth, width, height);
 
-    if (xflip || yflip)
-        image = image.transformed(QTransform().scale(xflip ? -1 : 1, yflip ? -1 : 1));
+    if (hScale != 1 || vScale != 1)
+        image = image.transformed(QTransform().scale(hScale, vScale));
 
     for (int i = 0; i < palette.size(); i++)
         image.setColor(i, palette.at(i));


### PR DESCRIPTION
Replaces the boolean arguments `xflip` and `yflip` in `createImage` with arguments for horizontal and vertical scale. This is a breaking change for the scripting API.

To help with future breaking changes this also adds `getPorymapVersion` to the API. I'm not happy with how it reads the version (by invisibly creating an "About" window and reading it from the UI text), feel free to change that. Test script: https://mystb.in/SpamJourneyAlloy

As with the last PR, skipped the changelog for now to avoid conflicts.