### PR TITLE
Stop misleading error when recent project doesn't exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The **"Breaking Changes"** listed below are changes that have been made in the d
 ### Changed
 - The Palette Editor now remembers the Bit Depth setting.
 - The min/max levels on the Wild Pokémon tab will now adjust automatically if they invalidate each other.
+- If the recent project directory doesn't exist Porymap will open an empty project instead of failing with a misleading error message.
 
 ### Fixed
 - Fix text boxes in the Palette Editor calculating color incorrectly.

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -483,12 +483,18 @@ bool MainWindow::openRecentProject() {
         return false;
 
     QString default_dir = porymapConfig.getRecentProject();
-    if (!default_dir.isNull() && default_dir.length() > 0) {
-        logInfo(QString("Opening recent project: '%1'").arg(default_dir));
-        return openProject(default_dir);
+    if (default_dir.isNull() || default_dir.length() <= 0)
+        return false;
+
+    if (!QDir(default_dir).exists()) {
+        QString message = QString("Recent project directory '%1' doesn't exist.").arg(QDir::toNativeSeparators(default_dir));
+        logWarn(message);
+        this->statusBar()->showMessage(message);
+        return false;
     }
 
-    return false;
+    logInfo(QString("Opening recent project: '%1'").arg(default_dir));
+    return openProject(default_dir);
 }
 
 bool MainWindow::openProject(QString dir) {


### PR DESCRIPTION
Currently, if the `recent_project` directory doesn't exist Porymap will try to open it anyway, and fail with an error message about the first thing it was unable to find. Right now that's the map layouts:
```
There was an error opening the project <project path>. Please see <log path> for full error details.

Failed to read map layouts from <project path>/data/layouts/layouts.json
```

Users have to close this message to open a project. Now Porymap will immediately open an empty project, and give a more helpful message in the status bar and as a warning in the log.