### PR TITLE
Fix issues when user supplies incorrect number of encounters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ The **"Breaking Changes"** listed below are changes that have been made in the d
 - Fix the selection outline sticking in single-tile mode on the Prefab tab.
 - Fix heal location data being cleared if certain spaces aren't used in the table.
 - Fix bad URL color contrast on dark themes.
+- Fix some issues when too few/many pokémon are specified for a wild encounter group.
 
 ## [5.1.1] - 2023-02-20
 ### Added

--- a/src/project.cpp
+++ b/src/project.cpp
@@ -1670,6 +1670,11 @@ bool Project::readWildMonData() {
                         newMon.species = monObj["species"].string_value();
                         header.wildMons[field].wildPokemon.append(newMon);
                     }
+                    // If the user supplied too few pokémon for this group then we fill in the rest.
+                    for (int i = header.wildMons[field].wildPokemon.length(); i < monField.encounterRates.length(); i++) {
+                        WildPokemon newMon; // Keep default values
+                        header.wildMons[field].wildPokemon.append(newMon);
+                    }
                 }
             }
             wildMonData[mapConstant].insert({encounterObj["base_label"].string_value(), header});

--- a/src/ui/encountertablemodel.cpp
+++ b/src/ui/encountertablemodel.cpp
@@ -10,11 +10,10 @@ EncounterTableModel::EncounterTableModel(WildMonInfo info, EncounterFields field
 
     this->resize(this->monInfo.wildPokemon.size(), ColumnType::Count);
 
-    this->slotRatios = fields[fieldIndex].encounterRates;
-
     for (int r = 0; r < this->numRows; r++) {
         this->groupNames.append(QString());
         this->slotPercentages.append(0.0);
+        this->slotRatios.append(fields[fieldIndex].encounterRates.value(r, 0));
     }
 
     if (!this->encounterFields[this->fieldIndex].groups.empty()) {


### PR DESCRIPTION
Closes #553 

Also fixes an OOB read in `slotRatios` if more pokémon are specified than are normally in the encounter group.