### PR TITLE
Fix build on Linux

### DIFF
--- a/include/lib/fex/lexer.h
+++ b/include/lib/fex/lexer.h
@@ -1,6 +1,7 @@
 #ifndef INCLUDE_CORE_LEXER_H
 #define INCLUDE_CORE_LEXER_H
 
+#include <cstdint>
 #include <string>
 #include <vector>
 


### PR DESCRIPTION
Build was failing on Linux. Need `cstdint` due to the use of `uint32_t` [here](https://github.com/huderlem/porymap/blob/c28d3dc1c94cdba517644ba77d25944d0a64d120/include/lib/fex/lexer.h#L115).

Alternatively, we could just use an `unsigned int` here (this will be 32 bits on most systems), or even an `unsigned long` if there is a specific compatibility goal that drove this decision. Either approach compiles to exactly the same binary on my machine, so I don't think it matters.