### PR TITLE
Display values for missing items in combo boxes

### DIFF
--- a/include/ui/noscrollcombobox.h
+++ b/include/ui/noscrollcombobox.h
@@ -10,6 +10,7 @@ class NoScrollComboBox : public QComboBox
 public:
     explicit NoScrollComboBox(QWidget *parent = nullptr);
     void wheelEvent(QWheelEvent *event);
+    void setTextItem(const QString &text);
 
 private:
 };

--- a/include/ui/tileseteditor.h
+++ b/include/ui/tileseteditor.h
@@ -136,6 +136,7 @@ private:
     void copyMetatile(bool cut);
     void pasteMetatile(const Metatile * toPaste);
     bool replaceMetatile(uint16_t metatileId, const Metatile * src);
+    void setComboValue(QComboBox * combo, int value);
 
     Ui::TilesetEditor *ui;
     History<MetatileHistoryItem*> metatileHistory;

--- a/src/ui/eventframes.cpp
+++ b/src/ui/eventframes.cpp
@@ -334,18 +334,11 @@ void ObjectFrame::initialize() {
     const QSignalBlocker blocker(this);
     EventFrame::initialize();
 
-    int index = -1;
-
     // sprite
-    index = this->combo_sprite->findText(this->object->getGfx());
-    if (index < 0) {
-        this->combo_sprite->setCurrentText(this->object->getGfx());
-    } else {
-        this->combo_sprite->setCurrentIndex(index);
-    }
+    this->combo_sprite->setTextItem(this->object->getGfx());
 
     // movement
-    this->combo_movement->setCurrentIndex(this->combo_movement->findText(this->object->getMovement()));
+    this->combo_movement->setTextItem(this->object->getMovement());
 
     // radius
     this->spinner_radius_x->setValue(this->object->getRadiusX());
@@ -357,15 +350,10 @@ void ObjectFrame::initialize() {
         this->button_script->hide();
 
     // flag
-    index = this->combo_flag->findText(this->object->getFlag());
-    if (index < 0) {
-        this->combo_flag->setCurrentText(this->object->getFlag());
-    } else {
-        this->combo_flag->setCurrentIndex(index);
-    }
+    this->combo_flag->setTextItem(this->object->getFlag());
 
     // trainer type
-    this->combo_trainer_type->setCurrentIndex(this->combo_trainer_type->findText(this->object->getTrainerType()));
+    this->combo_trainer_type->setTextItem(this->object->getTrainerType());
 
     // sight berry
     this->combo_radius_treeid->setCurrentText(this->object->getSightRadiusBerryTreeID());
@@ -463,8 +451,6 @@ void CloneObjectFrame::initialize() {
     const QSignalBlocker blocker(this);
     EventFrame::initialize();
 
-    int index = -1;
-
     // sprite
     this->combo_sprite->setCurrentText(this->clone->getGfx());
 
@@ -474,12 +460,7 @@ void CloneObjectFrame::initialize() {
     this->spinner_target_id->setValue(this->clone->getTargetID());
 
     // target map
-    index = this->combo_target_map->findText(this->clone->getTargetMap());
-    if (index < 0) {
-        this->combo_target_map->setCurrentText(this->clone->getTargetMap());
-    } else {
-        this->combo_target_map->setCurrentIndex(index);
-    }
+    this->combo_target_map->setTextItem(this->clone->getTargetMap());
 }
 
 void CloneObjectFrame::populate(Project *project) {
@@ -542,15 +523,8 @@ void WarpFrame::initialize() {
     const QSignalBlocker blocker(this);
     EventFrame::initialize();
 
-    int index = -1;
-
     // dest map
-    index = this->combo_dest_map->findText(this->warp->getDestinationMap());
-    if (index < 0) {
-        this->combo_dest_map->setCurrentText(this->warp->getDestinationMap());
-    } else {
-        this->combo_dest_map->setCurrentIndex(index);
-    }
+    this->combo_dest_map->setTextItem(this->warp->getDestinationMap());
 
     // dest id
     this->spinner_dest_warp->setValue(this->warp->getDestinationWarpID());
@@ -631,18 +605,11 @@ void TriggerFrame::initialize() {
     const QSignalBlocker blocker(this);
     EventFrame::initialize();
 
-    int index = -1;
-
     // script
     this->combo_script->setCurrentText(this->trigger->getScriptLabel());
 
     // var
-    index = this->combo_var->findText(this->trigger->getScriptVar());
-    if (index < 0) {
-        this->combo_var->setCurrentText(this->trigger->getScriptVar());
-    } else {
-        this->combo_var->setCurrentIndex(index);
-    }
+    this->combo_var->setTextItem(this->trigger->getScriptVar());
 
     // var value
     this->combo_var_value->setCurrentText(this->trigger->getScriptVarValue());
@@ -709,15 +676,8 @@ void WeatherTriggerFrame::initialize() {
     const QSignalBlocker blocker(this);
     EventFrame::initialize();
 
-    int index = -1;
-
     // weather
-    index = this->combo_weather->findText(this->weatherTrigger->getWeather());
-    if (index < 0) {
-        this->combo_weather->setCurrentText(this->weatherTrigger->getWeather());
-    } else {
-        this->combo_weather->setCurrentIndex(index);
-    }
+    this->combo_weather->setTextItem(this->weatherTrigger->getWeather());
 }
 
 void WeatherTriggerFrame::populate(Project *project) {
@@ -782,15 +742,8 @@ void SignFrame::initialize() {
     const QSignalBlocker blocker(this);
     EventFrame::initialize();
 
-    int index = -1;
-
     // facing dir
-    index = this->combo_facing_dir->findText(this->sign->getFacingDirection());
-    if (index < 0) {
-        this->combo_facing_dir->setCurrentText(this->sign->getFacingDirection());
-    } else {
-        this->combo_facing_dir->setCurrentIndex(index);
-    }
+    this->combo_facing_dir->setTextItem(this->sign->getFacingDirection());
 
     // script
     this->combo_script->setCurrentText(this->sign->getScriptLabel());
@@ -905,23 +858,11 @@ void HiddenItemFrame::initialize() {
     const QSignalBlocker blocker(this);
     EventFrame::initialize();
 
-    int index = -1;
-
     // item
-    index = this->combo_item->findText(this->hiddenItem->getItem());
-    if (index < 0) {
-        this->combo_item->setCurrentText(this->hiddenItem->getItem());
-    } else {
-        this->combo_item->setCurrentIndex(index);
-    }
+    this->combo_item->setTextItem(this->hiddenItem->getItem());
 
     // flag
-    index = this->combo_flag->findText(this->hiddenItem->getFlag());
-    if (index < 0) {
-        this->combo_flag->setCurrentText(this->hiddenItem->getFlag());
-    } else {
-        this->combo_flag->setCurrentIndex(index);
-    }
+    this->combo_flag->setTextItem(this->hiddenItem->getFlag());
 
     // quantity
     if (projectConfig.getHiddenItemQuantityEnabled()) {
@@ -986,15 +927,8 @@ void SecretBaseFrame::initialize() {
     const QSignalBlocker blocker(this);
     EventFrame::initialize();
 
-    int index = -1;
-
     // id
-    index = this->combo_base_id->findText(this->secretBase->getBaseID());
-    if (index < 0) {
-        this->combo_base_id->setCurrentText(this->secretBase->getBaseID());
-    } else {
-        this->combo_base_id->setCurrentIndex(index);
-    }
+    this->combo_base_id->setTextItem(this->secretBase->getBaseID());
 }
 
 void SecretBaseFrame::populate(Project *project) {
@@ -1065,19 +999,14 @@ void HealLocationFrame::initialize() {
     const QSignalBlocker blocker(this);
     EventFrame::initialize();
 
-    if (projectConfig.getHealLocationRespawnDataEnabled()) {
-        int index = this->combo_respawn_map->findText(this->healLocation->getRespawnMap());
-        if (index < 0) {
-            this->combo_respawn_map->setCurrentText(this->healLocation->getRespawnMap());
-        } else {
-            this->combo_respawn_map->setCurrentIndex(index);
-        }
-
+    bool respawnEnabled = projectConfig.getHealLocationRespawnDataEnabled();
+    if (respawnEnabled) {
+        this->combo_respawn_map->setTextItem(this->healLocation->getRespawnMap());
         this->spinner_respawn_npc->setValue(this->healLocation->getRespawnNPC());
     }
 
-    this->hideable_respawn_map->setVisible(projectConfig.getHealLocationRespawnDataEnabled());
-    this->hideable_respawn_npc->setVisible(projectConfig.getHealLocationRespawnDataEnabled());
+    this->hideable_respawn_map->setVisible(respawnEnabled);
+    this->hideable_respawn_npc->setVisible(respawnEnabled);
 }
 
 void HealLocationFrame::populate(Project *project) {

--- a/src/ui/noscrollcombobox.cpp
+++ b/src/ui/noscrollcombobox.cpp
@@ -28,3 +28,12 @@ void NoScrollComboBox::wheelEvent(QWheelEvent *event)
     if (hasFocus())
         QComboBox::wheelEvent(event);
 }
+
+void NoScrollComboBox::setTextItem(const QString &text)
+{
+    int index = this->findText(text);
+    if (index >= 0)
+        this->setCurrentIndex(index);
+    else
+        this->setCurrentText(text);
+}

--- a/src/ui/tileseteditor.cpp
+++ b/src/ui/tileseteditor.cpp
@@ -348,25 +348,37 @@ void TilesetEditor::onHoveredMetatileCleared() {
     this->ui->statusbar->clearMessage();
 }
 
+void TilesetEditor::setComboValue(QComboBox * combo, int value) {
+    int index = combo->findData(value);
+    if (index >= 0) {
+        // Valid item
+        combo->setCurrentIndex(index);
+    } else if (combo->isEditable()) {
+        // Invalid item in editable box, just display the text
+        combo->setCurrentText(QString::number(value));
+    } else {
+        // Invalid item in uneditable box, display text as placeholder
+        // On Qt < 5.15 this will display an empty box
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 15, 0))
+        combo->setPlaceholderText(QString::number(value));
+#endif
+        combo->setCurrentIndex(index);
+    }
+}
+
 void TilesetEditor::onSelectedMetatileChanged(uint16_t metatileId) {
     this->metatile = Tileset::getMetatile(metatileId, this->primaryTileset, this->secondaryTileset);
     this->metatileLayersItem->setMetatile(metatile);
     this->metatileLayersItem->draw();
     this->ui->graphicsView_metatileLayers->setFixedSize(this->metatileLayersItem->pixmap().width() + 2, this->metatileLayersItem->pixmap().height() + 2);
-
-    int index = this->ui->comboBox_metatileBehaviors->findData(this->metatile->behavior);
-    if (index != -1)
-        this->ui->comboBox_metatileBehaviors->setCurrentIndex(index);
-    else
-        this->ui->comboBox_metatileBehaviors->setCurrentText(QString::number(this->metatile->behavior));
-
     this->ui->lineEdit_metatileLabel->setText(this->metatile->label);
+    setComboValue(this->ui->comboBox_metatileBehaviors, this->metatile->behavior);
     if (!projectConfig.getTripleLayerMetatilesEnabled()) {
-        this->ui->comboBox_layerType->setCurrentIndex(this->ui->comboBox_layerType->findData(this->metatile->layerType));
+        setComboValue(this->ui->comboBox_layerType, this->metatile->layerType);
     }
     if (projectConfig.getBaseGameVersion() == BaseGameVersion::pokefirered) {
-        this->ui->comboBox_encounterType->setCurrentIndex(this->ui->comboBox_encounterType->findData(this->metatile->encounterType));
-        this->ui->comboBox_terrainType->setCurrentIndex(this->ui->comboBox_terrainType->findData(this->metatile->terrainType));
+        setComboValue(this->ui->comboBox_encounterType, this->metatile->encounterType);
+        setComboValue(this->ui->comboBox_terrainType, this->metatile->terrainType);
     }
 }
 


### PR DESCRIPTION
For the `Movement`, `Trainer Type`, `Layer Type`, `Encounter Type`, and `Terrain Type` combo boxes, display the given value if it doesn't exist as one of the items.

Fixes a regression for this behavior on the first two, which is relevant in vanilla for e.g. the Seafoam Island boulders. These events use Trainer Type to store a flag value.


As I'm on Qt 5.14 I can't test the changes to the Tileset Editor boxes. If you run this script
```js
export function onProjectOpened(projectPath) {
    utility.registerAction("runTest", "Run Test");
}
export function runTest() {
    map.setMetatileAttributes(1, 0xFFFFFFFF);
}
```
and select metatile 1 in the Tileset Editor, you should see values displayed in the Metatile Behavior, Layer Type, and (if pokefirered) the Encounter and Terrain Type combo boxes, as opposed to empty boxes or text.
