### PR TITLE
Allow navigating to connected maps from any tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The **"Breaking Changes"** listed below are changes that have been made in the d
 - Add option to turn off the checkerboard fill for new tilesets.
 
 ### Changed
+- Double-clicking on a connecting map on the Map or Events tabs will now open that map.
 - Hovering on border metatiles with the mouse will now display their information in the bottom bar.
 
 ### Fixed

--- a/include/editor.h
+++ b/include/editor.h
@@ -110,8 +110,7 @@ public:
     QGraphicsPixmapItem *current_view = nullptr;
     MapPixmapItem *map_item = nullptr;
     ConnectionPixmapItem* selected_connection_item = nullptr;
-    QList<QGraphicsPixmapItem*> connection_items;
-    QList<ConnectionPixmapItem*> connection_edit_items;
+    QList<ConnectionPixmapItem*> connection_items;
     QGraphicsPathItem *connection_mask = nullptr;
     CollisionPixmapItem *collision_item = nullptr;
     QGraphicsItemGroup *events_group = nullptr;
@@ -147,6 +146,7 @@ public:
     QUndoGroup editGroup; // Manages the undo history for each map
 
     bool selectingEvent = false;
+    bool editingConnections = false;
 
     void shouldReselectEvents();
     void scaleMapView(int);
@@ -166,6 +166,7 @@ private:
     void setBorderItemsVisible(bool, qreal = 1);
     void setConnectionEditControlValues(MapConnection*);
     void setConnectionEditControlsEnabled(bool);
+    void setConnectionHighlights(bool);
     void createConnectionItem(MapConnection* connection, bool hide);
     void populateConnectionMapPickers();
     void setDiveEmergeControls();

--- a/include/editor.h
+++ b/include/editor.h
@@ -166,7 +166,7 @@ private:
     void setConnectionEditControlValues(MapConnection*);
     void setConnectionEditControlsEnabled(bool);
     void setConnectionsEditable(bool);
-    void createConnectionItem(MapConnection* connection, bool hide);
+    void createConnectionItem(MapConnection* connection);
     void populateConnectionMapPickers();
     void setDiveEmergeControls();
     void updateDiveEmergeMap(QString mapName, QString direction);

--- a/include/editor.h
+++ b/include/editor.h
@@ -146,7 +146,6 @@ public:
     QUndoGroup editGroup; // Manages the undo history for each map
 
     bool selectingEvent = false;
-    bool editingConnections = false;
 
     void shouldReselectEvents();
     void scaleMapView(int);
@@ -166,7 +165,7 @@ private:
     void setBorderItemsVisible(bool, qreal = 1);
     void setConnectionEditControlValues(MapConnection*);
     void setConnectionEditControlsEnabled(bool);
-    void setConnectionHighlights(bool);
+    void setConnectionsEditable(bool);
     void createConnectionItem(MapConnection* connection, bool hide);
     void populateConnectionMapPickers();
     void setDiveEmergeControls();

--- a/include/ui/connectionpixmapitem.h
+++ b/include/ui/connectionpixmapitem.h
@@ -29,6 +29,9 @@ public:
     void render(qreal opacity = 1);
     int getMinOffset();
     int getMaxOffset();
+    void setEditable(bool editable);
+    bool getEditable();
+    void updateHighlight(bool selected);
 
 protected:
     QVariant itemChange(GraphicsItemChange change, const QVariant &value);

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -1528,7 +1528,7 @@ void Editor::displayMapConnections() {
         if (connection->direction == "dive" || connection->direction == "emerge") {
             continue;
         }
-        createConnectionItem(connection, false);
+        createConnectionItem(connection);
     }
 
     if (!connection_items.empty()) {
@@ -1538,7 +1538,7 @@ void Editor::displayMapConnections() {
     maskNonVisibleConnectionTiles();
 }
 
-void Editor::createConnectionItem(MapConnection* connection, bool hide) {
+void Editor::createConnectionItem(MapConnection* connection) {
     Map *connected_map = project->getMap(connection->map_name);
     if (!connected_map) {
         return;
@@ -1566,7 +1566,6 @@ void Editor::createConnectionItem(MapConnection* connection, bool hide) {
     item->setY(y);
     item->setZValue(-1);
     scene->addItem(item);
-    item->setVisible(!hide);
     connect(item, &ConnectionPixmapItem::connectionMoved, this, &Editor::onConnectionMoved);
     connect(item, &ConnectionPixmapItem::connectionItemSelected, this, &Editor::onConnectionItemSelected);
     connect(item, &ConnectionPixmapItem::connectionItemDoubleClicked, this, &Editor::onConnectionItemDoubleClicked);
@@ -1758,7 +1757,7 @@ void Editor::addNewConnection() {
     newConnection->offset = 0;
     newConnection->map_name = defaultMapName;
     map->connections.append(newConnection);
-    createConnectionItem(newConnection, true);
+    createConnectionItem(newConnection);
     onConnectionItemSelected(connection_items.last());
     ui->label_NumConnections->setText(QString::number(map->connections.length()));
 

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -95,8 +95,7 @@ void Editor::setEditingMap() {
     }
     setBorderItemsVisible(ui->checkBox_ToggleBorder->isChecked());
     setConnectionItemsVisible(ui->checkBox_ToggleBorder->isChecked());
-    setConnectionHighlights(false);
-    this->editingConnections = false;
+    setConnectionsEditable(false);
     this->cursorMapTileRect->stopSingleTileMode();
     this->cursorMapTileRect->setActive(true);
 
@@ -119,8 +118,7 @@ void Editor::setEditingCollision() {
     }
     setBorderItemsVisible(ui->checkBox_ToggleBorder->isChecked());
     setConnectionItemsVisible(ui->checkBox_ToggleBorder->isChecked());
-    setConnectionHighlights(false);
-    this->editingConnections = false;
+    setConnectionsEditable(false);
     this->cursorMapTileRect->setSingleTileMode();
     this->cursorMapTileRect->setActive(true);
 
@@ -143,8 +141,7 @@ void Editor::setEditingObjects() {
     }
     setBorderItemsVisible(ui->checkBox_ToggleBorder->isChecked());
     setConnectionItemsVisible(ui->checkBox_ToggleBorder->isChecked());
-    setConnectionHighlights(false);
-    this->editingConnections = false;
+    setConnectionsEditable(false);
     this->cursorMapTileRect->setSingleTileMode();
     this->cursorMapTileRect->setActive(false);
 
@@ -192,8 +189,7 @@ void Editor::setEditingConnections() {
     }
     setBorderItemsVisible(true, 0.4);
     setConnectionItemsVisible(true);
-    setConnectionHighlights(true);
-    this->editingConnections = true;
+    setConnectionsEditable(true);
     this->cursorMapTileRect->setSingleTileMode();
     this->cursorMapTileRect->setActive(false);
 }
@@ -860,30 +856,20 @@ void Editor::setConnectionEditControlsEnabled(bool enabled) {
     }
 }
 
-void Editor::setConnectionHighlights(bool enabled) {
+void Editor::setConnectionsEditable(bool editable) {
     for (ConnectionPixmapItem* item : connection_items) {
-        bool isSelectedItem = item == selected_connection_item;
-        int zValue = (isSelectedItem || !enabled) ? 0 : -1;
-        qreal opacity = (isSelectedItem || !enabled) ? 1 : 0.75;
-        item->setZValue(zValue);
-        item->render(opacity);
-        if (enabled && isSelectedItem) {
-            QPixmap pixmap = item->pixmap();
-            QPainter painter(&pixmap);
-            painter.setPen(QColor(255, 0, 255));
-            painter.drawRect(0, 0, pixmap.width() - 1, pixmap.height() - 1);
-            painter.end();
-            item->setPixmap(pixmap);
-        }
+        item->setEditable(editable);
+        item->updateHighlight(item == selected_connection_item);
     }
 }
 
 void Editor::onConnectionItemSelected(ConnectionPixmapItem* connectionItem) {
-    selected_connection_item = connectionItem;
-    if (!selected_connection_item || !this->editingConnections)
+    if (!connectionItem)
         return;
 
-    setConnectionHighlights(true);
+    selected_connection_item = connectionItem;
+    for (ConnectionPixmapItem* item : connection_items)
+        item->updateHighlight(item == selected_connection_item);
     setConnectionEditControlsEnabled(true);
     setConnectionEditControlValues(selected_connection_item->connection);
     ui->spinBox_ConnectionOffset->setMaximum(selected_connection_item->getMaxOffset());

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -1630,7 +1630,7 @@ void Editor::updateMapBorder() {
 }
 
 void Editor::updateMapConnections() {
-   for (int i = 0; i < connection_items.size(); i++) {
+    for (int i = 0; i < connection_items.size(); i++) {
         Map *connected_map = project->getMap(connection_items[i]->connection->map_name);
         if (!connected_map)
             continue;

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -86,7 +86,6 @@ void Editor::setEditingMap() {
         displayMapConnections();
         map_item->draw();
         map_item->setVisible(true);
-        setConnectionsVisibility(ui->checkBox_ToggleBorder->isChecked());
     }
     if (collision_item) {
         collision_item->setVisible(false);
@@ -95,7 +94,9 @@ void Editor::setEditingMap() {
         events_group->setVisible(false);
     }
     setBorderItemsVisible(ui->checkBox_ToggleBorder->isChecked());
-    setConnectionItemsVisible(false);
+    setConnectionItemsVisible(ui->checkBox_ToggleBorder->isChecked());
+    setConnectionHighlights(false);
+    this->editingConnections = false;
     this->cursorMapTileRect->stopSingleTileMode();
     this->cursorMapTileRect->setActive(true);
 
@@ -108,7 +109,6 @@ void Editor::setEditingCollision() {
         displayMapConnections();
         collision_item->draw();
         collision_item->setVisible(true);
-        setConnectionsVisibility(ui->checkBox_ToggleBorder->isChecked());
     }
     if (map_item) {
         map_item->paintingMode = MapPixmapItem::PaintMode::Metatiles;
@@ -118,7 +118,9 @@ void Editor::setEditingCollision() {
         events_group->setVisible(false);
     }
     setBorderItemsVisible(ui->checkBox_ToggleBorder->isChecked());
-    setConnectionItemsVisible(false);
+    setConnectionItemsVisible(ui->checkBox_ToggleBorder->isChecked());
+    setConnectionHighlights(false);
+    this->editingConnections = false;
     this->cursorMapTileRect->setSingleTileMode();
     this->cursorMapTileRect->setActive(true);
 
@@ -135,13 +137,14 @@ void Editor::setEditingObjects() {
         displayMapConnections();
         map_item->draw();
         map_item->setVisible(true);
-        setConnectionsVisibility(ui->checkBox_ToggleBorder->isChecked());
     }
     if (collision_item) {
         collision_item->setVisible(false);
     }
     setBorderItemsVisible(ui->checkBox_ToggleBorder->isChecked());
-    setConnectionItemsVisible(false);
+    setConnectionItemsVisible(ui->checkBox_ToggleBorder->isChecked());
+    setConnectionHighlights(false);
+    this->editingConnections = false;
     this->cursorMapTileRect->setSingleTileMode();
     this->cursorMapTileRect->setActive(false);
 
@@ -172,7 +175,6 @@ void Editor::setEditingConnections() {
         map_item->setVisible(true);
         populateConnectionMapPickers();
         ui->label_NumConnections->setText(QString::number(map->connections.length()));
-        setConnectionsVisibility(false);
         setDiveEmergeControls();
         bool controlsEnabled = selected_connection_item != nullptr;
         setConnectionEditControlsEnabled(controlsEnabled);
@@ -190,6 +192,8 @@ void Editor::setEditingConnections() {
     }
     setBorderItemsVisible(true, 0.4);
     setConnectionItemsVisible(true);
+    setConnectionHighlights(true);
+    this->editingConnections = true;
     this->cursorMapTileRect->setSingleTileMode();
     this->cursorMapTileRect->setActive(false);
 }
@@ -747,7 +751,7 @@ void Editor::populateConnectionMapPickers() {
 }
 
 void Editor::setConnectionItemsVisible(bool visible) {
-    for (ConnectionPixmapItem* item : connection_edit_items) {
+    for (ConnectionPixmapItem* item : connection_items) {
         item->setVisible(visible);
         item->setEnabled(visible);
     }
@@ -856,17 +860,14 @@ void Editor::setConnectionEditControlsEnabled(bool enabled) {
     }
 }
 
-void Editor::onConnectionItemSelected(ConnectionPixmapItem* connectionItem) {
-    if (!connectionItem)
-        return;
-
-    for (ConnectionPixmapItem* item : connection_edit_items) {
-        bool isSelectedItem = item == connectionItem;
-        int zValue = isSelectedItem ? 0 : -1;
-        qreal opacity = isSelectedItem ? 1 : 0.75;
+void Editor::setConnectionHighlights(bool enabled) {
+    for (ConnectionPixmapItem* item : connection_items) {
+        bool isSelectedItem = item == selected_connection_item;
+        int zValue = (isSelectedItem || !enabled) ? 0 : -1;
+        qreal opacity = (isSelectedItem || !enabled) ? 1 : 0.75;
         item->setZValue(zValue);
         item->render(opacity);
-        if (isSelectedItem) {
+        if (enabled && isSelectedItem) {
             QPixmap pixmap = item->pixmap();
             QPainter painter(&pixmap);
             painter.setPen(QColor(255, 0, 255));
@@ -875,7 +876,14 @@ void Editor::onConnectionItemSelected(ConnectionPixmapItem* connectionItem) {
             item->setPixmap(pixmap);
         }
     }
+}
+
+void Editor::onConnectionItemSelected(ConnectionPixmapItem* connectionItem) {
     selected_connection_item = connectionItem;
+    if (!selected_connection_item || !this->editingConnections)
+        return;
+
+    setConnectionHighlights(true);
     setConnectionEditControlsEnabled(true);
     setConnectionEditControlValues(selected_connection_item->connection);
     ui->spinBox_ConnectionOffset->setMaximum(selected_connection_item->getMaxOffset());
@@ -885,7 +893,7 @@ void Editor::onConnectionItemSelected(ConnectionPixmapItem* connectionItem) {
 
 void Editor::setSelectedConnectionFromMap(QString mapName) {
     // Search for the first connection that connects to the given map map.
-    for (ConnectionPixmapItem* item : connection_edit_items) {
+    for (ConnectionPixmapItem* item : connection_items) {
         if (item->connection->map_name == mapName) {
             onConnectionItemSelected(item);
             break;
@@ -1075,13 +1083,6 @@ QString Editor::getMovementPermissionText(uint16_t collision, uint16_t elevation
         message = QString("Collision: Impassable (%1), Elevation: %2").arg(collision).arg(elevation);
     }
     return message;
-}
-
-void Editor::setConnectionsVisibility(bool visible) {
-    for (QGraphicsPixmapItem* item : connection_items) {
-        item->setVisible(visible);
-        item->setActive(visible);
-    }
 }
 
 bool Editor::setMap(QString map_name) {
@@ -1528,22 +1529,14 @@ DraggablePixmapItem *Editor::addMapEvent(Event *event) {
 }
 
 void Editor::displayMapConnections() {
-    for (QGraphicsPixmapItem* item : connection_items) {
-        if (item->scene()) {
-            item->scene()->removeItem(item);
-        }
-        delete item;
-    }
-    connection_items.clear();
-
-    for (ConnectionPixmapItem* item : connection_edit_items) {
+    for (ConnectionPixmapItem* item : connection_items) {
         if (item->scene()) {
             item->scene()->removeItem(item);
         }
         delete item;
     }
     selected_connection_item = nullptr;
-    connection_edit_items.clear();
+    connection_items.clear();
 
     for (MapConnection *connection : map->connections) {
         if (connection->direction == "dive" || connection->direction == "emerge") {
@@ -1552,8 +1545,8 @@ void Editor::displayMapConnections() {
         createConnectionItem(connection, false);
     }
 
-    if (!connection_edit_items.empty()) {
-        onConnectionItemSelected(connection_edit_items.first());
+    if (!connection_items.empty()) {
+        onConnectionItemSelected(connection_items.first());
     }
 
     maskNonVisibleConnectionTiles();
@@ -1582,26 +1575,16 @@ void Editor::createConnectionItem(MapConnection* connection, bool hide) {
         y = offset * 16;
     }
 
-    QGraphicsPixmapItem *item = new QGraphicsPixmapItem(pixmap);
-    item->setZValue(-1);
+    ConnectionPixmapItem *item = new ConnectionPixmapItem(pixmap, connection, x, y, map->getWidth(), map->getHeight());
     item->setX(x);
     item->setY(y);
+    item->setZValue(-1);
     scene->addItem(item);
-    connection_items.append(item);
     item->setVisible(!hide);
-
-    ConnectionPixmapItem *connection_edit_item = new ConnectionPixmapItem(pixmap, connection, x, y, map->getWidth(), map->getHeight());
-    connection_edit_item->setX(x);
-    connection_edit_item->setY(y);
-    connection_edit_item->setZValue(-1);
-    scene->addItem(connection_edit_item);
-    connect(connection_edit_item, &ConnectionPixmapItem::connectionMoved,
-            this, &Editor::onConnectionMoved);
-    connect(connection_edit_item, &ConnectionPixmapItem::connectionItemSelected,
-            this, &Editor::onConnectionItemSelected);
-    connect(connection_edit_item, &ConnectionPixmapItem::connectionItemDoubleClicked,
-            this, &Editor::onConnectionItemDoubleClicked);
-    connection_edit_items.append(connection_edit_item);
+    connect(item, &ConnectionPixmapItem::connectionMoved, this, &Editor::onConnectionMoved);
+    connect(item, &ConnectionPixmapItem::connectionItemSelected, this, &Editor::onConnectionItemSelected);
+    connect(item, &ConnectionPixmapItem::connectionItemDoubleClicked, this, &Editor::onConnectionItemDoubleClicked);
+    connection_items.append(item);
 }
 
 // Hides connected map tiles that cannot be seen from the current map (beyond BORDER_DISTANCE).
@@ -1662,18 +1645,14 @@ void Editor::updateMapBorder() {
 }
 
 void Editor::updateMapConnections() {
-    if (connection_items.size() != connection_edit_items.size())
-        return;
-
-    for (int i = 0; i < connection_items.size(); i++) {
-        Map *connected_map = project->getMap(connection_edit_items[i]->connection->map_name);
+   for (int i = 0; i < connection_items.size(); i++) {
+        Map *connected_map = project->getMap(connection_items[i]->connection->map_name);
         if (!connected_map)
             continue;
 
-        QPixmap pixmap = connected_map->renderConnection(*(connection_edit_items[i]->connection), map->layout);
+        QPixmap pixmap = connected_map->renderConnection(*(connection_items[i]->connection), map->layout);
+        connection_items[i]->basePixmap = pixmap;
         connection_items[i]->setPixmap(pixmap);
-        connection_edit_items[i]->basePixmap = pixmap;
-        connection_edit_items[i]->setPixmap(pixmap);
     }
 
     maskNonVisibleConnectionTiles();
@@ -1794,7 +1773,7 @@ void Editor::addNewConnection() {
     newConnection->map_name = defaultMapName;
     map->connections.append(newConnection);
     createConnectionItem(newConnection, true);
-    onConnectionItemSelected(connection_edit_items.last());
+    onConnectionItemSelected(connection_items.last());
     ui->label_NumConnections->setText(QString::number(map->connections.length()));
 
     updateMirroredConnection(newConnection, newConnection->direction, newConnection->map_name);
@@ -1866,7 +1845,7 @@ void Editor::removeCurrentConnection() {
         return;
 
     map->connections.removeOne(selected_connection_item->connection);
-    connection_edit_items.removeOne(selected_connection_item);
+    connection_items.removeOne(selected_connection_item);
     removeMirroredConnection(selected_connection_item->connection);
 
     if (selected_connection_item && selected_connection_item->scene()) {
@@ -1879,8 +1858,8 @@ void Editor::removeCurrentConnection() {
     ui->spinBox_ConnectionOffset->setValue(0);
     ui->label_NumConnections->setText(QString::number(map->connections.length()));
 
-    if (connection_edit_items.length() > 0) {
-        onConnectionItemSelected(connection_edit_items.last());
+    if (connection_items.length() > 0) {
+        onConnectionItemSelected(connection_items.last());
     }
 }
 
@@ -1951,7 +1930,7 @@ void Editor::updateSecondaryTileset(QString tilesetLabel, bool forceLoad)
 void Editor::toggleBorderVisibility(bool visible, bool enableScriptCallback)
 {
     this->setBorderItemsVisible(visible);
-    this->setConnectionsVisibility(visible);
+    this->setConnectionItemsVisible(visible);
     porymapConfig.setShowBorder(visible);
     if (enableScriptCallback)
         Scripting::cb_BorderVisibilityToggled(visible);

--- a/src/ui/connectionpixmapitem.cpp
+++ b/src/ui/connectionpixmapitem.cpp
@@ -65,7 +65,34 @@ QVariant ConnectionPixmapItem::itemChange(GraphicsItemChange change, const QVari
     }
 }
 
+void ConnectionPixmapItem::setEditable(bool editable) {
+    setFlag(ItemIsMovable, editable);
+    setFlag(ItemSendsGeometryChanges, editable);
+}
+
+bool ConnectionPixmapItem::getEditable() {
+    return (this->flags() & ItemIsMovable) != 0;
+}
+
+void ConnectionPixmapItem::updateHighlight(bool selected) {
+    bool editable = this->getEditable();
+    int zValue = (selected || !editable) ? 0 : -1;
+    qreal opacity = (selected || !editable) ? 1 : 0.75;
+    this->setZValue(zValue);
+    this->render(opacity);
+    if (editable && selected) {
+        QPixmap pixmap = this->pixmap();
+        QPainter painter(&pixmap);
+        painter.setPen(QColor(255, 0, 255));
+        painter.drawRect(0, 0, pixmap.width() - 1, pixmap.height() - 1);
+        painter.end();
+        this->setPixmap(pixmap);
+    }
+}
+
 void ConnectionPixmapItem::mousePressEvent(QGraphicsSceneMouseEvent *) {
+    if (!this->getEditable())
+        return;
     emit connectionItemSelected(this);
 }
 

--- a/src/ui/mapimageexporter.cpp
+++ b/src/ui/mapimageexporter.cpp
@@ -392,7 +392,7 @@ QPixmap MapImageExporter::getFormattedMapPixmap(Map *map, bool ignoreBorder) {
     if (!this->mode) {
         // if showing connections, draw on outside of image
         QPainter connectionPainter(&pixmap);
-        for (auto connectionItem : editor->connection_edit_items) {
+        for (auto connectionItem : editor->connection_items) {
             QString direction = connectionItem->connection->direction;
             if ((showUpConnections && direction == "up")
              || (showDownConnections && direction == "down")


### PR DESCRIPTION
Double-clicking on a connecting map on the Map or Events tabs will now open that map. The connection pixmaps are still only highlighted and editable when the Connections tab is open.

Closes #245