### PR TITLE
Preserve import/export path in file dialogs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ The **"Breaking Changes"** listed below are changes that have been made in the d
 ### Added
 - Add `setScale` to the scripting API.
 
+### Changed
+- The last-used directory is now preserved in import/export file dialogs.
+
 ## [5.0.0] - 2022-10-30
 ### Breaking Changes
 - Proper support for pokefirered's clone objects was added, which requires the changes made in [pokefirered/#484](https://github.com/pret/pokefirered/pull/484).

--- a/include/project.h
+++ b/include/project.h
@@ -83,6 +83,7 @@ public:
     QFileSystemWatcher fileWatcher;
     QMap<QString, qint64> modifiedFileTimestamps;
     bool usingAsmTilesets;
+    QString importExportPath;
 
     const QPixmap entitiesPixmap = QPixmap(":/images/Entities_16x16.png");
 
@@ -212,6 +213,8 @@ public:
 
     QString getDefaultPrimaryTilesetLabel();
     QString getDefaultSecondaryTilesetLabel();
+
+    void setImportExportPath(QString filename);
 
     static int getNumTilesPrimary();
     static int getNumTilesTotal();

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -2430,12 +2430,12 @@ void MainWindow::importMapFromAdvanceMap1_92()
     QString filepath = QFileDialog::getOpenFileName(
                 this,
                 QString("Import Map from Advance Map 1.92"),
-                this->editor->project->root,
+                this->editor->project->importExportPath,
                 "Advance Map 1.92 Map Files (*.map)");
     if (filepath.isEmpty()) {
         return;
     }
-
+    this->editor->project->setImportExportPath(filepath);
     MapParser parser;
     bool error = false;
     MapLayout *mapLayout = parser.parse(filepath, &error, editor->project);

--- a/src/project.cpp
+++ b/src/project.cpp
@@ -91,6 +91,7 @@ void Project::initSignals() {
 
 void Project::set_root(QString dir) {
     this->root = dir;
+    this->importExportPath = dir;
     this->parser.set_root(dir);
 }
 
@@ -2607,4 +2608,9 @@ bool Project::calculateDefaultMapSize(){
 int Project::getMaxObjectEvents()
 {
     return Project::max_object_events;
+}
+
+void Project::setImportExportPath(QString filename)
+{
+    this->importExportPath = QFileInfo(filename).absolutePath();
 }

--- a/src/ui/mapimageexporter.cpp
+++ b/src/ui/mapimageexporter.cpp
@@ -64,12 +64,13 @@ void MapImageExporter::saveImage() {
     }
 
     QString defaultFilepath = QString("%1/%2.%3")
-            .arg(editor->project->root)
+            .arg(editor->project->importExportPath)
             .arg(defaultFilename)
             .arg(this->mode == ImageExporterMode::Timelapse ? "gif" : "png");
     QString filter = this->mode == ImageExporterMode::Timelapse ? "Image Files (*.gif)" : "Image Files (*.png *.jpg *.bmp)";
     QString filepath = QFileDialog::getSaveFileName(this, title, defaultFilepath, filter);
     if (!filepath.isEmpty()) {
+        editor->project->setImportExportPath(filepath);
         switch (this->mode) {
             case ImageExporterMode::Normal:
                 this->preview.save(filepath);

--- a/src/ui/paletteeditor.cpp
+++ b/src/ui/paletteeditor.cpp
@@ -384,12 +384,12 @@ void PaletteEditor::on_actionImport_Palette_triggered()
     QString filepath = QFileDialog::getOpenFileName(
                 this,
                 QString("Import Tileset Palette"),
-                this->project->root,
+                this->project->importExportPath,
                 "Palette Files (*.pal *.act *tpl *gpl)");
     if (filepath.isEmpty()) {
         return;
     }
-
+    this->project->setImportExportPath(filepath);
     bool error = false;
     QList<QRgb> palette = PaletteUtil::parse(filepath, &error);
     if (error) {

--- a/src/ui/regionmappropertiesdialog.cpp
+++ b/src/ui/regionmappropertiesdialog.cpp
@@ -34,7 +34,9 @@ QString RegionMapPropertiesDialog::browse(QString filter, QFileDialog::FileMode 
     if (!this->project) return QString();
     QFileDialog browser;
     browser.setFileMode(mode);
-    QString filepath = browser.getOpenFileName(this, "Select a File", this->project->root, filter);
+    QString filepath = browser.getOpenFileName(this, "Select a File", this->project->importExportPath, filter);
+    if (!filepath.isEmpty())
+        this->project->setImportExportPath(filepath);
 
     // remove the project root from the filepath
     return filepath.replace(this->project->root + "/", "");

--- a/src/ui/tileseteditor.cpp
+++ b/src/ui/tileseteditor.cpp
@@ -620,12 +620,12 @@ void TilesetEditor::importTilesetTiles(Tileset *tileset, bool primary) {
     QString filepath = QFileDialog::getOpenFileName(
                 this,
                 QString("Import %1 Tileset Tiles Image").arg(descriptorCaps),
-                this->project->root,
+                this->project->importExportPath,
                 "Image Files (*.png *.bmp *.jpg *.dib)");
     if (filepath.isEmpty()) {
         return;
     }
-
+    this->project->setImportExportPath(filepath);
     logInfo(QString("Importing %1 tileset tiles '%2'").arg(descriptor).arg(filepath));
 
     // Read image data from buffer so that the built-in QImage doesn't try to detect file format
@@ -681,12 +681,12 @@ void TilesetEditor::importTilesetTiles(Tileset *tileset, bool primary) {
         QString filepath = QFileDialog::getOpenFileName(
             this,
             QString("Select Palette for Tiles Image").arg(descriptorCaps),
-            this->project->root,
+            this->project->importExportPath,
             "Palette Files (*.pal *.act *tpl *gpl)");
         if (filepath.isEmpty()) {
             return;
         }
-
+        this->project->setImportExportPath(filepath);
         bool error = false;
         QList<QRgb> palette = PaletteUtil::parse(filepath, &error);
         if (error) {
@@ -916,9 +916,10 @@ void TilesetEditor::pasteMetatile(const Metatile * toPaste)
 void TilesetEditor::on_actionExport_Primary_Tiles_Image_triggered()
 {
     QString defaultName = QString("%1_Tiles_Pal%2").arg(this->primaryTileset->name).arg(this->paletteId);
-    QString defaultFilepath = QString("%1/%2.png").arg(this->project->root).arg(defaultName);
+    QString defaultFilepath = QString("%1/%2.png").arg(this->project->importExportPath).arg(defaultName);
     QString filepath = QFileDialog::getSaveFileName(this, "Export Primary Tiles Image", defaultFilepath, "Image Files (*.png)");
     if (!filepath.isEmpty()) {
+        this->project->setImportExportPath(filepath);
         QImage image = this->tileSelector->buildPrimaryTilesIndexedImage();
         exportIndexed4BPPPng(image, filepath);
     }
@@ -927,9 +928,10 @@ void TilesetEditor::on_actionExport_Primary_Tiles_Image_triggered()
 void TilesetEditor::on_actionExport_Secondary_Tiles_Image_triggered()
 {
     QString defaultName = QString("%1_Tiles_Pal%2").arg(this->secondaryTileset->name).arg(this->paletteId);
-    QString defaultFilepath = QString("%1/%2.png").arg(this->project->root).arg(defaultName);
+    QString defaultFilepath = QString("%1/%2.png").arg(this->project->importExportPath).arg(defaultName);
     QString filepath = QFileDialog::getSaveFileName(this, "Export Secondary Tiles Image", defaultFilepath, "Image Files (*.png)");
     if (!filepath.isEmpty()) {
+        this->project->setImportExportPath(filepath);
         QImage image = this->tileSelector->buildSecondaryTilesIndexedImage();
         exportIndexed4BPPPng(image, filepath);
     }
@@ -938,9 +940,10 @@ void TilesetEditor::on_actionExport_Secondary_Tiles_Image_triggered()
 void TilesetEditor::on_actionExport_Primary_Metatiles_Image_triggered()
 {
     QString defaultName = QString("%1_Metatiles").arg(this->primaryTileset->name);
-    QString defaultFilepath = QString("%1/%2.png").arg(this->project->root).arg(defaultName);
+    QString defaultFilepath = QString("%1/%2.png").arg(this->project->importExportPath).arg(defaultName);
     QString filepath = QFileDialog::getSaveFileName(this, "Export Primary Metatiles Image", defaultFilepath, "Image Files (*.png)");
     if (!filepath.isEmpty()) {
+        this->project->setImportExportPath(filepath);
         QImage image = this->metatileSelector->buildPrimaryMetatilesImage();
         image.save(filepath, "PNG");
     }
@@ -949,9 +952,10 @@ void TilesetEditor::on_actionExport_Primary_Metatiles_Image_triggered()
 void TilesetEditor::on_actionExport_Secondary_Metatiles_Image_triggered()
 {
     QString defaultName = QString("%1_Metatiles").arg(this->secondaryTileset->name);
-    QString defaultFilepath = QString("%1/%2.png").arg(this->project->root).arg(defaultName);
+    QString defaultFilepath = QString("%1/%2.png").arg(this->project->importExportPath).arg(defaultName);
     QString filepath = QFileDialog::getSaveFileName(this, "Export Secondary Metatiles Image", defaultFilepath, "Image Files (*.png)");
     if (!filepath.isEmpty()) {
+        this->project->setImportExportPath(filepath);
         QImage image = this->metatileSelector->buildSecondaryMetatilesImage();
         image.save(filepath, "PNG");
     }
@@ -975,12 +979,12 @@ void TilesetEditor::importTilesetMetatiles(Tileset *tileset, bool primary)
     QString filepath = QFileDialog::getOpenFileName(
                 this,
                 QString("Import %1 Tileset Metatiles from Advance Map 1.92").arg(descriptorCaps),
-                this->project->root,
+                this->project->importExportPath,
                 "Advance Map 1.92 Metatile Files (*.bvd)");
     if (filepath.isEmpty()) {
         return;
     }
-
+    this->project->setImportExportPath(filepath);
     bool error = false;
     QList<Metatile*> metatiles = MetatileParser::parse(filepath, &error, primary);
     if (error) {


### PR DESCRIPTION
Opens file dialogs to the directory that was used by the last file dialog. Applies to exporting/importing map images, Advance Map data, tile images, metatile images, and palettes.