### PR TITLE
Add Cut for metatiles in the Tileset Editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ The **"Breaking Changes"** listed below are changes that have been made in the d
 
 ### Added
 - Add prefab support
-- Add Copy/Paste for metatiles in the Tileset Editor.
+- Add Cut/Copy/Paste for metatiles in the Tileset Editor.
 - Add new features to the scripting API, including the ability to display message boxes and user input windows, set overlay opacity, get/set map header properties, read/write the map border, read tile pixel data, and set blocks or metatile attributes using a raw value.
 - Add button to copy the full metatile label to the clipboard in the Tileset Editor.
 - Add option to not open the most recent project on launch.

--- a/forms/tileseteditor.ui
+++ b/forms/tileseteditor.ui
@@ -567,6 +567,7 @@
     <property name="title">
      <string>Edit</string>
     </property>
+    <addaction name="actionCut"/>
     <addaction name="actionCopy"/>
     <addaction name="actionPaste"/>
     <addaction name="actionUndo"/>
@@ -663,6 +664,14 @@
   <action name="actionImport_Secondary_Metatiles">
    <property name="text">
     <string>Import Secondary Metatiles from Advance Map 1.92...</string>
+   </property>
+  </action>
+  <action name="actionCut">
+   <property name="text">
+    <string>Cut</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+X</string>
    </property>
   </action>
   <action name="actionCopy">

--- a/include/config.h
+++ b/include/config.h
@@ -238,6 +238,8 @@ public:
     bool getCreateMapTextFileEnabled();
     void setTripleLayerMetatilesEnabled(bool enable);
     bool getTripleLayerMetatilesEnabled();
+    int getNumLayersInMetatile();
+    int getNumTilesInMetatile();
     void setNewMapMetatileId(int metatileId);
     int getNewMapMetatileId();
     void setNewMapElevation(int elevation);

--- a/include/core/metatile.h
+++ b/include/core/metatile.h
@@ -36,6 +36,7 @@ public:
     Metatile();
     Metatile(const Metatile &other) = default;
     Metatile &operator=(const Metatile &other) = default;
+    Metatile(const int numTiles);
 
 public:
     QList<Tile> tiles;

--- a/include/ui/tileseteditor.h
+++ b/include/ui/tileseteditor.h
@@ -105,8 +105,8 @@ private slots:
 
     void on_copyButton_metatileLabel_clicked();
 
+    void on_actionCut_triggered();
     void on_actionCopy_triggered();
-
     void on_actionPaste_triggered();
 
 private:
@@ -133,7 +133,9 @@ private:
     void closeEvent(QCloseEvent*);
     void countMetatileUsage();
     void countTileUsage();
-    bool replaceMetatile(uint16_t metatileId, Metatile * src);
+    void copyMetatile(bool cut);
+    void pasteMetatile(const Metatile * toPaste);
+    bool replaceMetatile(uint16_t metatileId, const Metatile * src);
 
     Ui::TilesetEditor *ui;
     History<MetatileHistoryItem*> metatileHistory;

--- a/include/ui/tileseteditortileselector.h
+++ b/include/ui/tileseteditortileselector.h
@@ -7,8 +7,8 @@
 class TilesetEditorTileSelector: public SelectablePixmapItem {
     Q_OBJECT
 public:
-    TilesetEditorTileSelector(Tileset *primaryTileset, Tileset *secondaryTileset, bool isTripleLayer)
-        : SelectablePixmapItem(16, 16, isTripleLayer ? 6 : 4, 2) {
+    TilesetEditorTileSelector(Tileset *primaryTileset, Tileset *secondaryTileset, int numLayers)
+        : SelectablePixmapItem(16, 16, numLayers * 2, 2) {
         this->primaryTileset = primaryTileset;
         this->secondaryTileset = secondaryTileset;
         this->numTilesWide = 16;

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -795,6 +795,14 @@ bool ProjectConfig::getTripleLayerMetatilesEnabled() {
     return this->enableTripleLayerMetatiles;
 }
 
+int ProjectConfig::getNumLayersInMetatile() {
+    return this->enableTripleLayerMetatiles ? 3 : 2;
+}
+
+int ProjectConfig::getNumTilesInMetatile() {
+    return this->enableTripleLayerMetatiles ? 12 : 8;
+}
+
 void ProjectConfig::setNewMapMetatileId(int metatileId) {
     this->newMapMetatileId = metatileId;
     this->save();

--- a/src/core/metatile.cpp
+++ b/src/core/metatile.cpp
@@ -10,6 +10,19 @@ Metatile::Metatile() :
     unusedAttributes(0)
 {  }
 
+Metatile::Metatile(const int numTiles) :
+    behavior(0),
+    layerType(0),
+    encounterType(0),
+    terrainType(0),
+    unusedAttributes(0)
+{
+    Tile tile = Tile();
+    for (int i = 0; i < numTiles; i++) {
+        this->tiles.append(tile);
+    }
+}
+
 int Metatile::getIndexInTileset(int metatileId) {
     if (metatileId < Project::getNumMetatilesPrimary()) {
         return metatileId;

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1307,8 +1307,8 @@ void MainWindow::on_actionNew_Tileset_triggered() {
         int numMetaTiles = createTilesetDialog->isSecondary ? (Project::getNumTilesTotal() - Project::getNumTilesPrimary()) : Project::getNumTilesPrimary();
         QImage tilesImage(":/images/blank_tileset.png");
         editor->project->loadTilesetTiles(&newSet, tilesImage);
+        int tilesPerMetatile = projectConfig.getNumTilesInMetatile();
         for(int i = 0; i < numMetaTiles; ++i) {
-            int tilesPerMetatile = projectConfig.getTripleLayerMetatilesEnabled() ? 12 : 8;
             Metatile *mt = new Metatile();
             for(int j = 0; j < tilesPerMetatile; ++j){
                 Tile tile(0, false, false, 0);

--- a/src/project.cpp
+++ b/src/project.cpp
@@ -1079,7 +1079,7 @@ void Project::saveTilesetMetatiles(Tileset *tileset) {
     QFile metatiles_file(tileset->metatiles_path);
     if (metatiles_file.open(QIODevice::WriteOnly | QIODevice::Truncate)) {
         QByteArray data;
-        int numTiles = projectConfig.getTripleLayerMetatilesEnabled() ? 12 : 8;
+        int numTiles = projectConfig.getNumTilesInMetatile();
         for (Metatile *metatile : tileset->metatiles) {
             for (int i = 0; i < numTiles; i++) {
                 uint16_t tile = metatile->tiles.at(i).rawValue();
@@ -1591,7 +1591,7 @@ void Project::loadTilesetMetatiles(Tileset* tileset) {
     QFile metatiles_file(tileset->metatiles_path);
     if (metatiles_file.open(QIODevice::ReadOnly)) {
         QByteArray data = metatiles_file.readAll();
-        int tilesPerMetatile = projectConfig.getTripleLayerMetatilesEnabled() ? 12 : 8;
+        int tilesPerMetatile = projectConfig.getNumTilesInMetatile();
         int bytesPerMetatile = 2 * tilesPerMetatile;
         int num_metatiles = data.length() / bytesPerMetatile;
         QList<Metatile*> metatiles;

--- a/src/scriptapi/apimap.cpp
+++ b/src/scriptapi/apimap.cpp
@@ -691,7 +691,7 @@ void MainWindow::setMetatileAttributes(int metatileId, int attributes) {
 }
 
 int MainWindow::calculateTileBounds(int * tileStart, int * tileEnd) {
-    int maxNumTiles = projectConfig.getTripleLayerMetatilesEnabled() ? 12 : 8;
+    int maxNumTiles = projectConfig.getNumTilesInMetatile();
     if (*tileEnd >= maxNumTiles || *tileEnd < 0)
         *tileEnd = maxNumTiles - 1;
     if (*tileStart >= maxNumTiles || *tileStart < 0)

--- a/src/scriptapi/scripting.cpp
+++ b/src/scriptapi/scripting.cpp
@@ -70,7 +70,6 @@ void Scripting::populateGlobalObject(MainWindow *mainWindow) {
     int numTilesTotal = Project::getNumTilesTotal();
     int numMetatilesPrimary = Project::getNumMetatilesPrimary();
     int numMetatilesTotal = Project::getNumMetatilesTotal();
-    bool tripleLayerEnabled = projectConfig.getTripleLayerMetatilesEnabled();
 
     // Invisibly create an "About" window to read Porymap version
     AboutPorymap *about = new AboutPorymap(mainWindow);
@@ -85,8 +84,8 @@ void Scripting::populateGlobalObject(MainWindow *mainWindow) {
     constants.setProperty("max_secondary_tiles", numTilesTotal - numTilesPrimary);
     constants.setProperty("max_primary_metatiles", numMetatilesPrimary);
     constants.setProperty("max_secondary_metatiles", numMetatilesTotal - numMetatilesPrimary);
-    constants.setProperty("layers_per_metatile", tripleLayerEnabled ? 3 : 2);
-    constants.setProperty("tiles_per_metatile", tripleLayerEnabled ? 12 : 8);
+    constants.setProperty("layers_per_metatile", projectConfig.getNumLayersInMetatile());
+    constants.setProperty("tiles_per_metatile", projectConfig.getNumTilesInMetatile());
     constants.setProperty("base_game_version", projectConfig.getBaseGameVersionString());
 
     instance->engine->globalObject().setProperty("constants", constants);

--- a/src/ui/metatilelayersitem.cpp
+++ b/src/ui/metatilelayersitem.cpp
@@ -19,9 +19,9 @@ void MetatileLayersItem::draw() {
         QPoint(80, 16),
     };
 
-    int numTiles = projectConfig.getNumTilesInMetatile();
-    QPixmap pixmap(numTiles * 8, 32);
+    QPixmap pixmap(projectConfig.getNumLayersInMetatile() * 32, 32);
     QPainter painter(&pixmap);
+    int numTiles = projectConfig.getNumTilesInMetatile();
     for (int i = 0; i < numTiles; i++) {
         Tile tile = this->metatile->tiles.at(i);
         QImage tileImage = getPalettedTileImage(tile.tileId, this->primaryTileset, this->secondaryTileset, tile.palette, true)

--- a/src/ui/metatilelayersitem.cpp
+++ b/src/ui/metatilelayersitem.cpp
@@ -19,11 +19,9 @@ void MetatileLayersItem::draw() {
         QPoint(80, 16),
     };
 
-    bool isTripleLayerMetatile = projectConfig.getTripleLayerMetatilesEnabled();
-    int width = isTripleLayerMetatile ? 96 : 64;
-    QPixmap pixmap(width, 32);
+    int numTiles = projectConfig.getNumTilesInMetatile();
+    QPixmap pixmap(numTiles * 8, 32);
     QPainter painter(&pixmap);
-    int numTiles = isTripleLayerMetatile ? 12 : 8;
     for (int i = 0; i < numTiles; i++) {
         Tile tile = this->metatile->tiles.at(i);
         QImage tileImage = getPalettedTileImage(tile.tileId, this->primaryTileset, this->secondaryTileset, tile.palette, true)
@@ -98,8 +96,7 @@ void MetatileLayersItem::clearLastModifiedCoords() {
 }
 
 void MetatileLayersItem::getBoundedCoords(QPointF pos, int *x, int *y) {
-    bool isTripleLayerMetatile = projectConfig.getTripleLayerMetatilesEnabled();
-    int maxX = isTripleLayerMetatile ? 5 : 3;
+    int maxX = (projectConfig.getNumLayersInMetatile() * 2) - 1;
     *x = static_cast<int>(pos.x()) / 16;
     *y = static_cast<int>(pos.y()) / 16;
     if (*x < 0) *x = 0;

--- a/src/ui/tileseteditor.cpp
+++ b/src/ui/tileseteditor.cpp
@@ -192,8 +192,7 @@ void TilesetEditor::initMetatileLayersItem() {
 
 void TilesetEditor::initTileSelector()
 {
-    this->tileSelector = new TilesetEditorTileSelector(this->primaryTileset, this->secondaryTileset,
-                                                       projectConfig.getTripleLayerMetatilesEnabled());
+    this->tileSelector = new TilesetEditorTileSelector(this->primaryTileset, this->secondaryTileset, projectConfig.getNumLayersInMetatile());
     connect(this->tileSelector, &TilesetEditorTileSelector::hoveredTileChanged,
             this, &TilesetEditor::onHoveredTileChanged);
     connect(this->tileSelector, &TilesetEditorTileSelector::hoveredTileCleared,
@@ -398,8 +397,7 @@ void TilesetEditor::onMetatileLayerTileChanged(int x, int y) {
     QPoint dimensions = this->tileSelector->getSelectionDimensions();
     QList<Tile> tiles = this->tileSelector->getSelectedTiles();
     int selectedTileIndex = 0;
-    bool isTripleLayerMetatile = projectConfig.getTripleLayerMetatilesEnabled();
-    int maxTileIndex = isTripleLayerMetatile ? 12: 8;
+    int maxTileIndex = projectConfig.getNumTilesInMetatile();
     for (int j = 0; j < dimensions.y(); j++) {
         for (int i = 0; i < dimensions.x(); i++) {
             int tileIndex = ((x + i) / 2 * 4) + ((y + j) * 2) + ((x + i) % 2);
@@ -430,8 +428,7 @@ void TilesetEditor::onMetatileLayerSelectionChanged(QPoint selectionOrigin, int 
     QList<int> tileIdxs;
     int x = selectionOrigin.x();
     int y = selectionOrigin.y();
-    bool isTripleLayerMetatile = projectConfig.getTripleLayerMetatilesEnabled();
-    int maxTileIndex = isTripleLayerMetatile ? 12: 8;
+    int maxTileIndex = projectConfig.getNumTilesInMetatile();
     for (int j = 0; j < height; j++) {
         for (int i = 0; i < width; i++) {
             int tileIndex = ((x + i) / 2 * 4) + ((y + j) * 2) + ((x + i) % 2);
@@ -759,28 +756,18 @@ void TilesetEditor::on_actionChange_Metatiles_Count_triggered()
     if (dialog.exec() == QDialog::Accepted) {
         int numPrimaryMetatiles = primarySpinBox->value();
         int numSecondaryMetatiles = secondarySpinBox->value();
-        int numTiles = projectConfig.getTripleLayerMetatilesEnabled() ? 12 : 8;
+        int numTiles = projectConfig.getNumTilesInMetatile();
         while (this->primaryTileset->metatiles.length() > numPrimaryMetatiles) {
             delete this->primaryTileset->metatiles.takeLast();
         }
         while (this->primaryTileset->metatiles.length() < numPrimaryMetatiles) {
-            Tile tile(0, false, false, 0);
-            Metatile *metatile = new Metatile();
-            for (int i = 0; i < numTiles; i++) {
-                metatile->tiles.append(tile);
-            }
-            this->primaryTileset->metatiles.append(metatile);
+            this->primaryTileset->metatiles.append(new Metatile(numTiles));
         }
         while (this->secondaryTileset->metatiles.length() > numSecondaryMetatiles) {
             delete this->secondaryTileset->metatiles.takeLast();
         }
         while (this->secondaryTileset->metatiles.length() < numSecondaryMetatiles) {
-            Tile tile(0, false, false, 0);
-            Metatile *metatile = new Metatile();
-            for (int i = 0; i < numTiles; i++) {
-                metatile->tiles.append(tile);
-            }
-            this->secondaryTileset->metatiles.append(metatile);
+            this->secondaryTileset->metatiles.append(new Metatile(numTiles));
         }
 
         this->metatileSelector->updateSelectedMetatile();
@@ -852,10 +839,7 @@ void TilesetEditor::on_actionRedo_triggered()
 
 void TilesetEditor::on_actionCut_triggered()
 {
-    int numTiles = projectConfig.getTripleLayerMetatilesEnabled() ? 12 : 8;
-    Metatile * empty = new Metatile();
-    for (int i = 0; i < numTiles; i++)
-        empty->tiles.append(Tile());
+    Metatile * empty = new Metatile(projectConfig.getNumTilesInMetatile());
     this->copyMetatile(true);
     this->pasteMetatile(empty);
     delete empty;


### PR DESCRIPTION
To complement the new Copy/Paste. Additionally moved all the instances of `getTripleLayerMetatilesEnabled() ? 12 : 8` to a single function.