### PR TITLE
Add name list functions to API

### DIFF
--- a/docsrc/manual/scripting-capabilities.rst
+++ b/docsrc/manual/scripting-capabilities.rst
@@ -1360,6 +1360,66 @@ All utility functions are callable via the global ``utility`` object.
    :param boolean editable: whether the user is allowed to enter their own text instead. Defaults to ``false``
    :returns {input, ok}: ``input`` will be the input text and ``ok`` will be ``true`` if ``OK`` was selected. ``input`` will be the text of the item at ``default`` and ``ok`` will be ``false`` if ``Cancel`` was selected or if the window was closed without selection.
 
+.. js:function:: utility.getMapNames()
+
+   Gets the list of map names.
+
+   :returns array: the list of map names
+
+.. js:function:: utility.getTilesetNames()
+
+   Gets the list of tileset names.
+
+   :returns array: the list of tileset names
+
+.. js:function:: utility.getPrimaryTilesetNames()
+
+   Gets the list of primary tileset names.
+
+   :returns array: the list of primary tileset names
+
+.. js:function:: utility.getSecondaryTilesetNames()
+
+   Gets the list of secondary tileset names.
+
+   :returns array: the list of secondary tileset names
+
+.. js:function:: utility.getMetatileBehaviorNames()
+
+   Gets the list of metatile behavior names.
+
+   :returns array: the list of metatile behavior names
+
+.. js:function:: utility.getSongNames()
+
+   Gets the list of song names.
+
+   :returns array: the list of song names
+
+.. js:function:: utility.getLocationNames()
+
+   Gets the list of map location names.
+
+   :returns array: the list of map location names
+
+.. js:function:: utility.getWeatherNames()
+
+   Gets the list of weather names.
+
+   :returns array: the list of weather names
+
+.. js:function:: utility.getMapTypeNames()
+
+   Gets the list of map type names.
+
+   :returns array: the list of map type names
+
+.. js:function:: utility.getBattleSceneNames()
+
+   Gets the list of battle scene names.
+
+   :returns array: the list of battle scene names
+
 .. js:function:: utility.isPrimaryTileset(tilesetName)
 
    Gets whether the specified tileset is a primary tileset.

--- a/include/scriptutility.h
+++ b/include/scriptutility.h
@@ -39,6 +39,16 @@ public:
     Q_INVOKABLE void setMetatileLayerOrder(QList<int> order);
     Q_INVOKABLE QList<float> getMetatileLayerOpacity();
     Q_INVOKABLE void setMetatileLayerOpacity(QList<float> order);
+    Q_INVOKABLE QList<QString> getMapNames();
+    Q_INVOKABLE QList<QString> getTilesetNames();
+    Q_INVOKABLE QList<QString> getPrimaryTilesetNames();
+    Q_INVOKABLE QList<QString> getSecondaryTilesetNames();
+    Q_INVOKABLE QList<QString> getMetatileBehaviorNames();
+    Q_INVOKABLE QList<QString> getSongNames();
+    Q_INVOKABLE QList<QString> getLocationNames();
+    Q_INVOKABLE QList<QString> getWeatherNames();
+    Q_INVOKABLE QList<QString> getMapTypeNames();
+    Q_INVOKABLE QList<QString> getBattleSceneNames();
     Q_INVOKABLE bool isPrimaryTileset(QString tilesetName);
     Q_INVOKABLE bool isSecondaryTileset(QString tilesetName);
 

--- a/src/scriptapi/apiutility.cpp
+++ b/src/scriptapi/apiutility.cpp
@@ -211,14 +211,70 @@ void ScriptUtility::setMetatileLayerOpacity(QList<float> order) {
     window->refreshAfterPalettePreviewChange();
 }
 
-bool ScriptUtility::isPrimaryTileset(QString tilesetName) {
+QList<QString> ScriptUtility::getMapNames() {
     if (!window || !window->editor || !window->editor->project)
-        return false;
-    return window->editor->project->tilesetLabels["primary"].contains(tilesetName);
+        return QList<QString>();
+    return window->editor->project->mapNames;
+}
+
+QList<QString> ScriptUtility::getTilesetNames() {
+    if (!window || !window->editor || !window->editor->project)
+        return QList<QString>();
+    return window->editor->project->tilesetLabelsOrdered;
+}
+
+QList<QString> ScriptUtility::getPrimaryTilesetNames() {
+    if (!window || !window->editor || !window->editor->project)
+        return QList<QString>();
+    return window->editor->project->tilesetLabels["primary"];
+}
+
+QList<QString> ScriptUtility::getSecondaryTilesetNames() {
+    if (!window || !window->editor || !window->editor->project)
+        return QList<QString>();
+    return window->editor->project->tilesetLabels["secondary"];
+}
+
+QList<QString> ScriptUtility::getMetatileBehaviorNames() {
+    if (!window || !window->editor || !window->editor->project)
+        return QList<QString>();
+    return window->editor->project->metatileBehaviorMap.keys();
+}
+
+QList<QString> ScriptUtility::getSongNames() {
+    if (!window || !window->editor || !window->editor->project)
+        return QList<QString>();
+    return window->editor->project->songNames;
+}
+
+QList<QString> ScriptUtility::getLocationNames() {
+    if (!window || !window->editor || !window->editor->project)
+        return QList<QString>();
+    return window->editor->project->mapSectionNameToValue.keys();
+}
+
+QList<QString> ScriptUtility::getWeatherNames() {
+    if (!window || !window->editor || !window->editor->project)
+        return QList<QString>();
+    return window->editor->project->weatherNames;
+}
+
+QList<QString> ScriptUtility::getMapTypeNames() {
+    if (!window || !window->editor || !window->editor->project)
+        return QList<QString>();
+    return window->editor->project->mapTypes;
+}
+
+QList<QString> ScriptUtility::getBattleSceneNames() {
+    if (!window || !window->editor || !window->editor->project)
+        return QList<QString>();
+    return window->editor->project->mapBattleScenes;
+}
+
+bool ScriptUtility::isPrimaryTileset(QString tilesetName) {
+    return getPrimaryTilesetNames().contains(tilesetName);
 }
 
 bool ScriptUtility::isSecondaryTileset(QString tilesetName) {
-    if (!window || !window->editor || !window->editor->project)
-        return false;
-    return window->editor->project->tilesetLabels["secondary"].contains(tilesetName);
+    return getSecondaryTilesetNames().contains(tilesetName);
 }


### PR DESCRIPTION
Adds a number of functions to get lists of names from the API (maps, tilesets, map header properties). These are meant to support other API functions (mostly those for editing the map header) that take the name of some constant as a string, or future API functions that might need these names (e.g. for specifying a map to delete by name). 

Test script:
```js
export function onProjectOpened(projectPath) {
    utility.registerAction("runTest", "Run Test");
}

export function runTest() {
    utility.log("------ Maps ------");
    utility.log(utility.getMapNames() + "\n");
    utility.log("------ Tilesets (all) ------");
    utility.log(utility.getTilesetNames() + "\n");
    utility.log("------ Tilesets (primary) ------");
    utility.log(utility.getPrimaryTilesetNames() + "\n");
    utility.log("------ Tilesets (secondary) ------");
    utility.log(utility.getSecondaryTilesetNames() + "\n");
    utility.log("------ Behaviors ------");
    utility.log(utility.getMetatileBehaviorNames() + "\n");
    utility.log("------ Songs ------");
    utility.log(utility.getSongNames() + "\n");
    utility.log("------ Locations ------");
    utility.log(utility.getLocationNames() + "\n");
    utility.log("------ Weather ------");
    utility.log(utility.getWeatherNames() + "\n");
    utility.log("------ Map Types ------");
    utility.log(utility.getMapTypeNames() + "\n");
    utility.log("------ Battle Scenes ------");
    utility.log(utility.getBattleSceneNames() + "\n");
}
```