### PR TITLE
Fix Region Map Editor being opened by Shortcuts Editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The **"Breaking Changes"** listed below are changes that have been made in the d
 - Hovering on border metatiles with the mouse will now display their information in the bottom bar.
 
 ### Fixed
+- Fix the Region Map Editor being opened by the Shortcuts Editor.
 - Fix New Map settings being preserved when switching projects.
 - Fix scripting API callback `onMapResized` not triggering.
 - Fix crash when importing AdvanceMap metatiles while `enable_triple_layer_metatiles` is enabled.

--- a/include/mainwindow.h
+++ b/include/mainwindow.h
@@ -379,7 +379,7 @@ private:
     void setWindowDisabled(bool);
 
     void initTilesetEditor();
-    bool initRegionMapEditor();
+    bool initRegionMapEditor(bool silent = false);
     void initShortcutsEditor();
     void connectSubEditorsToShortcutsEditor();
 

--- a/include/ui/regionmapeditor.h
+++ b/include/ui/regionmapeditor.h
@@ -26,7 +26,7 @@ public:
     explicit RegionMapEditor(QWidget *parent = 0, Project *pro = nullptr);
     ~RegionMapEditor();
 
-    bool load();
+    bool load(bool silent = false);
 
     void onRegionMapTileSelectorSelectedTileChanged(unsigned id);
     void onRegionMapTileSelectorHoveredTileChanged(unsigned id);

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1815,7 +1815,7 @@ void MainWindow::connectSubEditorsToShortcutsEditor() {
             tilesetEditor, &TilesetEditor::applyUserShortcuts);
 
     if (!regionMapEditor)
-        initRegionMapEditor();
+        initRegionMapEditor(true);
     if (regionMapEditor)
         connect(shortcutsEditor, &ShortcutsEditor::shortcutsSaved,
                 regionMapEditor, &RegionMapEditor::applyUserShortcuts);
@@ -2813,23 +2813,19 @@ void MainWindow::on_pushButton_CreatePrefab_clicked() {
     }
 }
 
-bool MainWindow::initRegionMapEditor() {
+bool MainWindow::initRegionMapEditor(bool silent) {
     this->regionMapEditor = new RegionMapEditor(this, this->editor->project);
-    this->regionMapEditor->setAttribute(Qt::WA_DeleteOnClose);
-    connect(this->regionMapEditor, &QObject::destroyed, [this](){
-        this->regionMapEditor = nullptr;
-    });
-
-    bool success = this->regionMapEditor->load();
+    bool success = this->regionMapEditor->load(silent);
     if (!success) {
         delete this->regionMapEditor;
         this->regionMapEditor = nullptr;
-        QMessageBox msgBox(this);
-        QString errorMsg = QString("There was an error opening the region map data. Please see %1 for full error details.\n\n%3")
-                .arg(getLogPath())
-                .arg(getMostRecentError());
-        msgBox.critical(nullptr, "Error Opening Region Map Editor", errorMsg);
-
+        if (!silent) {
+            QMessageBox msgBox(this);
+            QString errorMsg = QString("There was an error opening the region map data. Please see %1 for full error details.\n\n%3")
+                    .arg(getLogPath())
+                    .arg(getMostRecentError());
+            msgBox.critical(nullptr, "Error Opening Region Map Editor", errorMsg);
+        }
         return false;
     }
 

--- a/src/ui/regionmapeditor.cpp
+++ b/src/ui/regionmapeditor.cpp
@@ -498,15 +498,10 @@ bool RegionMapEditor::setup() {
     if (!region_maps.empty()) {
         setRegionMap(region_maps.begin()->second);
     }
-
-    this->show();
-    this->setWindowState(Qt::WindowState::WindowActive);
-    this->activateWindow();
-
     return true;
 }
 
-bool RegionMapEditor::load() {
+bool RegionMapEditor::load(bool silent) {
     // check for config json file
     QString jsonConfigFilepath = this->project->root + "/" + projectConfig.getFilePath(ProjectFilePath::json_region_porymap_cfg);
 
@@ -526,6 +521,7 @@ bool RegionMapEditor::load() {
     }
 
     if (badConfig) {
+        if (silent) return false;
         // show popup explaining next window
         QMessageBox warning;
         warning.setIcon(QMessageBox::Warning);


### PR DESCRIPTION
Fixes a few problems related to how the Region Map Editor (RME) gets used by the Shortcuts Editor:
- `RegionMapEditor::setup()` no longer displays the window. This is already handled by `MainWindow::on_actionRegion_Map_Editor_triggered()`.
- `RegionMapEditor::load` and `MainWindow::initRegionMapEditor` now take a `bool silent` argument, which stops error messages from appearing if the Shortcuts Editor fails to initialize the RME. In this case the related shortcuts simply don't appear in the editor.
- `MainWindow`'s `regionMapEditor` is no longer deleted when the RME window is closed. This stops a crash that can occur by launching the Shortcuts Editor, launching then closing the RME, then trying to save the shortcuts. This has the side effect of preserving the RME's state when the window is closed, which I assume is ok.

Closes #498 