### PR TITLE
Improve heal location reading/writing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,9 @@ The **"Breaking Changes"** listed below are changes that have been made in the d
 - The currently selected event for each event group will persist between tabs.
 - An object event's sprite will now render if a number is specified instead of a graphics constant.
 - Palette editor ui is updated a bit to allow hex and rgb value input.
+- Heal location constants will no longer be deleted if they're not used in the data tables.
+- The heal location prefixes `SPAWN_` and `HEAL_LOCATION_` may now be used interchangeably.
+- The number and order of entries in the heal location data tables can now be changed arbitrarily, and independently of each other.
 - The metatile behavior is now displayed in the bottom bar mouseover text.
 - Removed some unnecessary error logs from the scripting API and added new useful ones.
 

--- a/include/core/events.h
+++ b/include/core/events.h
@@ -626,15 +626,15 @@ public:
     void setRespawnMap(QString newRespawnMap) { this->respawnMap = newRespawnMap; }
     QString getRespawnMap() { return this->respawnMap; }
 
-    void setRespawnNPC(uint16_t newRespawnNPC) { this->respawnNPC = newRespawnNPC; }
-    uint16_t getRespawnNPC() { return this->respawnNPC; }
+    void setRespawnNPC(uint8_t newRespawnNPC) { this->respawnNPC = newRespawnNPC; }
+    uint8_t getRespawnNPC() { return this->respawnNPC; }
 
 private:
     int index = -1;
     QString locationName;
     QString idName;
     QString respawnMap;
-    uint16_t respawnNPC = 0;
+    uint8_t respawnNPC = 0;
 };
 
 

--- a/include/core/heallocation.h
+++ b/include/core/heallocation.h
@@ -11,17 +11,17 @@ class HealLocation {
 
 public:
     HealLocation()=default;
-    HealLocation(QString, QString, int, uint16_t, uint16_t, QString = "", uint16_t = 0);
+    HealLocation(QString, QString, int, int16_t, int16_t, QString = "", uint8_t = 0);
     friend QDebug operator<<(QDebug debug, const HealLocation &hl);
 
 public:
     QString idName;
     QString mapName;
     int     index;
-    uint16_t  x;
-    uint16_t  y;
+    int16_t  x;
+    int16_t  y;
     QString respawnMap;
-    uint16_t respawnNPC;
+    uint8_t respawnNPC;
     static HealLocation fromEvent(Event *);
 };
 

--- a/include/core/heallocation.h
+++ b/include/core/heallocation.h
@@ -11,7 +11,7 @@ class HealLocation {
 
 public:
     HealLocation()=default;
-    HealLocation(QString, QString, int, int16_t, int16_t, QString = "", uint8_t = 0);
+    HealLocation(QString, QString, int, int16_t, int16_t, QString = "", uint8_t = 1);
     friend QDebug operator<<(QDebug debug, const HealLocation &hl);
 
 public:

--- a/include/project.h
+++ b/include/project.h
@@ -159,7 +159,7 @@ public:
     void saveMapGroups();
     void saveWildMonData();
     void saveMapConstantsHeader();
-    void saveHealLocationStruct(Map*);
+    void saveHealLocations(Map*);
     void saveTilesets(Tileset*, Tileset*);
     void saveTilesetMetatileLabels(Tileset*, Tileset*);
     void saveTilesetMetatileAttributes(Tileset*);
@@ -209,8 +209,6 @@ public:
     QCompleter *getEventScriptLabelCompleter(QStringList additionalScriptLabels);
     QStringList getGlobalScriptLabels();
 
-    void saveMapHealEvents(Map *map);
-
     static int getNumTilesPrimary();
     static int getNumTilesTotal();
     static int getNumMetatilesPrimary();
@@ -235,6 +233,9 @@ private:
     void setNewMapBorder(Map *map);
     void setNewMapEvents(Map *map);
     void setNewMapConnections(Map *map);
+
+    void saveHealLocationsData(Map *map);
+    void saveHealLocationsConstants();
 
     void ignoreWatchedFileTemporarily(QString filepath);
 

--- a/include/project.h
+++ b/include/project.h
@@ -49,6 +49,7 @@ public:
     QStringList mapNames;
     QMap<QString, QVariant> miscConstants;
     QList<HealLocation> healLocations;
+    QMap<QString, int> healLocationNameToValue;
     QMap<QString, QString> mapConstantsToMapNames;
     QMap<QString, QString> mapNamesToMapConstants;
     QStringList mapLayoutsTable;
@@ -97,7 +98,7 @@ public:
         bool isConst;
     };
     DataQualifiers getDataQualifiers(QString, QString);
-    QMap<QString, DataQualifiers> dataQualifiers;
+    DataQualifiers healLocationDataQualifiers;
 
     QMap<QString, Map*> mapCache;
     Map* loadMap(QString);
@@ -187,6 +188,7 @@ public:
     bool readBgEventFacingDirections();
     bool readTrainerTypes();
     bool readMetatileBehaviors();
+    bool readHealLocationConstants();
     bool readHealLocations();
     bool readMiscellaneousConstants();
     bool readEventScriptLabels();

--- a/src/core/events.cpp
+++ b/src/core/events.cpp
@@ -879,13 +879,16 @@ OrderedJson::object HealLocationEvent::buildEventJson(Project *) {
 }
 
 void HealLocationEvent::setDefaultValues(Project *) {
-    if (this->getMap()) {
-        this->setLocationName(Map::mapConstantFromName(this->getMap()->name).remove(0,4));
-        this->setIdName(this->getMap()->name.replace(QRegularExpression("([a-z])([A-Z])"), "\\1_\\2").toUpper());
-    }
     this->setElevation(3);
-    if (projectConfig.getHealLocationRespawnDataEnabled()) {
-        if (this->getMap()) this->setRespawnMap(this->getMap()->name);
+    if (!this->getMap())
+        return;
+    bool respawnEanbled = projectConfig.getHealLocationRespawnDataEnabled();
+    QString mapConstant = Map::mapConstantFromName(this->getMap()->name).remove(0,4);
+    QString prefix = respawnEanbled ? "SPAWN_" : "HEAL_LOCATION_";
+    this->setLocationName(mapConstant);
+    this->setIdName(prefix + mapConstant);
+    if (respawnEanbled) {
+        this->setRespawnMap(this->getMap()->name);
         this->setRespawnNPC(1);
     }
 }

--- a/src/core/heallocation.cpp
+++ b/src/core/heallocation.cpp
@@ -4,8 +4,8 @@
 #include "map.h"
 
 HealLocation::HealLocation(QString id, QString map,
-                           int i, uint16_t x, uint16_t y,
-                           QString respawnMap, uint16_t respawnNPC) {
+                           int i, int16_t x, int16_t y,
+                           QString respawnMap, uint8_t respawnNPC) {
     this->idName = id;
     this->mapName = map;
     this->index = i;

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1204,7 +1204,7 @@ void MainWindow::onNewMapCreated() {
 
     if (ParseUtil::gameStringToBool(newMap->isFlyable)) {
         addNewEvent(Event::Type::HealLocation);
-        editor->project->saveHealLocationStruct(newMap);
+        editor->project->saveHealLocations(newMap);
         editor->save();
     }
 

--- a/src/project.cpp
+++ b/src/project.cpp
@@ -854,7 +854,7 @@ void Project::saveHealLocationsData(Map *map) {
     if (respawnEnabled)
         text += respawnMapTableText + tableEnd + respawnNPCTableText + tableEnd;
 
-    QString filepath = root + "/src/data/heal_locations.h";
+    QString filepath = root + "/" + projectConfig.getFilePath(ProjectFilePath::data_heal_locations);
     ignoreWatchedFileTemporarily(filepath);
     saveTextFile(filepath, text);
 }
@@ -2024,7 +2024,7 @@ bool Project::readRegionMapSections() {
 bool Project::readHealLocationConstants() {
     this->healLocationNameToValue.clear();
     QStringList prefixes{ "\\bSPAWN_", "\\bHEAL_LOCATION_" };
-    QString constantsFilename = "include/constants/heal_locations.h";
+    QString constantsFilename = projectConfig.getFilePath(ProjectFilePath::constants_heal_locations);
     fileWatcher.addPath(root + "/" + constantsFilename);
     this->healLocationNameToValue = parser.readCDefines(constantsFilename, prefixes);
     // No need to check if empty, not finding any heal location constants is ok


### PR DESCRIPTION
- `SPAWN_*` or `HEAL_LOCATION_*` constants in `include/constants/heal_locations.h` will not be deleted if they aren't used in `src/data/heal_locations.h`. This is to support <https://github.com/pret/pokeemerald/pull/1671>
- `SPAWN_*` and `HEAL_LOCATION_*` may now be used interchangeably, and are not strictly enforced based on the config settings.
- Heal location table data may now be ordered arbitrarily, independent of the other data tables and their constant values.
- If heal location data is present in at least 1 but not all of the heal location tables, entries with default values will be added for the rest.
- Fixed a bug where heal locations created via New Map could temporarily have an incorrect name for their respawn map.
