### PR TITLE
Suppress errors for unneeded defines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ The **"Breaking Changes"** listed below are changes that have been made in the d
 - Fix object events added by pasting ignoring the map event limit.
 - Fixed a bug where saving the tileset editor would reselect the main editor's first selected metatile.
 - Fix crashes / unexpected behavior if certain scripting API functions are given invalid palette or tile numbers.
-- Silence unnecessary errors about `SECRET_BASE_GROUP` when parsing `secret_bases.h`.
+- Silence unnecessary error logging when parsing C defines Porymap doesn't use.
 
 ## [4.5.0] - 2021-12-26
 ### Added

--- a/include/core/parseutil.h
+++ b/include/core/parseutil.h
@@ -75,7 +75,7 @@ private:
     QString text;
     QString file;
     QString curDefine;
-    QMap<QString, QStringList> errorMap;
+    QHash<QString, QStringList> errorMap;
     QList<Token> tokenizeExpression(QString expression, const QMap<QString, int> &knownIdentifiers);
     QList<Token> generatePostfix(const QList<Token> &tokens);
     int evaluatePostfix(const QList<Token> &postfix);

--- a/include/core/parseutil.h
+++ b/include/core/parseutil.h
@@ -74,10 +74,15 @@ private:
     QString root;
     QString text;
     QString file;
+    QString curDefine;
+    QMap<QString, QStringList> errorMap;
     QList<Token> tokenizeExpression(QString expression, const QMap<QString, int> &knownIdentifiers);
     QList<Token> generatePostfix(const QList<Token> &tokens);
     int evaluatePostfix(const QList<Token> &postfix);
-    void error(const QString &message, const QString &expression);
+    void recordError(const QString &message);
+    void recordErrors(const QStringList &errors);
+    void logRecordedErrors();
+    QString createErrorMessage(const QString &message, const QString &expression);
 
     static const QRegularExpression re_incScriptLabel;
     static const QRegularExpression re_globalIncScriptLabel;

--- a/src/project.cpp
+++ b/src/project.cpp
@@ -2218,15 +2218,10 @@ bool Project::readSecretBaseIds() {
     if (!projectConfig.getEventSecretBaseEnabled())
         return true;
 
-    // SECRET_BASE_GROUP is a function-like macro, which Porymap can't handle.
-    // Redefine it so Porymap won't produce spurious errors about failing to parse it.
-    QMap<QString, int> knownDefines = QMap<QString, int>();
-    knownDefines.insert("SECRET_BASE_GROUP", 0);
-
     QStringList prefixes("\\bSECRET_BASE_[A-Za-z0-9_]*_[0-9]+");
     QString filename = projectConfig.getFilePath(ProjectFilePath::constants_secret_bases);
     fileWatcher.addPath(root + "/" + filename);
-    secretBaseIds = parser.readCDefinesSorted(filename, prefixes, knownDefines);
+    secretBaseIds = parser.readCDefinesSorted(filename, prefixes);
     if (secretBaseIds.isEmpty()) {
         logError(QString("Failed to read secret base id constants from %1").arg(filename));
         return false;


### PR DESCRIPTION
This persistent (and irrelevant) error log still exists in pokefirered
```
[ERROR] include/constants/global.h:43:29: unknown token 'PARTY_SIZE' found in expression 'PARTY_SIZE + 10)'
```
and a recent update to pokeemerald added new ones:
```
[ERROR] include/constants/global.h:38:37: unknown token 'max' found in expression 'max(FRONTIER_PARTY_SIZE,        max(FRONTIER_DOUBLES_PARTY_SIZE,FRONTIER_MULTI_PARTY_SIZE)))'
[ERROR] include/constants/global.h:38:60: unknown token 'max' found in expression ',        max(FRONTIER_DOUBLES_PARTY_SIZE,FRONTIER_MULTI_PARTY_SIZE)))'
[ERROR] include/constants/global.h:38:69: unknown token 'max' found in expression 'max(FRONTIER_DOUBLES_PARTY_SIZE,FRONTIER_MULTI_PARTY_SIZE)))'
[ERROR] include/constants/global.h:38:125: unknown token 'E' found in expression 'E)))'
```

This updates `ParseUtil` so that it records errors internally while parsing C defines, and only logs errors for defines that match the regex of defines Porymap is ultimately looking for. This suppresses the above errors and removes the need to explicitly suppress errors for `SECRET_BASE_GROUP`.

Example define set:
```c
#define IM_NOT_NEEDED (UNKNOWN + 1) // line 1
#define IM_NOT_SEARCHED_FOR (UNKNOWN + 2) // line 2
#define IM_SEARCHED_FOR (IM_NOT_SEARCHED_FOR + 1) // line 3
```

Errors prior to this PR:
```
[ERROR] <file>:1:24: unknown token 'UNKNOWN' found in expression 'UNKNOWN + 1)'
[ERROR] <file>:2:30: unknown token 'UNKNOWN' found in expression 'UNKNOWN + 2)'
```

Errors after this PR:
```
[ERROR] Failed to parse 'IM_SEARCHED_FOR':
<file>:2:30: unknown token 'UNKNOWN' found in expression 'UNKNOWN + 2)'
```