### PR TITLE
Improve API text rendering speed

### DIFF
--- a/include/ui/overlay.h
+++ b/include/ui/overlay.h
@@ -5,6 +5,7 @@
 #include <QString>
 #include <QColor>
 #include <QPainter>
+#include <QStaticText>
 
 class OverlayItem {
 public:
@@ -15,8 +16,9 @@ public:
 
 class OverlayText : public OverlayItem {
 public:
-    OverlayText(QString text, int x, int y, QColor color, int fontSize) {
-        this->text = text;
+    OverlayText(const QString inputText, int x, int y, QColor color, int fontSize) :
+        text(QStaticText(inputText))
+    {
         this->x = x;
         this->y = y;
         this->color = color;
@@ -25,7 +27,7 @@ public:
     ~OverlayText() {}
     virtual void render(QPainter *painter, int x, int y);
 private:
-    QString text;
+    const QStaticText text;
     int x;
     int y;
     QColor color;
@@ -93,7 +95,7 @@ public:
     void renderItems(QPainter *painter);
     QList<OverlayItem*> getItems();
     void clearItems();
-    void addText(QString text, int x, int y, QString color = "#000000", int fontSize = 12);
+    void addText(const QString text, int x, int y, QString color = "#000000", int fontSize = 12);
     void addRect(int x, int y, int width, int height, QString color = "#000000", bool filled = false);
     bool addImage(int x, int y, QString filepath, bool useCache = true, int width = -1, int height = -1, int xOffset = 0, int yOffset = 0, qreal hScale = 1, qreal vScale = 1, QList<QRgb> palette = QList<QRgb>(), bool setTransparency = false);
     bool addImage(int x, int y, QImage image);

--- a/src/ui/overlay.cpp
+++ b/src/ui/overlay.cpp
@@ -7,7 +7,7 @@ void OverlayText::render(QPainter *painter, int x, int y) {
     font.setPixelSize(this->fontSize);
     painter->setFont(font);
     painter->setPen(this->color);
-    painter->drawText(this->x + x, this->y + y, this->text);
+    painter->drawStaticText(this->x + x, this->y + y, this->text);
 }
 
 void OverlayRect::render(QPainter *painter, int x, int y) {
@@ -90,7 +90,7 @@ void Overlay::move(int deltaX, int deltaY) {
     this->y += deltaY;
 }
 
-void Overlay::addText(QString text, int x, int y, QString color, int fontSize) {
+void Overlay::addText(const QString text, int x, int y, QString color, int fontSize) {
     this->items.append(new OverlayText(text, x, y, QColor(color), fontSize));
 }
 


### PR DESCRIPTION
Rendering lots of text with the API is prohibitively slow because each text item will be painted again when the map view is updated, and `QPainter::drawText` has to recalculate the text's layout. We can use the much faster `QPainter::drawStaticText` instead because the text can't be edited once the user has drawn it.

Old:
![text_old](https://user-images.githubusercontent.com/25753467/194995259-eb9dcb3c-5f15-4aaa-8aa4-44988d8ae1ea.gif)

New:
![text_new](https://user-images.githubusercontent.com/25753467/194995283-21e307f4-6032-422e-92fc-b97f97464f0f.gif)

This is still slower than rendering the text once onto an image and subsequently rendering the image, but that's been a bit of a pain to do without losing resolution. It may still be worth looking into in the future, especially if other features are added to API text rendering that might require layout recalculations.
