### PR TITLE
Automatically adjust min/max encounter levels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The **"Breaking Changes"** listed below are changes that have been made in the d
 ## [Unreleased]
 ### Changed
 - The Palette Editor now remembers the Bit Depth setting.
+- The min/max levels on the Wild Pokémon tab will now adjust automatically if they invalidate each other.
 
 ### Fixed
 - Fix text boxes in the Palette Editor calculating color incorrectly.

--- a/src/ui/encountertabledelegates.cpp
+++ b/src/ui/encountertabledelegates.cpp
@@ -61,12 +61,8 @@ QWidget *SpinBoxDelegate::createEditor(QWidget *parent, const QStyleOptionViewIt
     editor->setFrame(false);
 
     int col = index.column();
-    if (col == EncounterTableModel::ColumnType::MinLevel) {
+    if (col == EncounterTableModel::ColumnType::MinLevel || col == EncounterTableModel::ColumnType::MaxLevel) {
         editor->setMinimum(this->project->miscConstants.value("min_level_define").toInt());
-        editor->setMaximum(index.siblingAtColumn(EncounterTableModel::ColumnType::MaxLevel).data(Qt::EditRole).toInt());
-    }
-    else if (col == EncounterTableModel::ColumnType::MaxLevel) {
-        editor->setMinimum(index.siblingAtColumn(EncounterTableModel::ColumnType::MinLevel).data(Qt::EditRole).toInt());
         editor->setMaximum(this->project->miscConstants.value("max_level_define").toInt());
     }
     else if (col == EncounterTableModel::ColumnType::EncounterRate) {

--- a/src/ui/encountertablemodel.cpp
+++ b/src/ui/encountertablemodel.cpp
@@ -155,13 +155,21 @@ bool EncounterTableModel::setData(const QModelIndex &index, const QVariant &valu
             this->monInfo.wildPokemon[row].species = value.toString();
             break;
 
-        case ColumnType::MinLevel:
-            this->monInfo.wildPokemon[row].minLevel = value.toInt();
+        case ColumnType::MinLevel: {
+            int minLevel = value.toInt();
+            this->monInfo.wildPokemon[row].minLevel = minLevel;
+            if (minLevel > this->monInfo.wildPokemon[row].maxLevel)
+                this->monInfo.wildPokemon[row].maxLevel = minLevel;
             break;
+        }
 
-        case ColumnType::MaxLevel:
-            this->monInfo.wildPokemon[row].maxLevel = value.toInt();
+        case ColumnType::MaxLevel: {
+            int maxLevel = value.toInt();
+            this->monInfo.wildPokemon[row].maxLevel = maxLevel;
+            if (maxLevel < this->monInfo.wildPokemon[row].minLevel)
+                this->monInfo.wildPokemon[row].minLevel = maxLevel;
             break;
+        }
 
         case ColumnType::EncounterRate:
             this->monInfo.encounterRate = value.toInt();


### PR DESCRIPTION
Currently users are prevented from increasing the min level above the max level for wild encounters. This was allowed in 4.5.0. Decreasing the max level below the min level is also disallowed, and wasn't previously allowed. Both are now allowed, and will adjust the corresponding limit accordingly.

