### PR TITLE
Support sharing metatile labels between tilesets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The **"Breaking Changes"** listed below are changes that have been made in the d
 - Fix tilesets that share part of their name loading incorrectly.
 - Fix events being hidden behind connecting maps.
 - Metatile labels with values defined outside their tileset are no longer deleted.
+- Fix the Tileset Editor retaining edit history after changing tilesets.
 - Fix some minor visual issues on the Connections tab.
 - Fix bug which caused encounter configurator to crash if slots in fields containing groups were deleted.
 - Fix bug which caused encounter configurator to crash if last field was deleted.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The **"Breaking Changes"** listed below are changes that have been made in the d
 - Fix null characters being unpredictably written to some JSON files.
 - Fix tilesets that share part of their name loading incorrectly.
 - Fix events being hidden behind connecting maps.
+- Metatile labels with values defined outside their tileset are no longer deleted.
 - Fix some minor visual issues on the Connections tab.
 - Fix bug which caused encounter configurator to crash if slots in fields containing groups were deleted.
 - Fix bug which caused encounter configurator to crash if last field was deleted.

--- a/docsrc/manual/tileset-editor.rst
+++ b/docsrc/manual/tileset-editor.rst
@@ -79,7 +79,7 @@ A name can be given to metatiles so that they may be referenced in source code.
 These are defined in ``include/constants/metatile_labels.h``.
 
 For example, the metatile pictured above can be referenced using the define 
-``METATILE_General_Grass``.
+``METATILE_General_Plain_Grass``.
 This define name can be copied using the Copy button next to the metatile label text box.
 
 Sometimes it may be useful to have a ``METATILE`` define that applies to many tilesets.

--- a/docsrc/manual/tileset-editor.rst
+++ b/docsrc/manual/tileset-editor.rst
@@ -76,12 +76,19 @@ Metatile Label
     *optional*
 
 A name can be given to metatiles so that they may be referenced in source code.
-These are defined in ``include/constants/metatile_labels.h`` and can be used in
-together with the ``METATILE_ID`` macro.
+These are defined in ``include/constants/metatile_labels.h``.
 
-For example, the metatile pictured above can be accessed like
-``METATILE_ID(General, Plain_Grass)``.
+For example, the metatile pictured above can be referenced using the define 
+``METATILE_General_Grass``.
+This define name can be copied using the Copy button next to the metatile label text box.
 
+Sometimes it may be useful to have a ``METATILE`` define that applies to many tilesets.
+This can be done by manually creating a ``METATILE`` define with a value outside its tileset.
+For example, the primary tileset ``SecretBase`` is associated with many secondary tilesets,
+all of which use the same labels. ``#define METATILE_SecretBase_PC 0x220`` defines a label
+for the secondary metatile id ``0x220`` which will be used by any secondary tileset that's
+paired with ``SecretBase``. Labels like this will appear gray in the text box, and can't
+be edited from within Porymap; they must be edited manually in ``metatile_labels.h``.
 
 
 

--- a/include/core/history.h
+++ b/include/core/history.h
@@ -10,9 +10,15 @@ public:
     History() { }
 
     ~History() {
+        clear();
+    }
+
+    void clear() {
         while (!history.isEmpty()) {
             delete history.takeLast();
         }
+        head = -1;
+        saved = -1;
     }
 
     T back() {

--- a/include/core/metatile.h
+++ b/include/core/metatile.h
@@ -70,7 +70,6 @@ public:
     uint32_t encounterType;
     uint32_t layerType;
     uint32_t unusedAttributes;
-    QString label;
 
     uint32_t getAttributes();
     void setAttributes(uint32_t data);
@@ -121,7 +120,6 @@ inline bool operator==(const Metatile &a, const Metatile &b) {
            a.encounterType    == b.encounterType &&
            a.terrainType      == b.terrainType &&
            a.unusedAttributes == b.unusedAttributes &&
-           a.label            == b.label &&
            a.tiles            == b.tiles;
 }
 

--- a/include/core/tileset.h
+++ b/include/core/tileset.h
@@ -5,6 +5,7 @@
 #include "metatile.h"
 #include "tile.h"
 #include <QImage>
+#include <QHash>
 
 class Tileset
 {
@@ -28,12 +29,15 @@ public:
 
     QList<QImage> tiles;
     QList<Metatile*> metatiles;
+    QHash<int, QString> metatileLabels;
     QList<QList<QRgb>> palettes;
     QList<QList<QRgb>> palettePreviews;
 
     static Tileset* getMetatileTileset(int, Tileset*, Tileset*);
     static Tileset* getTileTileset(int, Tileset*, Tileset*);
     static Metatile* getMetatile(int, Tileset*, Tileset*);
+    static QString getMetatileLabel(int, Tileset *, Tileset *, bool * isAlternateLabel = nullptr);
+    static bool setMetatileLabel(int, QString, Tileset *, Tileset *);
     static QList<QList<QRgb>> getBlockPalettes(Tileset*, Tileset*, bool useTruePalettes = false);
     static QList<QRgb> getPalette(int, Tileset*, Tileset*, bool useTruePalettes = false);
     static bool metatileIsValid(uint16_t metatileId, Tileset *, Tileset *);

--- a/include/core/tileset.h
+++ b/include/core/tileset.h
@@ -36,8 +36,11 @@ public:
     static Tileset* getMetatileTileset(int, Tileset*, Tileset*);
     static Tileset* getTileTileset(int, Tileset*, Tileset*);
     static Metatile* getMetatile(int, Tileset*, Tileset*);
-    static QString getMetatileLabel(int, Tileset *, Tileset *, bool * isAlternateLabel = nullptr);
+    static Tileset* getMetatileLabelTileset(int, Tileset*, Tileset*, bool * isShared = nullptr);
+    static QString getMetatileLabel(int, Tileset *, Tileset *, bool * isShared = nullptr);
     static bool setMetatileLabel(int, QString, Tileset *, Tileset *);
+    QString getMetatileLabelPrefix();
+    static QString getMetatileLabelPrefix(const QString &name);
     static QList<QList<QRgb>> getBlockPalettes(Tileset*, Tileset*, bool useTruePalettes = false);
     static QList<QRgb> getPalette(int, Tileset*, Tileset*, bool useTruePalettes = false);
     static bool metatileIsValid(uint16_t metatileId, Tileset *, Tileset *);

--- a/include/core/tileset.h
+++ b/include/core/tileset.h
@@ -7,6 +7,11 @@
 #include <QImage>
 #include <QHash>
 
+struct MetatileLabelPair {
+    QString normal;
+    QString shared;
+};
+
 class Tileset
 {
 public:
@@ -36,8 +41,9 @@ public:
     static Tileset* getMetatileTileset(int, Tileset*, Tileset*);
     static Tileset* getTileTileset(int, Tileset*, Tileset*);
     static Metatile* getMetatile(int, Tileset*, Tileset*);
-    static Tileset* getMetatileLabelTileset(int, Tileset*, Tileset*, bool * isShared = nullptr);
-    static QString getMetatileLabel(int, Tileset *, Tileset *, bool * isShared = nullptr);
+    static Tileset* getMetatileLabelTileset(int, Tileset*, Tileset*);
+    static QString getMetatileLabel(int, Tileset *, Tileset *);
+    static MetatileLabelPair getMetatileLabelPair(int metatileId, Tileset *primaryTileset, Tileset *secondaryTileset);
     static bool setMetatileLabel(int, QString, Tileset *, Tileset *);
     QString getMetatileLabelPrefix();
     static QString getMetatileLabelPrefix(const QString &name);

--- a/include/core/tileset.h
+++ b/include/core/tileset.h
@@ -8,7 +8,7 @@
 #include <QHash>
 
 struct MetatileLabelPair {
-    QString normal;
+    QString owned;
     QString shared;
 };
 
@@ -43,6 +43,7 @@ public:
     static Metatile* getMetatile(int, Tileset*, Tileset*);
     static Tileset* getMetatileLabelTileset(int, Tileset*, Tileset*);
     static QString getMetatileLabel(int, Tileset *, Tileset *);
+    static QString getOwnedMetatileLabel(int, Tileset *, Tileset *);
     static MetatileLabelPair getMetatileLabelPair(int metatileId, Tileset *primaryTileset, Tileset *secondaryTileset);
     static bool setMetatileLabel(int, QString, Tileset *, Tileset *);
     QString getMetatileLabelPrefix();

--- a/include/ui/tileseteditor.h
+++ b/include/ui/tileseteditor.h
@@ -127,7 +127,7 @@ private:
     void importTilesetTiles(Tileset*, bool);
     void importTilesetMetatiles(Tileset*, bool);
     void refresh();
-    void saveMetatileLabel();
+    void commitMetatileLabel();
     void closeEvent(QCloseEvent*);
     void countMetatileUsage();
     void countTileUsage();
@@ -146,6 +146,7 @@ private:
     Map *map = nullptr;
     Metatile *metatile = nullptr;
     Metatile *copiedMetatile = nullptr;
+    QString copiedMetatileLabel;
     int paletteId;
     bool tileXFlip;
     bool tileYFlip;

--- a/include/ui/tileseteditor.h
+++ b/include/ui/tileseteditor.h
@@ -16,10 +16,12 @@ class TilesetEditor;
 
 class MetatileHistoryItem {
 public:
-    MetatileHistoryItem(uint16_t metatileId, Metatile *prevMetatile, Metatile *newMetatile) {
+    MetatileHistoryItem(uint16_t metatileId, Metatile *prevMetatile, Metatile *newMetatile, QString prevLabel, QString newLabel) {
         this->metatileId = metatileId;
         this->prevMetatile = prevMetatile;
         this->newMetatile = newMetatile;
+        this->prevLabel = prevLabel;
+        this->newLabel = newLabel;
     }
     ~MetatileHistoryItem() {
         delete this->prevMetatile;
@@ -28,6 +30,8 @@ public:
     uint16_t metatileId;
     Metatile *prevMetatile;
     Metatile *newMetatile;
+    QString prevLabel;
+    QString newLabel;
 };
 
 class TilesetEditor : public QMainWindow
@@ -132,9 +136,11 @@ private:
     void countMetatileUsage();
     void countTileUsage();
     void copyMetatile(bool cut);
-    void pasteMetatile(const Metatile * toPaste);
-    bool replaceMetatile(uint16_t metatileId, const Metatile * src);
+    void pasteMetatile(const Metatile * toPaste, QString label);
+    bool replaceMetatile(uint16_t metatileId, const Metatile * src, QString label);
     void setComboValue(QComboBox * combo, int value);
+    void commitMetatileChange(Metatile * prevMetatile);
+    void commitMetatileAndLabelChange(Metatile * prevMetatile, QString prevLabel);
 
     Ui::TilesetEditor *ui;
     History<MetatileHistoryItem*> metatileHistory;

--- a/src/core/tileset.cpp
+++ b/src/core/tileset.cpp
@@ -113,18 +113,8 @@ Tileset* Tileset::getMetatileLabelTileset(int metatileId, Tileset *primaryTilese
     return nullptr;
 }
 
-// If the metatile has a label in the tileset it belongs to, return that label.
-// If it doesn't, and the metatile has a label in the other tileset, return that label.
-// Otherwise return an empty string.
-QString Tileset::getMetatileLabel(int metatileId, Tileset *primaryTileset, Tileset *secondaryTileset) {
-    Tileset * tileset = Tileset::getMetatileLabelTileset(metatileId, primaryTileset, secondaryTileset);
-    if (!tileset)
-        return QString();
-    return tileset->metatileLabels.value(metatileId);
-}
-
 // Return the pair of possible metatile labels for the specified metatile.
-// "normal" is the label for the tileset to which the metatile belongs.
+// "owned" is the label for the tileset to which the metatile belongs.
 // "shared" is the label for the tileset to which the metatile does not belong.
 MetatileLabelPair Tileset::getMetatileLabelPair(int metatileId, Tileset *primaryTileset, Tileset *secondaryTileset) {
     MetatileLabelPair labels;
@@ -132,13 +122,27 @@ MetatileLabelPair Tileset::getMetatileLabelPair(int metatileId, Tileset *primary
     QString secondaryMetatileLabel = secondaryTileset ? secondaryTileset->metatileLabels.value(metatileId) : "";
 
     if (metatileId < Project::getNumMetatilesPrimary()) {
-        labels.normal = primaryMetatileLabel;
+        labels.owned = primaryMetatileLabel;
         labels.shared = secondaryMetatileLabel;
     } else if (metatileId < Project::getNumMetatilesTotal()) {
-        labels.normal = secondaryMetatileLabel;
+        labels.owned = secondaryMetatileLabel;
         labels.shared = primaryMetatileLabel;
     }
     return labels;
+}
+
+// If the metatile has a label in the tileset it belongs to, return that label.
+// If it doesn't, and the metatile has a label in the other tileset, return that label.
+// Otherwise return an empty string.
+QString Tileset::getMetatileLabel(int metatileId, Tileset *primaryTileset, Tileset *secondaryTileset) {
+    MetatileLabelPair labels = Tileset::getMetatileLabelPair(metatileId, primaryTileset, secondaryTileset);
+    return !labels.owned.isEmpty() ? labels.owned : labels.shared;
+}
+
+// Just get the "owned" metatile label, i.e. the one for the tileset that the metatile belongs to.
+QString Tileset::getOwnedMetatileLabel(int metatileId, Tileset *primaryTileset, Tileset *secondaryTileset) {
+    MetatileLabelPair labels = Tileset::getMetatileLabelPair(metatileId, primaryTileset, secondaryTileset);
+    return labels.owned;
 }
 
 bool Tileset::setMetatileLabel(int metatileId, QString label, Tileset *primaryTileset, Tileset *secondaryTileset) {

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -932,14 +932,13 @@ void Editor::onHoveredMovementPermissionCleared() {
 
 QString Editor::getMetatileDisplayMessage(uint16_t metatileId) {
     Metatile *metatile = Tileset::getMetatile(metatileId, map->layout->tileset_primary, map->layout->tileset_secondary);
+    QString label = Tileset::getMetatileLabel(metatileId, map->layout->tileset_primary, map->layout->tileset_secondary);
     QString hexString = QString("%1").arg(metatileId, 3, 16, QChar('0')).toUpper();
     QString message = QString("Metatile: 0x%1").arg(hexString);
-    if (metatile) {
-        if (metatile->label.size())
-            message += QString(" \"%1\"").arg(metatile->label);
-        if (metatile->behavior) // Skip MB_NORMAL
-            message += QString(", Behavior: %1").arg(this->project->metatileBehaviorMapInverse.value(metatile->behavior, QString::number(metatile->behavior)));
-    }
+    if (label.size())
+        message += QString(" \"%1\"").arg(label);
+    if (metatile && metatile->behavior) // Skip MB_NORMAL
+        message += QString(", Behavior: %1").arg(this->project->metatileBehaviorMapInverse.value(metatile->behavior, QString::number(metatile->behavior)));
     return message;
 }
 

--- a/src/project.cpp
+++ b/src/project.cpp
@@ -1509,7 +1509,7 @@ bool Project::readTilesetMetatileLabels() {
     for (QString label : this->tilesetLabelsOrdered) {
         QString tilesetName = QString(label).replace("gTileset_", "");
         for (QString key : labels.keys()) {
-            if (key.contains(QString("METATILE_") + tilesetName)) {
+            if (key.contains(QString("METATILE_") + tilesetName + "_")) {
                 metatileLabelsMap[label][key] = labels[key];
             }
         }

--- a/src/project.cpp
+++ b/src/project.cpp
@@ -914,12 +914,16 @@ void Project::saveTilesetMetatileLabels(Tileset *primaryTileset, Tileset *second
 
     // Add the new labels.
     for (int metatileId : primaryTileset->metatileLabels.keys()) {
-        QString defineName = QString("%1%2").arg(primaryPrefix, primaryTileset->metatileLabels.value(metatileId));
+        QString label = primaryTileset->metatileLabels.value(metatileId);
+        if (label.isEmpty()) continue;
+        QString defineName = QString("%1%2").arg(primaryPrefix, label);
         defines.insert(defineName, metatileId);
         definesFileModified = true;
     }
     for (int metatileId : secondaryTileset->metatileLabels.keys()) {
-        QString defineName = QString("%1%2").arg(secondaryPrefix, secondaryTileset->metatileLabels.value(metatileId));
+        QString label = secondaryTileset->metatileLabels.value(metatileId);
+        if (label.isEmpty()) continue;
+        QString defineName = QString("%1%2").arg(secondaryPrefix, label);
         defines.insert(defineName, metatileId);
         definesFileModified = true;
     }

--- a/src/project.cpp
+++ b/src/project.cpp
@@ -913,21 +913,15 @@ void Project::saveTilesetMetatileLabels(Tileset *primaryTileset, Tileset *second
     }
 
     // Add the new labels.
-    for (int i = 0; i < primaryTileset->metatiles.size(); i++) {
-        Metatile *metatile = primaryTileset->metatiles.at(i);
-        if (metatile->label.size() != 0) {
-            QString defineName = QString("%1%2").arg(primaryPrefix, metatile->label);
-            defines.insert(defineName, i);
-            definesFileModified = true;
-        }
+    for (int metatileId : primaryTileset->metatileLabels.keys()) {
+        QString defineName = QString("%1%2").arg(primaryPrefix, primaryTileset->metatileLabels.value(metatileId));
+        defines.insert(defineName, metatileId);
+        definesFileModified = true;
     }
-    for (int i = 0; i < secondaryTileset->metatiles.size(); i++) {
-        Metatile *metatile = secondaryTileset->metatiles.at(i);
-        if (metatile->label.size() != 0) {
-            QString defineName = QString("%1%2").arg(secondaryPrefix, metatile->label);
-            defines.insert(defineName, i + Project::num_tiles_primary);
-            definesFileModified = true;
-        }
+    for (int metatileId : secondaryTileset->metatileLabels.keys()) {
+        QString defineName = QString("%1%2").arg(secondaryPrefix, secondaryTileset->metatileLabels.value(metatileId));
+        defines.insert(defineName, metatileId);
+        definesFileModified = true;
     }
 
     if (!definesFileModified) {
@@ -1521,17 +1515,10 @@ bool Project::readTilesetMetatileLabels() {
 void Project::loadTilesetMetatileLabels(Tileset* tileset) {
     QString tilesetPrefix = QString("METATILE_%1_").arg(QString(tileset->name).replace("gTileset_", ""));
 
+    // Reverse map for faster lookup by metatile id
     for (QString labelName : metatileLabelsMap[tileset->name].keys()) {
         int metatileId = metatileLabelsMap[tileset->name][labelName];
-        // subtract Project::num_tiles_primary from secondary metatiles
-        int offset = tileset->is_secondary ? Project::num_tiles_primary : 0;
-        Metatile *metatile = Tileset::getMetatile(metatileId - offset, tileset, nullptr);
-        if (metatile) {
-            metatile->label = labelName.replace(tilesetPrefix, "");
-        } else {
-            QString hexString = QString("%1").arg(metatileId, 3, 16, QChar('0')).toUpper();
-            logError(QString("Metatile 0x%1 (%2) cannot be found in tileset '%3'").arg(hexString, labelName, tileset->name));
-        }
+        tileset->metatileLabels[metatileId] = labelName.replace(tilesetPrefix, "");
     }
 }
 

--- a/src/project.cpp
+++ b/src/project.cpp
@@ -891,8 +891,8 @@ void Project::saveTilesets(Tileset *primaryTileset, Tileset *secondaryTileset) {
 }
 
 void Project::saveTilesetMetatileLabels(Tileset *primaryTileset, Tileset *secondaryTileset) {
-    QString primaryPrefix = QString("METATILE_%1_").arg(QString(primaryTileset->name).replace("gTileset_", ""));
-    QString secondaryPrefix = QString("METATILE_%1_").arg(QString(secondaryTileset->name).replace("gTileset_", ""));
+    QString primaryPrefix = primaryTileset->getMetatileLabelPrefix();
+    QString secondaryPrefix = secondaryTileset->getMetatileLabelPrefix();
 
     QMap<QString, int> defines;
     bool definesFileModified = false;
@@ -1500,11 +1500,11 @@ bool Project::readTilesetMetatileLabels() {
 
     QMap<QString, int> labels = parser.readCDefines(metatileLabelsFilename, QStringList() << "METATILE_");
 
-    for (QString label : this->tilesetLabelsOrdered) {
-        QString tilesetName = QString(label).replace("gTileset_", "");
+    for (QString tilesetLabel : this->tilesetLabelsOrdered) {
+        QString metatileLabelPrefix = Tileset::getMetatileLabelPrefix(tilesetLabel);
         for (QString key : labels.keys()) {
-            if (key.contains(QString("METATILE_") + tilesetName + "_")) {
-                metatileLabelsMap[label][key] = labels[key];
+            if (key.startsWith(metatileLabelPrefix)) {
+                metatileLabelsMap[tilesetLabel][key] = labels[key];
             }
         }
     }
@@ -1513,12 +1513,12 @@ bool Project::readTilesetMetatileLabels() {
 }
 
 void Project::loadTilesetMetatileLabels(Tileset* tileset) {
-    QString tilesetPrefix = QString("METATILE_%1_").arg(QString(tileset->name).replace("gTileset_", ""));
+    QString metatileLabelPrefix = tileset->getMetatileLabelPrefix();
 
     // Reverse map for faster lookup by metatile id
     for (QString labelName : metatileLabelsMap[tileset->name].keys()) {
         int metatileId = metatileLabelsMap[tileset->name][labelName];
-        tileset->metatileLabels[metatileId] = labelName.replace(tilesetPrefix, "");
+        tileset->metatileLabels[metatileId] = labelName.replace(metatileLabelPrefix, "");
     }
 }
 

--- a/src/scriptapi/apimap.cpp
+++ b/src/scriptapi/apimap.cpp
@@ -618,8 +618,6 @@ void MainWindow::setMetatileLabel(int metatileId, QString label) {
         return;
     }
 
-    // The user may not have the Tileset Editor open. This forcefully saves the change for them.
-    // If they do have the Tileset Editor open, this has the unintended side effect of saving other unsaved label changes.
     if (this->editor->project)
         this->editor->project->saveTilesetMetatileLabels(this->editor->map->layout->tileset_primary, this->editor->map->layout->tileset_secondary);
 }

--- a/src/ui/tileseteditor.cpp
+++ b/src/ui/tileseteditor.cpp
@@ -380,10 +380,10 @@ void TilesetEditor::onSelectedMetatileChanged(uint16_t metatileId) {
     this->metatileLayersItem->draw();
     this->ui->graphicsView_metatileLayers->setFixedSize(this->metatileLayersItem->pixmap().width() + 2, this->metatileLayersItem->pixmap().height() + 2);
 
-    bool isAlternateLabel = false;
-    QString label = Tileset::getMetatileLabel(metatileId, this->primaryTileset, this->secondaryTileset, &isAlternateLabel);
+    bool isShared = false;
+    QString label = Tileset::getMetatileLabel(metatileId, this->primaryTileset, this->secondaryTileset, &isShared);
     this->ui->lineEdit_metatileLabel->setText(label);
-    this->ui->lineEdit_metatileLabel->setReadOnly(isAlternateLabel);
+    this->ui->lineEdit_metatileLabel->setReadOnly(isShared);
 
     setComboValue(this->ui->comboBox_metatileBehaviors, this->metatile->behavior);
     setComboValue(this->ui->comboBox_layerType, this->metatile->layerType);
@@ -918,9 +918,9 @@ void TilesetEditor::copyMetatile(bool cut) {
     // Don't try to copy the label unless it's a cut, these should be unique to each metatile
     this->copiedMetatileLabel = "";
     if (cut) {
-        bool isAlternateLabel = false;
-        QString label = Tileset::getMetatileLabel(metatileId, this->primaryTileset, this->secondaryTileset, &isAlternateLabel);
-        if (!isAlternateLabel)
+        bool isShared = false;
+        QString label = Tileset::getMetatileLabel(metatileId, this->primaryTileset, this->secondaryTileset, &isShared);
+        if (!isShared)
             this->copiedMetatileLabel = label;
     }
 }
@@ -1165,12 +1165,11 @@ void TilesetEditor::countTileUsage() {
 }
 
 void TilesetEditor::on_copyButton_metatileLabel_clicked() {
-    // TODO: Handle alternate labels
     QString label = this->ui->lineEdit_metatileLabel->text();
     if (label.isEmpty()) return;
-    Tileset * tileset = Tileset::getMetatileTileset(this->getSelectedMetatileId(), this->primaryTileset, this->secondaryTileset);
+    Tileset * tileset = Tileset::getMetatileLabelTileset(this->getSelectedMetatileId(), this->primaryTileset, this->secondaryTileset);
     if (tileset)
-        label.prepend("METATILE_" + QString(tileset->name).replace("gTileset_", "") + "_");
+        label.prepend(tileset->getMetatileLabelPrefix());
     QGuiApplication::clipboard()->setText(label);
     QToolTip::showText(this->ui->copyButton_metatileLabel->mapToGlobal(QPoint(0, 0)), "Copied!");
 }

--- a/src/ui/tileseteditor.cpp
+++ b/src/ui/tileseteditor.cpp
@@ -842,15 +842,16 @@ void TilesetEditor::onPaletteEditorChangedPalette(int paletteId) {
     this->on_spinBox_paletteSelector_valueChanged(paletteId);
 }
 
-bool TilesetEditor::replaceMetatile(uint16_t metatileId, const Metatile * src, QString label)
+bool TilesetEditor::replaceMetatile(uint16_t metatileId, const Metatile * src, QString newLabel)
 {
     Metatile * dest = Tileset::getMetatile(metatileId, this->primaryTileset, this->secondaryTileset);
-    if (!dest || !src || *dest == *src)
+    QString oldLabel = Tileset::getOwnedMetatileLabel(metatileId, this->primaryTileset, this->secondaryTileset);
+    if (!dest || !src || (*dest == *src && oldLabel == newLabel))
         return false;
 
-    Tileset::setMetatileLabel(metatileId, label, this->primaryTileset, this->secondaryTileset);
+    Tileset::setMetatileLabel(metatileId, newLabel, this->primaryTileset, this->secondaryTileset);
     if (metatileId == this->getSelectedMetatileId())
-        this->ui->lineEdit_metatileLabel->setText(label);
+        this->ui->lineEdit_metatileLabel->setText(newLabel);
 
     this->metatile = dest;
     *this->metatile = *src;

--- a/src/ui/tileseteditor.cpp
+++ b/src/ui/tileseteditor.cpp
@@ -22,7 +22,6 @@ TilesetEditor::TilesetEditor(Project *project, Map *map, QWidget *parent) :
 {
     this->setTilesets(this->map->layout->tileset_primary_label, this->map->layout->tileset_secondary_label);
     this->initUi();
-    this->initMetatileHistory();
 }
 
 TilesetEditor::~TilesetEditor()
@@ -64,7 +63,6 @@ void TilesetEditor::updateTilesets(QString primaryTilesetLabel, QString secondar
         if (result == QMessageBox::Yes)
             this->on_actionSave_Tileset_triggered();
     }
-    this->hasUnsavedChanges = false;
     this->setTilesets(primaryTilesetLabel, secondaryTilesetLabel);
     this->refresh();
 }
@@ -89,6 +87,7 @@ void TilesetEditor::setTilesets(QString primaryTilesetLabel, QString secondaryTi
     this->primaryTileset = new Tileset(*primaryTileset);
     this->secondaryTileset = new Tileset(*secondaryTileset);
     if (paletteEditor) paletteEditor->setTilesets(this->primaryTileset, this->secondaryTileset);
+    this->initMetatileHistory();
 }
 
 void TilesetEditor::initUi() {
@@ -276,12 +275,13 @@ void TilesetEditor::restoreWindowState() {
 }
 
 void TilesetEditor::initMetatileHistory() {
-    MetatileHistoryItem *commit = new MetatileHistoryItem(0, nullptr, new Metatile(*metatile), QString(), QString());
+    metatileHistory.clear();
+    MetatileHistoryItem *commit = new MetatileHistoryItem(0, nullptr, new Metatile(), QString(), QString());
     metatileHistory.push(commit);
+    this->hasUnsavedChanges = false;
 }
 
 void TilesetEditor::reset() {
-    this->hasUnsavedChanges = false;
     this->setTilesets(this->primaryTileset->name, this->secondaryTileset->name);
     if (this->paletteEditor)
         this->paletteEditor->setTilesets(this->primaryTileset, this->secondaryTileset);


### PR DESCRIPTION
Metatile labels are now stored per-tileset, instead of per-metatile.

Fixes #414 
Fixes #472 (26f07ad)
Also fixes a 5.1.0 regression where Porymap inserts metatile labels from tilesets with shared names (e.g. it will create a new label called `METATILE_Petalburg_METATILE_PetalburgGym_Door`) (72ae9df)

TODO:
- [x] Reimplement label edit history
- [x] Reimplement the label copy button
- [x] Better visualization (it's not clear at a glance that the line edit is read-only; "shared" labels should be grayed out, and Porymap should allow users to insert new labels on top of them)
- [x] Update changelog and manual