### PR TITLE
Support 8BPP tileset tile images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project somewhat adheres to [Semantic Versioning](https://semver.org/sp
 The **"Breaking Changes"** listed below are changes that have been made in the decompilation projects (e.g. pokeemerald), which porymap requires in order to work properly. It also includes changes to the scripting API that may change the behavior of existing porymap scripts. If porymap is used with a project or API script that is not up-to-date with the breaking changes, then porymap will likely break or behave improperly.
 
 ## [Unreleased]
+### Added
+- Support for 8BPP tileset tile images.
+
 ### Changed
 - The Palette Editor now remembers the Bit Depth setting.
 

--- a/include/core/tileset.h
+++ b/include/core/tileset.h
@@ -38,6 +38,8 @@ public:
     QList<QList<QRgb>> palettes;
     QList<QList<QRgb>> palettePreviews;
 
+    bool hasUnsavedTilesImage;
+
     static Tileset* getMetatileTileset(int, Tileset*, Tileset*);
     static Tileset* getTileTileset(int, Tileset*, Tileset*);
     static Metatile* getMetatile(int, Tileset*, Tileset*);

--- a/include/ui/imageproviders.h
+++ b/include/ui/imageproviders.h
@@ -13,6 +13,7 @@ QImage getMetatileImage(Metatile*, Tileset*, Tileset*, QList<int>, QList<float>,
 QImage getTileImage(uint16_t, Tileset*, Tileset*);
 QImage getPalettedTileImage(uint16_t, Tileset*, Tileset*, int, bool useTruePalettes = false);
 QImage getGreyscaleTileImage(uint16_t tile, Tileset *primaryTileset, Tileset *secondaryTileset);
+void flattenTo4bppImage(QImage * image);
 
 static QList<QRgb> greyscalePalette({
     qRgb(0, 0, 0),

--- a/include/ui/tilemaptileselector.h
+++ b/include/ui/tilemaptileselector.h
@@ -4,6 +4,7 @@
 
 #include "selectablepixmapitem.h"
 #include "paletteutil.h"
+#include "imageproviders.h"
 
 #include <memory>
 using std::shared_ptr;
@@ -127,10 +128,7 @@ public:
         this->tileset = QImage(tilesetFilepath);
         this->format = format;
         if (this->tileset.format() == QImage::Format::Format_Indexed8 && this->format == TilemapFormat::BPP_4) {
-            // Squash pixel data to fit 4BPP. Allows project repo to use 8BPP images for 4BPP tilemaps
-            uchar * pixel = this->tileset.bits();
-            for (int i = 0; i < this->tileset.sizeInBytes(); i++, pixel++)
-                *pixel %= 16;
+            flattenTo4bppImage(&this->tileset);
         }
         bool err;
         if (!palFilepath.isEmpty()) {

--- a/src/core/tileset.cpp
+++ b/src/core/tileset.cpp
@@ -22,7 +22,8 @@ Tileset::Tileset(const Tileset &other)
       palettePaths(other.palettePaths),
       metatileLabels(other.metatileLabels),
       palettes(other.palettes),
-      palettePreviews(other.palettePreviews)
+      palettePreviews(other.palettePreviews),
+      hasUnsavedTilesImage(false)
 {
     for (auto tile : other.tiles) {
         tiles.append(tile.copy());

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -18,6 +18,7 @@
 #include "mapparser.h"
 #include "prefab.h"
 #include "montabwidget.h"
+#include "imageexport.h"
 
 #include <QFileDialog>
 #include <QClipboard>
@@ -1280,7 +1281,7 @@ void MainWindow::on_actionNew_Tileset_triggered() {
         }
         newSet.palettes[0][1] = qRgb(255,0,255);
         newSet.palettePreviews[0][1] = qRgb(255,0,255);
-        editor->project->saveTilesetTilesImage(&newSet);
+        exportIndexed4BPPPng(newSet.tilesImage, newSet.tilesImagePath);
         editor->project->saveTilesetMetatiles(&newSet);
         editor->project->saveTilesetMetatileAttributes(&newSet);
         editor->project->saveTilesetPalettes(&newSet);

--- a/src/ui/imageproviders.cpp
+++ b/src/ui/imageproviders.cpp
@@ -169,3 +169,12 @@ QImage getPalettedTileImage(uint16_t tileId, Tileset *primaryTileset, Tileset *s
 QImage getGreyscaleTileImage(uint16_t tileId, Tileset *primaryTileset, Tileset *secondaryTileset) {
     return getColoredTileImage(tileId, primaryTileset, secondaryTileset, greyscalePalette);
 }
+
+// gbagfx allows 4bpp image data to be represented with 8bpp .png files by considering only the lower 4 bits of each pixel.
+// Reproduce that here to support this type of image use.
+void flattenTo4bppImage(QImage * image) {
+    if (!image) return;
+    uchar * pixel = image->bits();
+    for (int i = 0; i < image->sizeInBytes(); i++, pixel++)
+        *pixel %= 16;
+}


### PR DESCRIPTION
gbagfx supports using 8bpp images to represent 4bpp data by ignoring the uppermost bits. Porymap now reproduces this behavior when reading or importing tileset tile images. Porymap will also no longer overwrite the tile images when saving tilesets (unless a new one was imported). When Porymap is used to create a new tileset it will still save the new tiles image as a 4bpp png.

Closes #533 