### PR TITLE
Add new map config options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The **"Breaking Changes"** listed below are changes that have been made in the d
 - Add new features to the scripting API, including the ability to display message boxes and user input windows, set overlay opacity, get/set map header properties, read tile pixel data, and set blocks or metatile attributes using a raw value.
 - Add button to copy the full metatile label to the clipboard in the Tileset Editor.
 - Add option to not open the most recent project on launch.
+- Add options for customizing how new maps are filled
 - Add color picker to palette editor for taking colors from the screen.
 
 ### Changed
@@ -39,6 +40,7 @@ The **"Breaking Changes"** listed below are changes that have been made in the d
 - Fix object events added by pasting ignoring the map event limit.
 - Fixed a bug where saving the tileset editor would reselect the main editor's first selected metatile.
 - Fix crashes / unexpected behavior if certain scripting API functions are given invalid palette or tile numbers.
+- Silence unnecessary errors about `SECRET_BASE_GROUP` when parsing `secret_bases.h`.
 
 ## [4.5.0] - 2021-12-26
 ### Added

--- a/docsrc/manual/settings-and-options.rst
+++ b/docsrc/manual/settings-and-options.rst
@@ -47,6 +47,9 @@ determined by this file.
    ``enable_floor_number``, 1 if ``pokefirered``, project, yes, Adds ``Floor Number`` to map headers
    ``create_map_text_file``, 1 if not ``pokeemerald``, project, yes, A ``text.inc`` or ``text.pory`` file will be created for any new map
    ``enable_triple_layer_metatiles``, 0, project, yes, Enables triple-layer metatiles (See https://github.com/pret/pokeemerald/wiki/Triple-layer-metatiles)
+   ``new_map_metatile``, 1, project, yes, The metatile id that will be used to fill new maps
+   ``new_map_elevation``, 3, project, yes, The elevation that will be used to fill new maps
+   ``new_map_border_metatiles``, "``468,469,476,477`` or ``20,21,28,29``", project, yes, The list of metatile ids that will be used to fill the 2x2 border of new maps
    ``custom_scripts``, , project, yes, A list of script files to load into the scripting engine
    ``prefabs_filepath``, ``<project_root>/prefabs.json``, project, yes, The filepath containing prefab JSON data
 

--- a/docsrc/manual/settings-and-options.rst
+++ b/docsrc/manual/settings-and-options.rst
@@ -30,7 +30,6 @@ determined by this file.
    ``show_player_view``, 0, global, yes, Display a rectangle for the GBA screen radius
    ``show_cursor_tile``, 0, global, yes, Display a rectangle around the hovered metatile(s)
    ``monitor_files``, 1, global, yes, Whether porymap will monitor changes to project files
-   ``region_map_dimensions``, 32x20, global, yes, The dimensions of the region map tilemap
    ``theme``, default, global, yes, The color theme for porymap windows and widgets
    ``text_editor_goto_line``, , global, yes, The command that will be executed when clicking the button next the ``Script`` combo-box.
    ``text_editor_open_directory``, , global, yes, The command that will be executed when clicking ``Open Project in Text Editor``.

--- a/include/config.h
+++ b/include/config.h
@@ -9,6 +9,10 @@
 #include <QKeySequence>
 #include <QMultiMap>
 
+// In both versions the default new map border is a generic tree
+#define DEFAULT_BORDER_RSE (QList<int>{468, 469, 476, 477})
+#define DEFAULT_BORDER_FRLG (QList<int>{20, 21, 28, 29})
+
 enum MapSortOrder {
     Group   =  0,
     Area    =  1,
@@ -28,7 +32,8 @@ protected:
     virtual QMap<QString, QString> getKeyValueMap() = 0;
     virtual void onNewConfigFileCreated() = 0;
     virtual void setUnreadKeys() = 0;
-    void setConfigBool(QString key, bool * field, QString value);
+    bool getConfigBool(QString key, QString value);
+    int getConfigInteger(QString key, QString value, int min, int max, int defaultValue);
 };
 
 class PorymapConfig: public KeyValueConfigBase
@@ -157,6 +162,9 @@ public:
         this->enableFloorNumber = false;
         this->createMapTextFile = false;
         this->enableTripleLayerMetatiles = false;
+        this->newMapMetatileId = 1;
+        this->newMapElevation = 3;
+        this->newMapBorderMetatileIds = DEFAULT_BORDER_RSE;
         this->prefabFilepath = QString();
         this->customScripts.clear();
         this->readKeys.clear();
@@ -192,6 +200,12 @@ public:
     bool getCreateMapTextFileEnabled();
     void setTripleLayerMetatilesEnabled(bool enable);
     bool getTripleLayerMetatilesEnabled();
+    void setNewMapMetatileId(int metatileId);
+    int getNewMapMetatileId();
+    void setNewMapElevation(int elevation);
+    int getNewMapElevation();
+    void setNewMapBorderMetatileIds(QList<int> metatileIds);
+    QList<int> getNewMapBorderMetatileIds();
     void setCustomScripts(QList<QString> scripts);
     QList<QString> getCustomScripts();
     void setPrefabFilepath(QString filepath);
@@ -218,6 +232,9 @@ private:
     bool enableFloorNumber;
     bool createMapTextFile;
     bool enableTripleLayerMetatiles;
+    int newMapMetatileId;
+    int newMapElevation;
+    QList<int> newMapBorderMetatileIds;
     QList<QString> customScripts;
     QStringList readKeys;
     QString prefabFilepath;

--- a/include/config.h
+++ b/include/config.h
@@ -54,7 +54,6 @@ public:
         this->showBorder = true;
         this->showGrid = false;
         this->monitorFiles = true;
-        this->regionMapDimensions = QSize(32, 20);
         this->theme = "default";
         this->textEditorOpenFolder = "";
         this->textEditorGotoLine = "";
@@ -74,7 +73,6 @@ public:
     void setShowBorder(bool enabled);
     void setShowGrid(bool enabled);
     void setMonitorFiles(bool monitor);
-    void setRegionMapDimensions(int width, int height);
     void setTheme(QString theme);
     void setTextEditorOpenFolder(const QString &command);
     void setTextEditorGotoLine(const QString &command);
@@ -93,7 +91,6 @@ public:
     bool getShowBorder();
     bool getShowGrid();
     bool getMonitorFiles();
-    QSize getRegionMapDimensions();
     QString getTheme();
     QString getTextEditorOpenFolder();
     QString getTextEditorGotoLine();
@@ -128,7 +125,6 @@ private:
     bool showBorder;
     bool showGrid;
     bool monitorFiles;
-    QSize regionMapDimensions;
     QString theme;
     QString textEditorOpenFolder;
     QString textEditorGotoLine;

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -1,6 +1,7 @@
 #include "config.h"
 #include "log.h"
 #include "shortcut.h"
+#include "map.h"
 #include <QDir>
 #include <QFile>
 #include <QFormLayout>
@@ -79,12 +80,23 @@ void KeyValueConfigBase::save() {
     }
 }
 
-void KeyValueConfigBase::setConfigBool(QString key, bool * field, QString value) {
+bool KeyValueConfigBase::getConfigBool(QString key, QString value) {
     bool ok;
-    *field = value.toInt(&ok);
-    if (!ok) {
+    int result = value.toInt(&ok);
+    if (!ok || (result != 0 && result != 1)) {
         logWarn(QString("Invalid config value for %1: '%2'. Must be 0 or 1.").arg(key).arg(value));
     }
+    return (result != 0);
+}
+
+int KeyValueConfigBase::getConfigInteger(QString key, QString value, int min, int max, int defaultValue) {
+    bool ok;
+    int result = value.toInt(&ok);
+    if (!ok) {
+        logWarn(QString("Invalid config value for %1: '%2'. Must be an integer.").arg(key).arg(value));
+        return defaultValue;
+    }
+    return qMin(max, qMax(min, result));
 }
 
 const QMap<MapSortOrder, QString> mapSortOrderMap = {
@@ -117,9 +129,9 @@ void PorymapConfig::parseConfigKeyValue(QString key, QString value) {
     if (key == "recent_project") {
         this->recentProject = value;
     } else if (key == "reopen_on_launch") {
-        setConfigBool(key, &this->reopenOnLaunch, value);
+        this->reopenOnLaunch = getConfigBool(key, value);
     } else if (key == "pretty_cursors") {
-        setConfigBool(key, &this->prettyCursors, value);
+        this->prettyCursors = getConfigBool(key, value);
     } else if (key == "map_sort_order") {
         QString sortOrder = value.toLower();
         if (mapSortOrderReverseMap.contains(sortOrder)) {
@@ -137,12 +149,7 @@ void PorymapConfig::parseConfigKeyValue(QString key, QString value) {
     } else if (key == "main_splitter_state") {
         this->mainSplitterState = bytesFromString(value);
     } else if (key == "collision_opacity") {
-        bool ok;
-        this->collisionOpacity = qMax(0, qMin(100, value.toInt(&ok)));
-        if (!ok) {
-            logWarn(QString("Invalid config value for collision_opacity: '%1'. Must be an integer.").arg(value));
-            this->collisionOpacity = 50;
-        }
+        this->collisionOpacity = getConfigInteger(key, value, 0, 100, 50);
     } else if (key == "tileset_editor_geometry") {
         this->tilesetEditorGeometry = bytesFromString(value);
     } else if (key == "tileset_editor_state") {
@@ -156,22 +163,17 @@ void PorymapConfig::parseConfigKeyValue(QString key, QString value) {
     } else if (key == "region_map_editor_state") {
         this->regionMapEditorState = bytesFromString(value);
     } else if (key == "metatiles_zoom") {
-        bool ok;
-        this->metatilesZoom = qMax(10, qMin(100, value.toInt(&ok)));
-        if (!ok) {
-            logWarn(QString("Invalid config value for metatiles_zoom: '%1'. Must be an integer.").arg(value));
-            this->metatilesZoom = 30;
-        }
+        this->metatilesZoom = getConfigInteger(key, value, 10, 100, 30);
     } else if (key == "show_player_view") {
-        setConfigBool(key, &this->showPlayerView, value);
+        this->showPlayerView = getConfigBool(key, value);
     } else if (key == "show_cursor_tile") {
-        setConfigBool(key, &this->showCursorTile, value);
+        this->showCursorTile = getConfigBool(key, value);
     } else if (key == "show_border") {
-        setConfigBool(key, &this->showBorder, value);
+        this->showBorder = getConfigBool(key, value);
     } else if (key == "show_grid") {
-        setConfigBool(key, &this->showGrid, value);
+        this->showGrid = getConfigBool(key, value);
     } else if (key == "monitor_files") {
-        setConfigBool(key, &this->monitorFiles, value);
+        this->monitorFiles = getConfigBool(key, value);
     } else if (key == "region_map_dimensions") {
         bool ok1, ok2;
         QStringList dims = value.split("x");
@@ -471,29 +473,47 @@ void ProjectConfig::parseConfigKeyValue(QString key, QString value) {
     } else if (key == "recent_map") {
         this->recentMap = value;
     } else if (key == "use_encounter_json") {
-        setConfigBool(key, &this->useEncounterJson, value);
+        this->useEncounterJson = getConfigBool(key, value);
     } else if (key == "use_poryscript") {
-        setConfigBool(key, &this->usePoryScript, value);
+        this->usePoryScript = getConfigBool(key, value);
     } else if (key == "use_custom_border_size") {
-        setConfigBool(key, &this->useCustomBorderSize, value);
+        this->useCustomBorderSize = getConfigBool(key, value);
     } else if (key == "enable_event_weather_trigger") {
-        setConfigBool(key, &this->enableEventWeatherTrigger, value);
+        this->enableEventWeatherTrigger = getConfigBool(key, value);
     } else if (key == "enable_event_secret_base") {
-        setConfigBool(key, &this->enableEventSecretBase, value);
+        this->enableEventSecretBase = getConfigBool(key, value);
     } else if (key == "enable_hidden_item_quantity") {
-        setConfigBool(key, &this->enableHiddenItemQuantity, value);
+        this->enableHiddenItemQuantity = getConfigBool(key, value);
     } else if (key == "enable_hidden_item_requires_itemfinder") {
-        setConfigBool(key, &this->enableHiddenItemRequiresItemfinder, value);
+        this->enableHiddenItemRequiresItemfinder = getConfigBool(key, value);
     } else if (key == "enable_heal_location_respawn_data") {
-        setConfigBool(key, &this->enableHealLocationRespawnData, value);
+        this->enableHealLocationRespawnData = getConfigBool(key, value);
     } else if (key == "enable_event_clone_object") {
-        setConfigBool(key, &this->enableEventCloneObject, value);
+        this->enableEventCloneObject = getConfigBool(key, value);
     } else if (key == "enable_floor_number") {
-        setConfigBool(key, &this->enableFloorNumber, value);
+        this->enableFloorNumber = getConfigBool(key, value);
     } else if (key == "create_map_text_file") {
-        setConfigBool(key, &this->createMapTextFile, value);
+        this->createMapTextFile = getConfigBool(key, value);
     } else if (key == "enable_triple_layer_metatiles") {
-        setConfigBool(key, &this->enableTripleLayerMetatiles, value);
+        this->enableTripleLayerMetatiles = getConfigBool(key, value);
+    } else if (key == "new_map_metatile") {
+        this->newMapMetatileId = getConfigInteger(key, value, 0, 1023, 0);
+    } else if (key == "new_map_elevation") {
+        this->newMapElevation = getConfigInteger(key, value, 0, 15, 3);
+    } else if (key == "new_map_border_metatiles") {
+        this->newMapBorderMetatileIds.clear();
+        QList<QString> metatileIds = value.split(",");
+        const int maxSize = DEFAULT_BORDER_WIDTH * DEFAULT_BORDER_HEIGHT;
+        const int size = qMin(metatileIds.size(), maxSize);
+        int i;
+        for (i = 0; i < size; i++) {
+            int metatileId = getConfigInteger(key, metatileIds.at(i), 0, 1023, 0);
+            this->newMapBorderMetatileIds.append(metatileId);
+        }
+        for (; i < maxSize; i++) {
+            // Set any metatiles not provided to 0
+            this->newMapBorderMetatileIds.append(0);
+        }
     } else if (key == "custom_scripts") {
         this->customScripts.clear();
         QList<QString> paths = value.split(",");
@@ -523,6 +543,7 @@ void ProjectConfig::setUnreadKeys() {
     if (!readKeys.contains("enable_event_clone_object")) this->enableEventCloneObject = isPokefirered;
     if (!readKeys.contains("enable_floor_number")) this->enableFloorNumber = isPokefirered;
     if (!readKeys.contains("create_map_text_file")) this->createMapTextFile = (this->baseGameVersion != BaseGameVersion::pokeemerald);
+    if (!readKeys.contains("new_map_border_metatiles")) this->newMapBorderMetatileIds = isPokefirered ? DEFAULT_BORDER_FRLG : DEFAULT_BORDER_RSE;
 }
 
 QMap<QString, QString> ProjectConfig::getKeyValueMap() {
@@ -541,6 +562,12 @@ QMap<QString, QString> ProjectConfig::getKeyValueMap() {
     map.insert("enable_floor_number", QString::number(this->enableFloorNumber));
     map.insert("create_map_text_file", QString::number(this->createMapTextFile));
     map.insert("enable_triple_layer_metatiles", QString::number(this->enableTripleLayerMetatiles));
+    map.insert("new_map_metatile", QString::number(this->newMapMetatileId));
+    map.insert("new_map_elevation", QString::number(this->newMapElevation));
+    QStringList metatiles;
+    for (auto metatile : this->newMapBorderMetatileIds)
+        metatiles << QString::number(metatile);
+    map.insert("new_map_border_metatiles", metatiles.join(","));
     map.insert("custom_scripts", this->customScripts.join(","));
     map.insert("prefabs_filepath", this->prefabFilepath);
     return map;
@@ -585,6 +612,9 @@ void ProjectConfig::onNewConfigFileCreated() {
     this->useEncounterJson = true;
     this->usePoryScript = false;
     this->enableTripleLayerMetatiles = false;
+    this->newMapMetatileId = 1;
+    this->newMapElevation = 3;
+    this->newMapBorderMetatileIds = isPokefirered ? DEFAULT_BORDER_FRLG : DEFAULT_BORDER_RSE;
     this->customScripts.clear();
 }
 
@@ -724,6 +754,33 @@ void ProjectConfig::setTripleLayerMetatilesEnabled(bool enable) {
 
 bool ProjectConfig::getTripleLayerMetatilesEnabled() {
     return this->enableTripleLayerMetatiles;
+}
+
+void ProjectConfig::setNewMapMetatileId(int metatileId) {
+    this->newMapMetatileId = metatileId;
+    this->save();
+}
+
+int ProjectConfig::getNewMapMetatileId() {
+    return this->newMapMetatileId;
+}
+
+void ProjectConfig::setNewMapElevation(int elevation) {
+    this->newMapElevation = elevation;
+    this->save();
+}
+
+int ProjectConfig::getNewMapElevation() {
+    return this->newMapElevation;
+}
+
+void ProjectConfig::setNewMapBorderMetatileIds(QList<int> metatileIds) {
+    this->newMapBorderMetatileIds = metatileIds;
+    this->save();
+}
+
+QList<int> ProjectConfig::getNewMapBorderMetatileIds() {
+    return this->newMapBorderMetatileIds;
 }
 
 void ProjectConfig::setCustomScripts(QList<QString> scripts) {

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -174,17 +174,6 @@ void PorymapConfig::parseConfigKeyValue(QString key, QString value) {
         this->showGrid = getConfigBool(key, value);
     } else if (key == "monitor_files") {
         this->monitorFiles = getConfigBool(key, value);
-    } else if (key == "region_map_dimensions") {
-        bool ok1, ok2;
-        QStringList dims = value.split("x");
-        int w = dims[0].toInt(&ok1);
-        int h = dims[1].toInt(&ok2);
-        if (!ok1 || !ok2) {
-            logWarn("Cannot parse region map dimensions. Using default values instead.");
-            this->regionMapDimensions = QSize(32, 20);
-        } else {
-            this->regionMapDimensions = QSize(w, h);
-        }
     } else if (key == "theme") {
         this->theme = value;
     } else if (key == "text_editor_open_directory") {
@@ -219,8 +208,6 @@ QMap<QString, QString> PorymapConfig::getKeyValueMap() {
     map.insert("show_border", this->showBorder ? "1" : "0");
     map.insert("show_grid", this->showGrid ? "1" : "0");
     map.insert("monitor_files", this->monitorFiles ? "1" : "0");
-    map.insert("region_map_dimensions", QString("%1x%2").arg(this->regionMapDimensions.width())
-                                                        .arg(this->regionMapDimensions.height()));
     map.insert("theme", this->theme);
     map.insert("text_editor_open_directory", this->textEditorOpenFolder);
     map.insert("text_editor_goto_line", this->textEditorGotoLine);
@@ -326,10 +313,6 @@ void PorymapConfig::setShowGrid(bool enabled) {
     this->save();
 }
 
-void PorymapConfig::setRegionMapDimensions(int width, int height) {
-    this->regionMapDimensions = QSize(width, height);
-}
-
 void PorymapConfig::setTheme(QString theme) {
     this->theme = theme;
 }
@@ -424,10 +407,6 @@ bool PorymapConfig::getShowGrid() {
 
 bool PorymapConfig::getMonitorFiles() {
     return this->monitorFiles;
-}
-
-QSize PorymapConfig::getRegionMapDimensions() {
-    return this->regionMapDimensions;
 }
 
 QString PorymapConfig::getTheme() {

--- a/src/project.cpp
+++ b/src/project.cpp
@@ -2218,10 +2218,15 @@ bool Project::readSecretBaseIds() {
     if (!projectConfig.getEventSecretBaseEnabled())
         return true;
 
+    // SECRET_BASE_GROUP is a function-like macro, which Porymap can't handle.
+    // Redefine it so Porymap won't produce spurious errors about failing to parse it.
+    QMap<QString, int> knownDefines = QMap<QString, int>();
+    knownDefines.insert("SECRET_BASE_GROUP", 0);
+
     QStringList prefixes("\\bSECRET_BASE_[A-Za-z0-9_]*_[0-9]+");
     QString filename = "include/constants/secret_bases.h";
     fileWatcher.addPath(root + "/" + filename);
-    secretBaseIds = parser.readCDefinesSorted(filename, prefixes);
+    secretBaseIds = parser.readCDefinesSorted(filename, prefixes, knownDefines);
     if (secretBaseIds.isEmpty()) {
         logError(QString("Failed to read secret base id constants from %1").arg(filename));
         return false;

--- a/src/project.cpp
+++ b/src/project.cpp
@@ -1179,11 +1179,14 @@ bool Project::loadBlockdata(MapLayout *layout) {
 
 void Project::setNewMapBlockdata(Map *map) {
     map->layout->blockdata.clear();
-    for (int i = 0; i < map->getWidth() * map->getHeight(); i++) {
-        map->layout->blockdata.append(qint16(0x3001));
+    int width = map->getWidth();
+    int height = map->getHeight();
+    Block block(projectConfig.getNewMapMetatileId(), 0, projectConfig.getNewMapElevation());
+    for (int i = 0; i < width * height; i++) {
+        map->layout->blockdata.append(block);
     }
     map->layout->lastCommitBlocks.blocks = map->layout->blockdata;
-    map->layout->lastCommitBlocks.mapDimensions = QSize(map->getWidth(), map->getHeight());
+    map->layout->lastCommitBlocks.mapDimensions = QSize(width, height);
 }
 
 bool Project::loadLayoutBorder(MapLayout *layout) {
@@ -1204,23 +1207,20 @@ bool Project::loadLayoutBorder(MapLayout *layout) {
 
 void Project::setNewMapBorder(Map *map) {
     map->layout->border.clear();
-    if (map->getBorderWidth() != DEFAULT_BORDER_WIDTH || map->getBorderHeight() != DEFAULT_BORDER_HEIGHT) {
-        for (int i = 0; i < map->getBorderWidth() * map->getBorderHeight(); i++) {
+    int width = map->getBorderWidth();
+    int height = map->getBorderHeight();
+    if (width != DEFAULT_BORDER_WIDTH || height != DEFAULT_BORDER_HEIGHT) {
+        for (int i = 0; i < width * height; i++) {
             map->layout->border.append(0);
         }
-    } else if (projectConfig.getBaseGameVersion() == BaseGameVersion::pokefirered) {
-        map->layout->border.append(qint16(0x0014));
-        map->layout->border.append(qint16(0x0015));
-        map->layout->border.append(qint16(0x001C));
-        map->layout->border.append(qint16(0x001D));
     } else {
-        map->layout->border.append(qint16(0x01D4));
-        map->layout->border.append(qint16(0x01D5));
-        map->layout->border.append(qint16(0x01DC));
-        map->layout->border.append(qint16(0x01DD));
+        QList<int> metatileIds = projectConfig.getNewMapBorderMetatileIds();
+        for (int i = 0; i < DEFAULT_BORDER_WIDTH * DEFAULT_BORDER_HEIGHT; i++) {
+            map->layout->border.append(qint16(metatileIds.at(i)));
+        }
     }
     map->layout->lastCommitBlocks.border = map->layout->border;
-    map->layout->lastCommitBlocks.borderDimensions = QSize(map->getBorderWidth(), map->getBorderHeight());
+    map->layout->lastCommitBlocks.borderDimensions = QSize(width, height);
 }
 
 void Project::saveLayoutBorder(Map *map) {


### PR DESCRIPTION
- Adds `new_map_metatile`, `new_map_elevation`, and `new_map_border_metatiles` for customizing the fill of new maps.
- Removes `region_map_dimensions` from the config. This is unused since the region map editor update
- Replace `setConfigBool` with `getConfigBool`

I'm also tired of the `SECRET_BASE_GROUP` errors in the log, I'm explicitly ignoring it until Porymap handles function-like macros.

Closes #388 