### PR TITLE
Support 8BPP images for 4BPP tilemaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The **"Breaking Changes"** listed below are changes that have been made in the d
 ### Fixed
 - Fix events being hidden behind connecting maps.
 - Fix some minor visual issues on the Connections tab.
+- Fix the updated pokefirered region map graphics appearing in grayscale.
 
 ## [5.1.0] - 2023-01-22
 ### Added

--- a/include/ui/tilemaptileselector.h
+++ b/include/ui/tilemaptileselector.h
@@ -126,6 +126,12 @@ public:
     TilemapTileSelector(QString tilesetFilepath, TilemapFormat format, QString palFilepath): SelectablePixmapItem(8, 8, 1, 1) {
         this->tileset = QImage(tilesetFilepath);
         this->format = format;
+        if (this->tileset.format() == QImage::Format::Format_Indexed8 && this->format == TilemapFormat::BPP_4) {
+            // Squash pixel data to fit 4BPP. Allows project repo to use 8BPP images for 4BPP tilemaps
+            uchar * pixel = this->tileset.bits();
+            for (int i = 0; i < this->tileset.sizeInBytes(); i++, pixel++)
+                *pixel %= 16;
+        }
         bool err;
         if (!palFilepath.isEmpty()) {
             this->palette = PaletteUtil::parse(palFilepath, &err);

--- a/src/ui/tilemaptileselector.cpp
+++ b/src/ui/tilemaptileselector.cpp
@@ -51,8 +51,7 @@ QImage TilemapTileSelector::setPalette(int paletteIndex) {
         {
             QVector<QRgb> newColorTable;
             int palMinLength = paletteIndex * 16 + 16;
-            if ((this->palette.count() < palMinLength) || (tilesetImage.colorTable().count() != 16)) {
-                // either a) the palette has less than 256 colors, or b) the image is improperly indexed
+            if (this->palette.count() < palMinLength) {
                 for (QRgb color : tilesetImage.colorTable()) {
                     int gray = qGray(color);
                     newColorTable.append(qRgb(gray, gray, gray));


### PR DESCRIPTION
The project repos can now use 8bpp images to represent 4bpp graphics accurately with multiple palettes. `gbagfx` handles this by taking the `% (1 << bit depth)` of each pixel.

After the changes in https://github.com/pret/pokefirered/commit/ffe2844139f8f3616c1a3de6a0b0ca6c98ddc318, pokefirered's region map graphics now do this, but Porymap's region map editor doesn't handle this conversion and it ends up defaulting to grayscale. Now Porymap constrains the image to 4bpp (Qt doesn't have an image representation for this, and if it did I imagine it wouldn't handle this 8bpp -> 4bpp conversion the same way)