### PR TITLE
Save new map settings, add default tileset config options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ The **"Breaking Changes"** listed below are changes that have been made in the d
 
 ### Changed
 - Overhauled the region map editor, adding support for tilemaps, and significant customization. Also now supports pokefirered.
+- Previous settings will be remembered in the New Map Options window.
 - The Custom Attributes table for map headers and events now supports types other than strings.
 - If an object event is inanimate, it will always render using its first frame.
 - Unused metatile attribute bits are preserved instead of being cleared.
@@ -62,6 +63,8 @@ The **"Breaking Changes"** listed below are changes that have been made in the d
 - Silence unnecessary error logging when parsing C defines Porymap doesn't use.
 - Fix some windows like the Tileset Editor not raising to the front when reactivated.
 - Metatile behaviors with no constant will now display their value in the Tileset Editor.
+- Fix incorrect limits on Floor Number and Border Width/Height in the New Map Options window.
+- Fix Border Width/Height being set to 0 when creating a new map from an existing layout.
 
 ## [4.5.0] - 2021-12-26
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,7 @@ The **"Breaking Changes"** listed below are changes that have been made in the d
 - Add Cut/Copy/Paste for metatiles in the Tileset Editor.
 - Add button to copy the full metatile label to the clipboard in the Tileset Editor.
 - Add ability to export an image of the primary or secondary tileset's metatiles.
-- Add option to not open the most recent project on launch.
-- Add options for customizing how new maps are filled
+- Add new config options for customizing how new maps are filled, setting default tilesets, and whether the most recent project should be opened on launch.
 - Add color picker to palette editor for taking colors from the screen.
 - Add new features to the scripting API, including the ability to display messages and user input windows, set the overlay's opacity, rotation, scale, and clipping, interact with map header properties and the map border, read tile pixel data, and more.
 

--- a/docsrc/manual/project-files.rst
+++ b/docsrc/manual/project-files.rst
@@ -57,7 +57,7 @@ For example if you wanted to rename ``include/constants/items.h`` to ``headers/d
    include/constants/metatile_labels.h, yes, yes, ``constants_metatile_labels``,
    include/constants/metatile_behaviors.h, yes, no, ``constants_metatile_behaviors``,
    include/fieldmap.h, yes, no, ``constants_fieldmap``, reads tileset related constants
-   src/event_object_movement.c, yes, no, ``path_initial_facing_table``, reads ``gInitialMovementTypeFacingDirections``
-   src/pokemon_icon.c, yes, no, ``path_pokemon_icon_table``, reads files in ``gMonIconTable``
+   src/event_object_movement.c, yes, no, ``initial_facing_table``, reads ``gInitialMovementTypeFacingDirections``
+   src/pokemon_icon.c, yes, no, ``pokemon_icon_table``, reads files in ``gMonIconTable``
 
 

--- a/docsrc/manual/settings-and-options.rst
+++ b/docsrc/manual/settings-and-options.rst
@@ -52,6 +52,8 @@ your project root as ``porymap.user.cfg``. You should add this file to your giti
    ``new_map_metatile``, 1, project, yes, The metatile id that will be used to fill new maps
    ``new_map_elevation``, 3, project, yes, The elevation that will be used to fill new maps
    ``new_map_border_metatiles``, "``468,469,476,477`` or ``20,21,28,29``", project, yes, The list of metatile ids that will be used to fill the 2x2 border of new maps
+   ``default_primary_tileset``, ``gTileset_General``, project, yes, The label of the default primary tileset
+   ``default_secondary_tileset``, ``gTileset_Petalburg`` or ``gTileset_PalletTown``, project, yes, The label of the default secondary tileset
    ``custom_scripts``, , user, yes, A list of script files to load into the scripting engine
    ``prefabs_filepath``, ``<project_root>/prefabs.json``, project, yes, The filepath containing prefab JSON data
    ``prefabs_import_prompted``, 0, project, no, Keeps track of whether or not the project was prompted for importing default prefabs

--- a/forms/newmappopup.ui
+++ b/forms/newmappopup.ui
@@ -217,7 +217,7 @@
         </widget>
        </item>
        <item row="10" column="1">
-        <widget class="NoScrollComboBox" name="comboBox_Song">
+        <widget class="NoScrollComboBox" name="comboBox_NewMap_Song">
          <property name="toolTip">
           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The default background music for this map.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
          </property>

--- a/include/config.h
+++ b/include/config.h
@@ -209,6 +209,7 @@ public:
         this->newMapMetatileId = 1;
         this->newMapElevation = 3;
         this->newMapBorderMetatileIds = DEFAULT_BORDER_RSE;
+        this->defaultPrimaryTileset = "gTileset_General";
         this->prefabFilepath = QString();
         this->prefabImportPrompted = false;
         this->tilesetsHaveCallback = true;
@@ -251,6 +252,8 @@ public:
     int getNewMapElevation();
     void setNewMapBorderMetatileIds(QList<int> metatileIds);
     QList<int> getNewMapBorderMetatileIds();
+    QString getDefaultPrimaryTileset();
+    QString getDefaultSecondaryTileset();
     void setFilePath(ProjectFilePath pathId, QString path);
     QString getFilePath(ProjectFilePath pathId);
     void setPrefabFilepath(QString filepath);
@@ -285,6 +288,8 @@ private:
     int newMapMetatileId;
     int newMapElevation;
     QList<int> newMapBorderMetatileIds;
+    QString defaultPrimaryTileset;
+    QString defaultSecondaryTileset;
     QStringList readKeys;
     QString prefabFilepath;
     bool prefabImportPrompted;

--- a/include/config.h
+++ b/include/config.h
@@ -183,8 +183,8 @@ enum ProjectFilePath {
     constants_metatile_labels,
     constants_metatile_behaviors,
     constants_fieldmap,
-    path_initial_facing_table,
-    path_pokemon_icon_table,
+    initial_facing_table,
+    pokemon_icon_table,
 };
 
 class ProjectConfig: public KeyValueConfigBase

--- a/include/core/tileset.h
+++ b/include/core/tileset.h
@@ -15,7 +15,7 @@ public:
 
 public:
     QString name;
-    QString is_secondary;
+    bool is_secondary;
     QString tiles_label;
     QString palettes_label;
     QString metatiles_label;

--- a/include/mainwindow.h
+++ b/include/mainwindow.h
@@ -176,7 +176,7 @@ private slots:
     void onMapNeedsRedrawing();
     void onTilesetsSaved(QString, QString);
     void onWildMonDataChanged();
-    void openNewMapPopupWindow(int, QVariant);
+    void openNewMapPopupWindow(MapSortOrder, QVariant);
     void openNewMapPopupWindowImportMap(MapLayout *);
     void onNewMapCreated();
     void onMapCacheCleared();
@@ -330,6 +330,7 @@ private:
     bool isProgrammaticEventTabChange;
     bool projectHasUnsavedChanges;
     bool projectOpenFailure = false;
+    bool openedNewMapDialog = false;
 
     MapSortOrder mapSortOrder;
 

--- a/include/mainwindow.h
+++ b/include/mainwindow.h
@@ -389,6 +389,7 @@ private:
 
     QObjectList shortcutableObjects() const;
     void addCustomHeaderValue(QString key, QJsonValue value, bool isNew = false);
+    int insertTilesetLabel(QStringList * list, QString label);
 };
 
 enum MapListUserRoles {

--- a/include/mainwindow.h
+++ b/include/mainwindow.h
@@ -176,8 +176,7 @@ private slots:
     void onMapNeedsRedrawing();
     void onTilesetsSaved(QString, QString);
     void onWildMonDataChanged();
-    void openNewMapPopupWindow(MapSortOrder, QVariant);
-    void openNewMapPopupWindowImportMap(MapLayout *);
+    void openNewMapPopupWindow();
     void onNewMapCreated();
     void onMapCacheCleared();
     void importMapFromAdvanceMap1_92();

--- a/include/project.h
+++ b/include/project.h
@@ -108,7 +108,8 @@ public:
     QMap<QString, Tileset*> tilesetCache;
     Tileset* loadTileset(QString, Tileset *tileset = nullptr);
     Tileset* getTileset(QString, bool forceLoad = false);
-    QMap<QString, QStringList> tilesetLabels;
+    QStringList primaryTilesetLabels;
+    QStringList secondaryTilesetLabels;
     QStringList tilesetLabelsOrdered;
 
     Blockdata readBlockdata(QString);

--- a/include/project.h
+++ b/include/project.h
@@ -171,8 +171,7 @@ public:
 
     QString defaultSong;
     QStringList getVisibilities();
-    void insertTilesetLabel(QString label, bool isSecondary);
-    void insertTilesetLabel(QString label, QString isSecondaryStr);
+    void appendTilesetLabel(QString label, QString isSecondaryStr);
     bool readTilesetLabels();
     bool readTilesetProperties();
     bool readMaxMapDataSize();

--- a/include/project.h
+++ b/include/project.h
@@ -211,6 +211,9 @@ public:
     QCompleter *getEventScriptLabelCompleter(QStringList additionalScriptLabels);
     QStringList getGlobalScriptLabels();
 
+    QString getDefaultPrimaryTilesetLabel();
+    QString getDefaultSecondaryTilesetLabel();
+
     static int getNumTilesPrimary();
     static int getNumTilesTotal();
     static int getNumMetatilesPrimary();
@@ -230,7 +233,6 @@ private:
     void updateMapLayout(Map*);
 
     void setNewMapHeader(Map* map, int mapIndex);
-    void setNewMapLayout(Map* map);
     void setNewMapBlockdata(Map* map);
     void setNewMapBorder(Map *map);
     void setNewMapEvents(Map *map);

--- a/include/ui/newmappopup.h
+++ b/include/ui/newmappopup.h
@@ -22,10 +22,10 @@ public:
     bool existingLayout;
     bool importedMap;
     QString layoutId;
+    void init();
     void init(MapSortOrder type, QVariant data);
-    void initImportMap(MapLayout *);
-    void connectSignals();
-    static void initSettings(Project *project);
+    void init(MapLayout *);
+    static void setDefaultSettings(Project *project);
 
 signals:
     void applied();
@@ -33,12 +33,11 @@ signals:
 private:
     Ui::NewMapPopup *ui;
     Project *project;
-    void setDefaultValues(int, QString);
-    void setDefaultValuesImportMap(MapLayout *);
-    void setDefaultValuesProjectConfig();
     bool checkNewMapDimensions();
     bool checkNewMapGroup();
-    void populateComboBoxes();
+    void saveSettings();
+    void useLayout(QString layoutId);
+    void useLayoutSettings(MapLayout *mapLayout);
 
     struct Settings {
         QString group;
@@ -46,8 +45,8 @@ private:
         int height;
         int borderWidth;
         int borderHeight;
-        QString primaryTileset;
-        QString secondaryTileset;
+        QString primaryTilesetLabel;
+        QString secondaryTilesetLabel;
         QString type;
         QString location;
         QString song;

--- a/include/ui/newmappopup.h
+++ b/include/ui/newmappopup.h
@@ -22,10 +22,10 @@ public:
     bool existingLayout;
     bool importedMap;
     QString layoutId;
-    void init(int, int, QString, QString);
+    void init(MapSortOrder type, QVariant data);
     void initImportMap(MapLayout *);
-    void useLayout(QString);
     void connectSignals();
+    static void initSettings(Project *project);
 
 signals:
     void applied();
@@ -35,9 +35,30 @@ private:
     Project *project;
     void setDefaultValues(int, QString);
     void setDefaultValuesImportMap(MapLayout *);
-    void setDefaultValuesProjectConfig(bool, MapLayout*);
+    void setDefaultValuesProjectConfig();
     bool checkNewMapDimensions();
     bool checkNewMapGroup();
+    void populateComboBoxes();
+
+    struct Settings {
+        QString group;
+        int width;
+        int height;
+        int borderWidth;
+        int borderHeight;
+        QString primaryTileset;
+        QString secondaryTileset;
+        QString type;
+        QString location;
+        QString song;
+        bool canFlyTo;
+        bool showLocationName;
+        bool allowRunning;
+        bool allowBiking;
+        bool allowEscaping;
+        int floorNumber;
+    };
+    static struct Settings settings;
 
 private slots:
     void on_pushButton_NewMap_Accept_clicked();

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -59,8 +59,8 @@ const QMap<ProjectFilePath, std::pair<QString, QString>> defaultPaths = {
     {ProjectFilePath::constants_metatile_labels,        { "constants_metatile_labels",       "include/constants/metatile_labels.h"}},
     {ProjectFilePath::constants_metatile_behaviors,     { "constants_metatile_behaviors",    "include/constants/metatile_behaviors.h"}},
     {ProjectFilePath::constants_fieldmap,               { "constants_fieldmap",              "include/fieldmap.h"}},
-    {ProjectFilePath::path_pokemon_icon_table,          { "path_pokemon_icon_table",         "src/pokemon_icon.c"}},
-    {ProjectFilePath::path_initial_facing_table,        { "path_initial_facing_table",       "src/event_object_movement.c"}},
+    {ProjectFilePath::pokemon_icon_table,               { "pokemon_icon_table",              "src/pokemon_icon.c"}},
+    {ProjectFilePath::initial_facing_table,             { "initial_facing_table",            "src/event_object_movement.c"}},
 };
 
 ProjectFilePath reverseDefaultPaths(QString str) {

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -545,6 +545,10 @@ void ProjectConfig::parseConfigKeyValue(QString key, QString value) {
             // Set any metatiles not provided to 0
             this->newMapBorderMetatileIds.append(0);
         }
+    } else if (key == "default_primary_tileset") {
+        this->defaultPrimaryTileset = value;
+    } else if (key == "default_secondary_tileset") {
+        this->defaultSecondaryTileset = value;
 #ifdef CONFIG_BACKWARDS_COMPATABILITY
     } else if (key == "recent_map") {
         userConfig.setRecentMap(value);
@@ -594,6 +598,7 @@ void ProjectConfig::setUnreadKeys() {
     if (!readKeys.contains("enable_floor_number")) this->enableFloorNumber = isPokefirered;
     if (!readKeys.contains("create_map_text_file")) this->createMapTextFile = (this->baseGameVersion != BaseGameVersion::pokeemerald);
     if (!readKeys.contains("new_map_border_metatiles")) this->newMapBorderMetatileIds = isPokefirered ? DEFAULT_BORDER_FRLG : DEFAULT_BORDER_RSE;
+    if (!readKeys.contains("default_secondary_tileset")) this->defaultSecondaryTileset = isPokefirered ? "gTileset_PalletTown" : "gTileset_Petalburg";
 }
 
 QMap<QString, QString> ProjectConfig::getKeyValueMap() {
@@ -616,6 +621,8 @@ QMap<QString, QString> ProjectConfig::getKeyValueMap() {
     for (auto metatile : this->newMapBorderMetatileIds)
         metatiles << QString::number(metatile);
     map.insert("new_map_border_metatiles", metatiles.join(","));
+    map.insert("default_primary_tileset", this->defaultPrimaryTileset);
+    map.insert("default_secondary_tileset", this->defaultSecondaryTileset);
     map.insert("prefabs_filepath", this->prefabFilepath);
     map.insert("prefabs_import_prompted", QString::number(this->prefabImportPrompted));
     for (auto it = this->filePaths.constKeyValueBegin(); it != this->filePaths.constKeyValueEnd(); ++it) {
@@ -652,17 +659,7 @@ void ProjectConfig::onNewConfigFileCreated() {
             this->baseGameVersion = static_cast<BaseGameVersion>(baseGameVersionComboBox->currentData().toInt());
         }
     }
-    bool isPokefirered = this->baseGameVersion == BaseGameVersion::pokefirered;
-    this->useCustomBorderSize = isPokefirered;
-    this->enableEventWeatherTrigger = !isPokefirered;
-    this->enableEventSecretBase = !isPokefirered;
-    this->enableHiddenItemQuantity = isPokefirered;
-    this->enableHiddenItemRequiresItemfinder = isPokefirered;
-    this->enableHealLocationRespawnData = isPokefirered;
-    this->enableEventCloneObject = isPokefirered;
-    this->enableFloorNumber = isPokefirered;
-    this->createMapTextFile = (this->baseGameVersion != BaseGameVersion::pokeemerald);
-    this->newMapBorderMetatileIds = isPokefirered ? DEFAULT_BORDER_FRLG : DEFAULT_BORDER_RSE;
+    this->setUnreadKeys(); // Initialize version-specific options
 }
 
 void ProjectConfig::setProjectDir(QString projectDir) {
@@ -833,6 +830,14 @@ void ProjectConfig::setNewMapBorderMetatileIds(QList<int> metatileIds) {
 
 QList<int> ProjectConfig::getNewMapBorderMetatileIds() {
     return this->newMapBorderMetatileIds;
+}
+
+QString ProjectConfig::getDefaultPrimaryTileset() {
+    return this->defaultPrimaryTileset;
+}
+
+QString ProjectConfig::getDefaultSecondaryTileset() {
+    return this->defaultSecondaryTileset;
 }
 
 void ProjectConfig::setPrefabFilepath(QString filepath) {

--- a/src/core/tileset.cpp
+++ b/src/core/tileset.cpp
@@ -128,19 +128,20 @@ QList<QRgb> Tileset::getPalette(int paletteId, Tileset *primaryTileset, Tileset 
 
 bool Tileset::appendToHeaders(QString root, QString friendlyName, bool usingAsm) {
     QString headersFile = root + "/" + (usingAsm ? projectConfig.getFilePath(ProjectFilePath::tilesets_headers_asm)
-                                              : projectConfig.getFilePath(ProjectFilePath::tilesets_headers));
+                                                 : projectConfig.getFilePath(ProjectFilePath::tilesets_headers));
     QFile file(headersFile);
     if (!file.open(QIODevice::WriteOnly | QIODevice::Append)) {
         logError(QString("Could not write to file \"%1\"").arg(headersFile));
         return false;
     }
+    QString isSecondaryStr = this->is_secondary ? "TRUE" : "FALSE";
     QString dataString = "\n";
     if (usingAsm) {
         // Append to asm file
         dataString.append("\t.align 2\n");
         dataString.append(QString("%1::\n").arg(this->name));
         dataString.append("\t.byte TRUE @ is compressed\n");
-        dataString.append(QString("\t.byte %1 @ is secondary\n").arg(this->is_secondary));
+        dataString.append(QString("\t.byte %1 @ is secondary\n").arg(isSecondaryStr));
         dataString.append("\t.2byte 0 @ padding\n");
         dataString.append(QString("\t.4byte gTilesetTiles_%1\n").arg(friendlyName));
         dataString.append(QString("\t.4byte gTilesetPalettes_%1\n").arg(friendlyName));
@@ -156,7 +157,7 @@ bool Tileset::appendToHeaders(QString root, QString friendlyName, bool usingAsm)
         // Append to C file
         dataString.append(QString("const struct Tileset %1 =\n{\n").arg(this->name));
         if (projectConfig.getTilesetsHaveIsCompressed()) dataString.append("    .isCompressed = TRUE,\n");
-        dataString.append(QString("    .isSecondary = %1,\n").arg(this->is_secondary));
+        dataString.append(QString("    .isSecondary = %1,\n").arg(isSecondaryStr));
         dataString.append(QString("    .tiles = gTilesetTiles_%1,\n").arg(friendlyName));
         dataString.append(QString("    .palettes = gTilesetPalettes_%1,\n").arg(friendlyName));
         dataString.append(QString("    .metatiles = gMetatiles_%1,\n").arg(friendlyName));
@@ -245,7 +246,7 @@ bool Tileset::appendToMetatiles(QString root, QString friendlyName, bool usingAs
 // Example: for gTileset_DepartmentStore, returns "data/tilesets/secondary/department_store"
 QString Tileset::getExpectedDir()
 {
-    return Tileset::getExpectedDir(this->name, ParseUtil::gameStringToBool(this->is_secondary));
+    return Tileset::getExpectedDir(this->name, this->is_secondary);
 }
 
 QString Tileset::getExpectedDir(QString tilesetName, bool isSecondary)

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1141,20 +1141,20 @@ void MainWindow::onOpenMapListContextMenu(const QPoint &point)
 
 void MainWindow::onAddNewMapToGroupClick(QAction* triggeredAction)
 {
-    int groupNum = triggeredAction->data().toInt();
-    openNewMapPopupWindow(MapSortOrder::Group, groupNum);
+    openNewMapPopupWindow();
+    this->newMapPrompt->init(MapSortOrder::Group, triggeredAction->data());
 }
 
 void MainWindow::onAddNewMapToAreaClick(QAction* triggeredAction)
 {
-    QString secName = triggeredAction->data().toString();
-    openNewMapPopupWindow(MapSortOrder::Area, secName);
+    openNewMapPopupWindow();
+    this->newMapPrompt->init(MapSortOrder::Area, triggeredAction->data());
 }
 
 void MainWindow::onAddNewMapToLayoutClick(QAction* triggeredAction)
 {
-    QString layoutId = triggeredAction->data().toString();
-    openNewMapPopupWindow(MapSortOrder::Layout, layoutId);
+    openNewMapPopupWindow();
+    this->newMapPrompt->init(MapSortOrder::Layout, triggeredAction->data());
 }
 
 void MainWindow::onNewMapCreated() {
@@ -1191,9 +1191,10 @@ void MainWindow::onNewMapCreated() {
     delete newMap;
 }
 
-void MainWindow::openNewMapPopupWindow(MapSortOrder type, QVariant data) {
+void MainWindow::openNewMapPopupWindow() {
     if (!openedNewMapDialog) {
-        NewMapPopup::initSettings(this->editor->project);
+        NewMapPopup::setDefaultSettings(this->editor->project);
+        openedNewMapDialog = true;
     }
     if (!this->newMapPrompt) {
         this->newMapPrompt = new NewMapPopup(this, this->editor->project);
@@ -1204,31 +1205,13 @@ void MainWindow::openNewMapPopupWindow(MapSortOrder type, QVariant data) {
         this->newMapPrompt->raise();
         this->newMapPrompt->activateWindow();
     }
-    this->newMapPrompt->init(type, data);
     connect(this->newMapPrompt, &NewMapPopup::applied, this, &MainWindow::onNewMapCreated);
     this->newMapPrompt->setAttribute(Qt::WA_DeleteOnClose);
 }
 
-void MainWindow::openNewMapPopupWindowImportMap(MapLayout *mapLayout) {
-    if (!this->newMapPrompt) {
-        this->newMapPrompt = new NewMapPopup(this, this->editor->project);
-    }
-    if (!this->newMapPrompt->isVisible()) {
-        this->newMapPrompt->show();
-    } else {
-        this->newMapPrompt->raise();
-        this->newMapPrompt->activateWindow();
-    }
-
-    this->newMapPrompt->initImportMap(mapLayout);
-
-    connect(this->newMapPrompt, SIGNAL(applied()), this, SLOT(onNewMapCreated()));
-    connect(this->newMapPrompt, &QObject::destroyed, [=](QObject *) { this->newMapPrompt = nullptr; });
-    this->newMapPrompt->setAttribute(Qt::WA_DeleteOnClose);
-}
-
 void MainWindow::on_action_NewMap_triggered() {
-    openNewMapPopupWindow(MapSortOrder::Group, 0);
+    openNewMapPopupWindow();
+    this->newMapPrompt->init();
 }
 
 // Insert label for newly-created tileset into sorted list of existing labels
@@ -2466,7 +2449,8 @@ void MainWindow::importMapFromAdvanceMap1_92()
         return;
     }
 
-    openNewMapPopupWindowImportMap(mapLayout);
+    openNewMapPopupWindow();
+    this->newMapPrompt->init(mapLayout);
 }
 
 void MainWindow::showExportMapImageWindow(ImageExporterMode mode) {

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1191,7 +1191,10 @@ void MainWindow::onNewMapCreated() {
     delete newMap;
 }
 
-void MainWindow::openNewMapPopupWindow(int type, QVariant data) {
+void MainWindow::openNewMapPopupWindow(MapSortOrder type, QVariant data) {
+    if (!openedNewMapDialog) {
+        NewMapPopup::initSettings(this->editor->project);
+    }
     if (!this->newMapPrompt) {
         this->newMapPrompt = new NewMapPopup(this, this->editor->project);
     }
@@ -1201,18 +1204,7 @@ void MainWindow::openNewMapPopupWindow(int type, QVariant data) {
         this->newMapPrompt->raise();
         this->newMapPrompt->activateWindow();
     }
-    switch (type)
-    {
-        case MapSortOrder::Group:
-            this->newMapPrompt->init(type, data.toInt(), QString(), QString());
-            break;
-        case MapSortOrder::Area:
-            this->newMapPrompt->init(type, 0, data.toString(), QString());
-            break;
-        case MapSortOrder::Layout:
-            this->newMapPrompt->init(type, 0, QString(), data.toString());
-            break;
-    }
+    this->newMapPrompt->init(type, data);
     connect(this->newMapPrompt, &NewMapPopup::applied, this, &MainWindow::onNewMapCreated);
     this->newMapPrompt->setAttribute(Qt::WA_DeleteOnClose);
 }
@@ -1232,7 +1224,7 @@ void MainWindow::openNewMapPopupWindowImportMap(MapLayout *mapLayout) {
 
     connect(this->newMapPrompt, SIGNAL(applied()), this, SLOT(onNewMapCreated()));
     connect(this->newMapPrompt, &QObject::destroyed, [=](QObject *) { this->newMapPrompt = nullptr; });
-            this->newMapPrompt->setAttribute(Qt::WA_DeleteOnClose);
+    this->newMapPrompt->setAttribute(Qt::WA_DeleteOnClose);
 }
 
 void MainWindow::on_action_NewMap_triggered() {

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1284,7 +1284,7 @@ void MainWindow::on_actionNew_Tileset_triggered() {
         newSet.tilesImagePath = fullDirectoryPath + "/tiles.png";
         newSet.metatiles_path = fullDirectoryPath + "/metatiles.bin";
         newSet.metatile_attrs_path = fullDirectoryPath + "/metatile_attributes.bin";
-        newSet.is_secondary = createTilesetDialog->isSecondary ? "TRUE" : "FALSE";
+        newSet.is_secondary = createTilesetDialog->isSecondary;
         int numMetaTiles = createTilesetDialog->isSecondary ? (Project::getNumTilesTotal() - Project::getNumTilesPrimary()) : Project::getNumTilesPrimary();
         QImage tilesImage(":/images/blank_tileset.png");
         editor->project->loadTilesetTiles(&newSet, tilesImage);

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1239,6 +1239,15 @@ void MainWindow::on_action_NewMap_triggered() {
     openNewMapPopupWindow(MapSortOrder::Group, 0);
 }
 
+// Insert label for newly-created tileset into sorted list of existing labels
+int MainWindow::insertTilesetLabel(QStringList * list, QString label) {
+    int i = 0;
+    for (; i < list->length(); i++)
+        if (list->at(i) > label) break;
+    list->insert(i, label);
+    return i;
+}
+
 void MainWindow::on_actionNew_Tileset_triggered() {
     NewTilesetDialog *createTilesetDialog = new NewTilesetDialog(editor->project, this);
     if(createTilesetDialog->exec() == QDialog::Accepted){
@@ -1324,12 +1333,14 @@ void MainWindow::on_actionNew_Tileset_triggered() {
         newSet.appendToGraphics(editor->project->root, createTilesetDialog->friendlyName, editor->project->usingAsmTilesets);
         newSet.appendToMetatiles(editor->project->root, createTilesetDialog->friendlyName, editor->project->usingAsmTilesets);
 
-        if(!createTilesetDialog->isSecondary) {
-            this->ui->comboBox_PrimaryTileset->addItem(createTilesetDialog->fullSymbolName);
+        if (!createTilesetDialog->isSecondary) {
+            int index = insertTilesetLabel(&editor->project->primaryTilesetLabels, createTilesetDialog->fullSymbolName);
+            this->ui->comboBox_PrimaryTileset->insertItem(index, createTilesetDialog->fullSymbolName);
         } else {
-            this->ui->comboBox_SecondaryTileset->addItem(createTilesetDialog->fullSymbolName);
+            int index = insertTilesetLabel(&editor->project->secondaryTilesetLabels, createTilesetDialog->fullSymbolName);
+            this->ui->comboBox_SecondaryTileset->insertItem(index, createTilesetDialog->fullSymbolName);
         }
-        editor->project->insertTilesetLabel(createTilesetDialog->fullSymbolName, createTilesetDialog->isSecondary);
+        insertTilesetLabel(&editor->project->tilesetLabelsOrdered, createTilesetDialog->fullSymbolName);
 
         QMessageBox msgBox(this);
         msgBox.setText("Successfully created tileset.");

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -961,9 +961,9 @@ bool MainWindow::loadProjectCombos() {
     ui->comboBox_Location->clear();
     ui->comboBox_Location->addItems(project->mapSectionValueToName.values());
     ui->comboBox_PrimaryTileset->clear();
-    ui->comboBox_PrimaryTileset->addItems(project->tilesetLabels.value("primary"));
+    ui->comboBox_PrimaryTileset->addItems(project->primaryTilesetLabels);
     ui->comboBox_SecondaryTileset->clear();
-    ui->comboBox_SecondaryTileset->addItems(project->tilesetLabels.value("secondary"));
+    ui->comboBox_SecondaryTileset->addItems(project->secondaryTilesetLabels);
     ui->comboBox_Weather->clear();
     ui->comboBox_Weather->addItems(project->weatherNames);
     ui->comboBox_BattleScene->clear();
@@ -1266,8 +1266,7 @@ void MainWindow::on_actionNew_Tileset_triggered() {
             msgBox.exec();
             return;
         }
-        if (editor->project->tilesetLabels.value("primary").contains(createTilesetDialog->fullSymbolName)
-         || editor->project->tilesetLabels.value("secondary").contains(createTilesetDialog->fullSymbolName)) {
+        if (editor->project->tilesetLabelsOrdered.contains(createTilesetDialog->fullSymbolName)) {
             logError(QString("Could not create tileset \"%1\", the symbol \"%2\" already exists.").arg(createTilesetDialog->friendlyName, createTilesetDialog->fullSymbolName));
             QMessageBox msgBox(this);
             msgBox.setText("Failed to add new tileset.");
@@ -2547,7 +2546,7 @@ void MainWindow::on_comboBox_EmergeMap_currentTextChanged(const QString &mapName
 
 void MainWindow::on_comboBox_PrimaryTileset_currentTextChanged(const QString &tilesetLabel)
 {
-    if (editor->project->tilesetLabels["primary"].contains(tilesetLabel) && editor->map) {
+    if (editor->project->primaryTilesetLabels.contains(tilesetLabel) && editor->map) {
         editor->updatePrimaryTileset(tilesetLabel);
         redrawMapScene();
         on_horizontalSlider_MetatileZoom_valueChanged(ui->horizontalSlider_MetatileZoom->value());
@@ -2559,7 +2558,7 @@ void MainWindow::on_comboBox_PrimaryTileset_currentTextChanged(const QString &ti
 
 void MainWindow::on_comboBox_SecondaryTileset_currentTextChanged(const QString &tilesetLabel)
 {
-    if (editor->project->tilesetLabels["secondary"].contains(tilesetLabel) && editor->map) {
+    if (editor->project->secondaryTilesetLabels.contains(tilesetLabel) && editor->map) {
         editor->updateSecondaryTileset(tilesetLabel);
         redrawMapScene();
         on_horizontalSlider_MetatileZoom_valueChanged(ui->horizontalSlider_MetatileZoom->value());

--- a/src/project.cpp
+++ b/src/project.cpp
@@ -2166,7 +2166,7 @@ bool Project::readMovementTypes() {
 }
 
 bool Project::readInitialFacingDirections() {
-    QString filename = projectConfig.getFilePath(ProjectFilePath::path_initial_facing_table);
+    QString filename = projectConfig.getFilePath(ProjectFilePath::initial_facing_table);
     fileWatcher.addPath(root + "/" + filename);
     facingDirections = parser.readNamedIndexCArray(filename, "gInitialMovementTypeFacingDirections");
     if (facingDirections.isEmpty()) {
@@ -2507,7 +2507,7 @@ bool Project::readEventGraphics() {
 
 bool Project::readSpeciesIconPaths() {
     speciesToIconPath.clear();
-    QString srcfilename = projectConfig.getFilePath(ProjectFilePath::path_pokemon_icon_table);
+    QString srcfilename = projectConfig.getFilePath(ProjectFilePath::pokemon_icon_table);
     QString incfilename = projectConfig.getFilePath(ProjectFilePath::data_pokemon_gfx);
     fileWatcher.addPath(root + "/" + srcfilename);
     fileWatcher.addPath(root + "/" + incfilename);

--- a/src/project.cpp
+++ b/src/project.cpp
@@ -1851,22 +1851,16 @@ QString Project::getDefaultSecondaryTilesetLabel() {
     return defaultLabel;
 }
 
-void Project::insertTilesetLabel(QString label, bool isSecondary) {
-    if (!isSecondary)
-        this->primaryTilesetLabels.append(label);
-    else
-        this->secondaryTilesetLabels.append(label);
-    this->tilesetLabelsOrdered.append(label);
-}
-
-void Project::insertTilesetLabel(QString label, QString isSecondaryStr) {
+void Project::appendTilesetLabel(QString label, QString isSecondaryStr) {
     bool ok;
     bool isSecondary = ParseUtil::gameStringToBool(isSecondaryStr, &ok);
     if (!ok) {
         logError(QString("Unable to convert value '%1' of isSecondary to bool for tileset %2.").arg(isSecondaryStr).arg(label));
         return;
     }
-    insertTilesetLabel(label, isSecondary);
+    QStringList * list = isSecondary ? &this->secondaryTilesetLabels : &this->primaryTilesetLabels;
+    list->append(label);
+    this->tilesetLabelsOrdered.append(label);
 }
 
 bool Project::readTilesetLabels() {
@@ -1891,7 +1885,7 @@ bool Project::readTilesetLabels() {
         QRegularExpressionMatchIterator iter = re.globalMatch(text);
         while (iter.hasNext()) {
             QRegularExpressionMatch match = iter.next();
-            insertTilesetLabel(match.captured("label"), match.captured("isSecondary"));
+            appendTilesetLabel(match.captured("label"), match.captured("isSecondary"));
         }
         filename = asm_filename; // For error reporting further down
     } else {
@@ -1900,7 +1894,7 @@ bool Project::readTilesetLabels() {
         QStringList labels = structs.keys();
         // TODO: This is alphabetical, AdvanceMap import wants the vanilla order in tilesetLabelsOrdered
         for (const auto tilesetLabel : labels){
-            insertTilesetLabel(tilesetLabel, structs[tilesetLabel].value("isSecondary"));
+            appendTilesetLabel(tilesetLabel, structs[tilesetLabel].value("isSecondary"));
         }
     }
 

--- a/src/project.cpp
+++ b/src/project.cpp
@@ -1887,6 +1887,9 @@ bool Project::readTilesetLabels() {
             QRegularExpressionMatch match = iter.next();
             appendTilesetLabel(match.captured("label"), match.captured("isSecondary"));
         }
+        this->primaryTilesetLabels.sort();
+        this->secondaryTilesetLabels.sort();
+        this->tilesetLabelsOrdered.sort();
         filename = asm_filename; // For error reporting further down
     } else {
         this->usingAsmTilesets = false;

--- a/src/project.cpp
+++ b/src/project.cpp
@@ -1062,7 +1062,7 @@ Tileset* Project::loadTileset(QString label, Tileset *tileset) {
             tileset = new Tileset;
         }
         tileset->name = label;
-        tileset->is_secondary = values.value(memberMap.key("isSecondary"));
+        tileset->is_secondary = ParseUtil::gameStringToBool(values.value(memberMap.key("isSecondary")));
         tileset->tiles_label = values.value(memberMap.key("tiles"));
         tileset->palettes_label = values.value(memberMap.key("palettes"));
         tileset->metatiles_label = values.value(memberMap.key("metatiles"));
@@ -1078,7 +1078,7 @@ Tileset* Project::loadTileset(QString label, Tileset *tileset) {
         }
         const auto tilesetAttributes = structs[label];
         tileset->name = label;
-        tileset->is_secondary = tilesetAttributes.value("isSecondary");
+        tileset->is_secondary = ParseUtil::gameStringToBool(tilesetAttributes.value("isSecondary"));
         tileset->tiles_label = tilesetAttributes.value("tiles");
         tileset->palettes_label = tilesetAttributes.value("palettes");
         tileset->metatiles_label = tilesetAttributes.value("metatiles");
@@ -1568,7 +1568,8 @@ void Project::loadTilesetMetatileLabels(Tileset* tileset) {
     for (QString labelName : labels.keys()) {
         int metatileId = labels[labelName];
         // subtract Project::num_tiles_primary from secondary metatiles
-        Metatile *metatile = Tileset::getMetatile(metatileId - (ParseUtil::gameStringToBool(tileset->is_secondary) ? Project::num_tiles_primary : 0), tileset, nullptr);
+        int offset = tileset->is_secondary ? Project::num_tiles_primary : 0;
+        Metatile *metatile = Tileset::getMetatile(metatileId - offset, tileset, nullptr);
         if (metatile) {
             metatile->label = labelName.replace(tilesetPrefix, "");
         } else {

--- a/src/scriptapi/apiutility.cpp
+++ b/src/scriptapi/apiutility.cpp
@@ -226,13 +226,13 @@ QList<QString> ScriptUtility::getTilesetNames() {
 QList<QString> ScriptUtility::getPrimaryTilesetNames() {
     if (!window || !window->editor || !window->editor->project)
         return QList<QString>();
-    return window->editor->project->tilesetLabels["primary"];
+    return window->editor->project->primaryTilesetLabels;
 }
 
 QList<QString> ScriptUtility::getSecondaryTilesetNames() {
     if (!window || !window->editor || !window->editor->project)
         return QList<QString>();
-    return window->editor->project->tilesetLabels["secondary"];
+    return window->editor->project->secondaryTilesetLabels;
 }
 
 QList<QString> ScriptUtility::getMetatileBehaviorNames() {

--- a/src/ui/newmappopup.cpp
+++ b/src/ui/newmappopup.cpp
@@ -23,67 +23,104 @@ NewMapPopup::NewMapPopup(QWidget *parent, Project *project) :
 
 NewMapPopup::~NewMapPopup()
 {
+    saveSettings();
     delete ui;
 }
 
-void NewMapPopup::initSettings(Project *project) {
-    settings.group = project->groupNames.at(0);
-    settings.width = project->getDefaultMapSize();
-    settings.height = project->getDefaultMapSize();
-    settings.borderWidth = DEFAULT_BORDER_WIDTH;
-    settings.borderHeight = DEFAULT_BORDER_HEIGHT;
-    settings.primaryTileset = project->getDefaultPrimaryTilesetLabel();
-    settings.secondaryTileset = project->getDefaultSecondaryTilesetLabel();
-    settings.type = project->mapTypes.at(0);
-    settings.location = project->mapSectionValueToName.values().at(0);
-    settings.song = project->songNames.at(0);
-    settings.canFlyTo = false;
-    settings.showLocationName = true;
-    settings.allowRunning = false;
-    settings.allowBiking = false;
-    settings.allowEscaping = false;
-    settings.floorNumber = 0;
-}
-
-void NewMapPopup::init(MapSortOrder type, QVariant data) {
-    int groupNum = 0;
-    QString mapSec = QString();
-
-    switch (type)
-    {
-    case MapSortOrder::Group:
-        groupNum = data.toInt();
-        break;
-    case MapSortOrder::Area:
-        mapSec = data.toString();
-        break;
-    case MapSortOrder::Layout:
-        this->existingLayout = true;
-        this->layoutId = data.toString();
-        break;
-    }
-
-    populateComboBoxes();
-    setDefaultValues(groupNum, mapSec);
-    setDefaultValuesProjectConfig();
-    connectSignals();
-}
-
-void NewMapPopup::initImportMap(MapLayout *mapLayout) {
-    this->importedMap = true;
-    populateComboBoxes();
-    setDefaultValuesImportMap(mapLayout);
-    setDefaultValuesProjectConfig();
-    connectSignals();
-}
-
-void NewMapPopup::populateComboBoxes() {
+void NewMapPopup::init() {
+    // Populate combo boxes
     ui->comboBox_NewMap_Primary_Tileset->addItems(project->primaryTilesetLabels);
     ui->comboBox_NewMap_Secondary_Tileset->addItems(project->secondaryTilesetLabels);
     ui->comboBox_NewMap_Group->addItems(project->groupNames);
     ui->comboBox_NewMap_Song->addItems(project->songNames);
     ui->comboBox_NewMap_Type->addItems(project->mapTypes);
     ui->comboBox_NewMap_Location->addItems(project->mapSectionValueToName.values());
+
+    // Set spin box limits
+    ui->spinBox_NewMap_Width->setMinimum(1);
+    ui->spinBox_NewMap_Height->setMinimum(1);
+    ui->spinBox_NewMap_Width->setMaximum(project->getMaxMapWidth());
+    ui->spinBox_NewMap_Height->setMaximum(project->getMaxMapHeight());
+    ui->spinBox_NewMap_BorderWidth->setMinimum(1);
+    ui->spinBox_NewMap_BorderHeight->setMinimum(1);
+    ui->spinBox_NewMap_Floor_Number->setMinimum(-128);
+    ui->spinBox_NewMap_Floor_Number->setMaximum(127);
+
+    // Hide config specific ui elements
+    bool hasFlags = (projectConfig.getBaseGameVersion() != BaseGameVersion::pokeruby);
+    ui->checkBox_NewMap_Allow_Running->setVisible(hasFlags);
+    ui->checkBox_NewMap_Allow_Biking->setVisible(hasFlags);
+    ui->checkBox_NewMap_Allow_Escape_Rope->setVisible(hasFlags);
+    ui->label_NewMap_Allow_Running->setVisible(hasFlags);
+    ui->label_NewMap_Allow_Biking->setVisible(hasFlags);
+    ui->label_NewMap_Allow_Escape_Rope->setVisible(hasFlags);
+
+    bool hasCustomBorders = projectConfig.getUseCustomBorderSize();
+    ui->spinBox_NewMap_BorderWidth->setVisible(hasCustomBorders);
+    ui->spinBox_NewMap_BorderHeight->setVisible(hasCustomBorders);
+    ui->label_NewMap_BorderWidth->setVisible(hasCustomBorders);
+    ui->label_NewMap_BorderHeight->setVisible(hasCustomBorders);
+
+    bool hasFloorNumber = projectConfig.getFloorNumberEnabled();
+    ui->spinBox_NewMap_Floor_Number->setVisible(hasFloorNumber);
+    ui->label_NewMap_Floor_Number->setVisible(hasFloorNumber);
+
+    // Restore previous settings
+    ui->lineEdit_NewMap_Name->setText(project->getNewMapName());
+    ui->comboBox_NewMap_Group->setTextItem(settings.group);
+    ui->spinBox_NewMap_Width->setValue(settings.width);
+    ui->spinBox_NewMap_Height->setValue(settings.height);
+    ui->spinBox_NewMap_BorderWidth->setValue(settings.borderWidth);
+    ui->spinBox_NewMap_BorderHeight->setValue(settings.borderHeight);
+    ui->comboBox_NewMap_Primary_Tileset->setTextItem(settings.primaryTilesetLabel);
+    ui->comboBox_NewMap_Secondary_Tileset->setTextItem(settings.secondaryTilesetLabel);
+    ui->comboBox_NewMap_Type->setTextItem(settings.type);
+    ui->comboBox_NewMap_Location->setTextItem(settings.location);
+    ui->comboBox_NewMap_Song->setTextItem(settings.song);
+    ui->checkBox_NewMap_Flyable->setChecked(settings.canFlyTo);
+    ui->checkBox_NewMap_Show_Location->setChecked(settings.showLocationName);
+    ui->checkBox_NewMap_Allow_Running->setChecked(settings.allowRunning);
+    ui->checkBox_NewMap_Allow_Biking->setChecked(settings.allowBiking);
+    ui->checkBox_NewMap_Allow_Escape_Rope->setChecked(settings.allowEscaping);
+    ui->spinBox_NewMap_Floor_Number->setValue(settings.floorNumber);
+
+    // Connect signals
+    connect(ui->spinBox_NewMap_Width, QOverload<int>::of(&QSpinBox::valueChanged), [=](int){checkNewMapDimensions();});
+    connect(ui->spinBox_NewMap_Height, QOverload<int>::of(&QSpinBox::valueChanged), [=](int){checkNewMapDimensions();});
+
+    ui->frame_NewMap_Options->setEnabled(true);
+}
+
+// Creating new map by right-clicking in the map list
+void NewMapPopup::init(MapSortOrder type, QVariant data) {
+    switch (type)
+    {
+    case MapSortOrder::Group:
+        settings.group = project->groupNames.at(data.toInt());
+        break;
+    case MapSortOrder::Area:
+        settings.location = data.toString();
+        break;
+    case MapSortOrder::Layout:
+        useLayout(data.toString());
+        break;
+    }
+    init();
+}
+
+// Creating new map from AdvanceMap import
+void NewMapPopup::init(MapLayout *mapLayout) {
+    this->importedMap = true;
+    useLayoutSettings(mapLayout);
+
+    this->map = new Map();
+    this->map->layout = new MapLayout();
+    this->map->layout->blockdata = mapLayout->blockdata;
+
+    if (!mapLayout->border.isEmpty()) {
+        this->map->layout->border = mapLayout->border;
+    }
+    init();
 }
 
 bool NewMapPopup::checkNewMapDimensions() {
@@ -127,94 +164,66 @@ bool NewMapPopup::checkNewMapGroup() {
     }
 }
 
-void NewMapPopup::connectSignals() {
-    ui->spinBox_NewMap_Width->setMinimum(1);
-    ui->spinBox_NewMap_Height->setMinimum(1);
-    ui->spinBox_NewMap_Width->setMaximum(project->getMaxMapWidth());
-    ui->spinBox_NewMap_Height->setMaximum(project->getMaxMapHeight());
-
-    connect(ui->spinBox_NewMap_Width, QOverload<int>::of(&QSpinBox::valueChanged), [=](int){checkNewMapDimensions();});
-    connect(ui->spinBox_NewMap_Height, QOverload<int>::of(&QSpinBox::valueChanged), [=](int){checkNewMapDimensions();});
+void NewMapPopup::setDefaultSettings(Project *project) {
+    settings.group = project->groupNames.at(0);
+    settings.width = project->getDefaultMapSize();
+    settings.height = project->getDefaultMapSize();
+    settings.borderWidth = DEFAULT_BORDER_WIDTH;
+    settings.borderHeight = DEFAULT_BORDER_HEIGHT;
+    settings.primaryTilesetLabel = project->getDefaultPrimaryTilesetLabel();
+    settings.secondaryTilesetLabel = project->getDefaultSecondaryTilesetLabel();
+    settings.type = project->mapTypes.at(0);
+    settings.location = project->mapSectionValueToName.values().at(0);
+    settings.song = project->songNames.at(0);
+    settings.canFlyTo = false;
+    settings.showLocationName = true;
+    settings.allowRunning = false;
+    settings.allowBiking = false;
+    settings.allowEscaping = false;
+    settings.floorNumber = 0;
 }
 
-void NewMapPopup::setDefaultValues(int groupNum, QString mapSec) {
-    ui->lineEdit_NewMap_Name->setText(project->getNewMapName());
-
-    ui->comboBox_NewMap_Group->setTextItem(project->groupNames.at(groupNum));
-
-    if (this->existingLayout) {
-        MapLayout * layout = project->mapLayouts.value(layoutId);
-        ui->spinBox_NewMap_Width->setValue(layout->width);
-        ui->spinBox_NewMap_Height->setValue(layout->height);
-        ui->spinBox_NewMap_BorderWidth->setValue(layout->border_width);
-        ui->spinBox_NewMap_BorderHeight->setValue(layout->border_height);
-        ui->comboBox_NewMap_Primary_Tileset->setTextItem(layout->tileset_primary_label);
-        ui->comboBox_NewMap_Secondary_Tileset->setTextItem(layout->tileset_secondary_label);
-        ui->spinBox_NewMap_Width->setDisabled(true);
-        ui->spinBox_NewMap_Height->setDisabled(true);
-        ui->spinBox_NewMap_BorderWidth->setDisabled(true);
-        ui->spinBox_NewMap_BorderHeight->setDisabled(true);
-        ui->comboBox_NewMap_Primary_Tileset->setDisabled(true);
-        ui->comboBox_NewMap_Secondary_Tileset->setDisabled(true);
-    } else {
-        ui->spinBox_NewMap_Width->setValue(project->getDefaultMapSize());
-        ui->spinBox_NewMap_Height->setValue(project->getDefaultMapSize());
-        ui->spinBox_NewMap_BorderWidth->setValue(DEFAULT_BORDER_WIDTH);
-        ui->spinBox_NewMap_BorderHeight->setValue(DEFAULT_BORDER_HEIGHT);
-        ui->comboBox_NewMap_Primary_Tileset->setTextItem(project->getDefaultPrimaryTilesetLabel());
-        ui->comboBox_NewMap_Secondary_Tileset->setTextItem(project->getDefaultSecondaryTilesetLabel());
-    }
-
-    if (!mapSec.isEmpty()) ui->comboBox_NewMap_Location->setTextItem(mapSec);
-    ui->checkBox_NewMap_Show_Location->setChecked(true);
-
-    ui->frame_NewMap_Options->setEnabled(true);
+void NewMapPopup::saveSettings() {
+    settings.group = ui->comboBox_NewMap_Group->currentText();
+    settings.width = ui->spinBox_NewMap_Width->value();
+    settings.height = ui->spinBox_NewMap_Height->value();
+    settings.borderWidth = ui->spinBox_NewMap_BorderWidth->value();
+    settings.borderHeight = ui->spinBox_NewMap_BorderHeight->value();
+    settings.primaryTilesetLabel = ui->comboBox_NewMap_Primary_Tileset->currentText();
+    settings.secondaryTilesetLabel = ui->comboBox_NewMap_Secondary_Tileset->currentText();
+    settings.type = ui->comboBox_NewMap_Type->currentText();
+    settings.location = ui->comboBox_NewMap_Location->currentText();
+    settings.song = ui->comboBox_NewMap_Song->currentText();
+    settings.canFlyTo = ui->checkBox_NewMap_Flyable->isChecked();
+    settings.showLocationName = ui->checkBox_NewMap_Show_Location->isChecked();
+    settings.allowRunning = ui->checkBox_NewMap_Allow_Running->isChecked();
+    settings.allowBiking = ui->checkBox_NewMap_Allow_Biking->isChecked();
+    settings.allowEscaping = ui->checkBox_NewMap_Allow_Escape_Rope->isChecked();
+    settings.floorNumber = ui->spinBox_NewMap_Floor_Number->value();
 }
 
-void NewMapPopup::setDefaultValuesImportMap(MapLayout *mapLayout) {
-    ui->lineEdit_NewMap_Name->setText(project->getNewMapName());
-
-    ui->comboBox_NewMap_Group->setTextItem(project->groupNames.at(0));
-
-    ui->spinBox_NewMap_Width->setValue(mapLayout->width);
-    ui->spinBox_NewMap_Height->setValue(mapLayout->height);
-    ui->spinBox_NewMap_BorderWidth->setValue(mapLayout->border_width);
-    ui->spinBox_NewMap_BorderHeight->setValue(mapLayout->border_height);
-
-    ui->comboBox_NewMap_Primary_Tileset->setTextItem(mapLayout->tileset_primary_label);
-    ui->comboBox_NewMap_Secondary_Tileset->setTextItem(mapLayout->tileset_secondary_label);
-
-    ui->checkBox_NewMap_Show_Location->setChecked(true);
-
-    ui->frame_NewMap_Options->setEnabled(true);
-
-    this->map = new Map();
-    this->map->layout = new MapLayout();
-    this->map->layout->blockdata = mapLayout->blockdata;
-
-    if (!mapLayout->border.isEmpty()) {
-        this->map->layout->border = mapLayout->border;
-    }
+void NewMapPopup::useLayoutSettings(MapLayout *layout) {
+    if (!layout) return;
+    settings.width = layout->width;
+    settings.height = layout->height;
+    settings.borderWidth = layout->border_width;
+    settings.borderHeight = layout->border_height;
+    settings.primaryTilesetLabel = layout->tileset_primary_label;
+    settings.secondaryTilesetLabel = layout->tileset_secondary_label;
 }
 
-void NewMapPopup::setDefaultValuesProjectConfig() {
-    bool hasFlags = (projectConfig.getBaseGameVersion() != BaseGameVersion::pokeruby);
-    ui->checkBox_NewMap_Allow_Running->setVisible(hasFlags);
-    ui->checkBox_NewMap_Allow_Biking->setVisible(hasFlags);
-    ui->checkBox_NewMap_Allow_Escape_Rope->setVisible(hasFlags);
-    ui->label_NewMap_Allow_Running->setVisible(hasFlags);
-    ui->label_NewMap_Allow_Biking->setVisible(hasFlags);
-    ui->label_NewMap_Allow_Escape_Rope->setVisible(hasFlags);
+void NewMapPopup::useLayout(QString layoutId) {
+    this->existingLayout = true;
+    this->layoutId = layoutId;
+    useLayoutSettings(project->mapLayouts.value(this->layoutId));
 
-    bool hasCustomBorders = projectConfig.getUseCustomBorderSize();
-    ui->spinBox_NewMap_BorderWidth->setVisible(hasCustomBorders);
-    ui->spinBox_NewMap_BorderHeight->setVisible(hasCustomBorders);
-    ui->label_NewMap_BorderWidth->setVisible(hasCustomBorders);
-    ui->label_NewMap_BorderHeight->setVisible(hasCustomBorders);
-
-    bool hasFloorNumber = projectConfig.getFloorNumberEnabled();
-    ui->spinBox_NewMap_Floor_Number->setVisible(hasFloorNumber);
-    ui->label_NewMap_Floor_Number->setVisible(hasFloorNumber);
+    // Dimensions and tilesets can't be changed for new maps using an existing layout
+    ui->spinBox_NewMap_Width->setDisabled(true);
+    ui->spinBox_NewMap_Height->setDisabled(true);
+    ui->spinBox_NewMap_BorderWidth->setDisabled(true);
+    ui->spinBox_NewMap_BorderHeight->setDisabled(true);
+    ui->comboBox_NewMap_Primary_Tileset->setDisabled(true);
+    ui->comboBox_NewMap_Secondary_Tileset->setDisabled(true);
 }
 
 void NewMapPopup::on_lineEdit_NewMap_Name_textChanged(const QString &text) {

--- a/src/ui/newmappopup.cpp
+++ b/src/ui/newmappopup.cpp
@@ -132,6 +132,10 @@ void NewMapPopup::setDefaultValues(int groupNum, QString mapSec) {
         ui->spinBox_NewMap_Height->setValue(project->getDefaultMapSize());
         ui->spinBox_NewMap_BorderWidth->setValue(DEFAULT_BORDER_WIDTH);
         ui->spinBox_NewMap_BorderHeight->setValue(DEFAULT_BORDER_HEIGHT);
+        int primaryIdx = ui->comboBox_NewMap_Primary_Tileset->findText(project->getDefaultPrimaryTilesetLabel());
+        int secondaryIdx = ui->comboBox_NewMap_Secondary_Tileset->findText(project->getDefaultSecondaryTilesetLabel());
+        ui->comboBox_NewMap_Primary_Tileset->setCurrentIndex(primaryIdx);
+        ui->comboBox_NewMap_Secondary_Tileset->setCurrentIndex(secondaryIdx);
     }
 
     ui->comboBox_NewMap_Type->addItems(project->mapTypes);

--- a/src/ui/newmappopup.cpp
+++ b/src/ui/newmappopup.cpp
@@ -108,8 +108,8 @@ void NewMapPopup::useLayout(QString layoutId) {
 void NewMapPopup::setDefaultValues(int groupNum, QString mapSec) {
     ui->lineEdit_NewMap_Name->setText(project->getNewMapName());
 
-    ui->comboBox_NewMap_Primary_Tileset->addItems(project->tilesetLabels.value("primary"));
-    ui->comboBox_NewMap_Secondary_Tileset->addItems(project->tilesetLabels.value("secondary"));
+    ui->comboBox_NewMap_Primary_Tileset->addItems(project->primaryTilesetLabels);
+    ui->comboBox_NewMap_Secondary_Tileset->addItems(project->secondaryTilesetLabels);
 
     ui->comboBox_NewMap_Group->addItems(project->groupNames);
     ui->comboBox_NewMap_Group->setCurrentText(project->groupNames.at(groupNum));
@@ -147,8 +147,8 @@ void NewMapPopup::setDefaultValues(int groupNum, QString mapSec) {
 void NewMapPopup::setDefaultValuesImportMap(MapLayout *mapLayout) {
     ui->lineEdit_NewMap_Name->setText(project->getNewMapName());
 
-    ui->comboBox_NewMap_Primary_Tileset->addItems(project->tilesetLabels.value("primary"));
-    ui->comboBox_NewMap_Secondary_Tileset->addItems(project->tilesetLabels.value("secondary"));
+    ui->comboBox_NewMap_Primary_Tileset->addItems(project->primaryTilesetLabels);
+    ui->comboBox_NewMap_Secondary_Tileset->addItems(project->secondaryTilesetLabels);
 
     ui->comboBox_NewMap_Group->addItems(project->groupNames);
     ui->comboBox_NewMap_Group->setCurrentText(project->groupNames.at(0));


### PR DESCRIPTION
- The new map prompt will now preserve the last settings within a single session
- Fixed some bugs with the new map prompt: floor number and border dimensions had incorrect limits, and border dimensions were set to 0 when creating a map using an existing layout
- Add options to set the default primary/secondary tileset. Currently the default is the first tileset in the list, which because they're now sorted alphabetically is an odd choice.
- Insert new tileset labels into the list in sorted order, so they'll be in the same position in the combo boxes as when the project is reloaded.

Also stops treating the tileset lists as a map and `is_secondary` as a string, and drops the unnecessary `path_` prefix from two path configs to avoid the awkward `path/path_name=""`

Resolves #377 