### PR TITLE
Add 'Open Recent Project' menu

### DIFF
--- a/forms/mainwindow.ui
+++ b/forms/mainwindow.ui
@@ -3021,7 +3021,13 @@
     <property name="title">
      <string>File</string>
     </property>
+    <widget class="QMenu" name="menuOpen_Recent_Project">
+     <property name="title">
+      <string>Open Recent Project</string>
+     </property>
+    </widget>
     <addaction name="action_Open_Project"/>
+    <addaction name="menuOpen_Recent_Project"/>
     <addaction name="action_Reload_Project"/>
     <addaction name="action_Save"/>
     <addaction name="action_Save_Project"/>

--- a/include/config.h
+++ b/include/config.h
@@ -51,7 +51,7 @@ public:
         reset();
     }
     virtual void reset() override {
-        this->recentProject = "";
+        this->recentProjects.clear();
         this->reopenOnLaunch = true;
         this->mapSortOrder = MapSortOrder::Group;
         this->prettyCursors = true;
@@ -73,7 +73,8 @@ public:
         this->projectSettingsTab = 0;
         this->warpBehaviorWarningDisabled = false;
     }
-    void setRecentProject(QString project);
+    void addRecentProject(QString project);
+    void setRecentProjects(QStringList projects);
     void setReopenOnLaunch(bool enabled);
     void setMapSortOrder(MapSortOrder order);
     void setPrettyCursors(bool enabled);
@@ -101,6 +102,7 @@ public:
     void setProjectSettingsTab(int tab);
     void setWarpBehaviorWarningDisabled(bool disabled);
     QString getRecentProject();
+    QStringList getRecentProjects();
     bool getReopenOnLaunch();
     MapSortOrder getMapSortOrder();
     bool getPrettyCursors();
@@ -134,7 +136,7 @@ protected:
     virtual void onNewConfigFileCreated() override {};
     virtual void setUnreadKeys() override {};
 private:
-    QString recentProject;
+    QStringList recentProjects;
     bool reopenOnLaunch;
     QString stringFromByteArray(QByteArray);
     QByteArray bytesFromString(QString);

--- a/include/mainwindow.h
+++ b/include/mainwindow.h
@@ -354,6 +354,7 @@ private:
     bool setInitialMap();
     void setRecentMap(QString map_name);
     QStandardItem* createMapItem(QString mapName, int groupNum, int inGroupNum);
+    void refreshRecentProjectsMenu();
 
     void drawMapListIcons(QAbstractItemModel *model);
     void updateMapList();

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -319,9 +319,7 @@ QString PorymapConfig::getConfigFilepath() {
 
 void PorymapConfig::parseConfigKeyValue(QString key, QString value) {
     if (key == "recent_project") {
-        QStringList paths = value.split(",", Qt::SkipEmptyParts);
-        for (auto path : paths)
-            this->recentProjects.append(path);
+        this->recentProjects = value.split(",", Qt::SkipEmptyParts);
         this->recentProjects.removeDuplicates();
     } else if (key == "reopen_on_launch") {
         this->reopenOnLaunch = getConfigBool(key, value);

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -319,7 +319,10 @@ QString PorymapConfig::getConfigFilepath() {
 
 void PorymapConfig::parseConfigKeyValue(QString key, QString value) {
     if (key == "recent_project") {
-        this->recentProject = value;
+        QStringList paths = value.split(",", Qt::SkipEmptyParts);
+        for (auto path : paths)
+            this->recentProjects.append(path);
+        this->recentProjects.removeDuplicates();
     } else if (key == "reopen_on_launch") {
         this->reopenOnLaunch = getConfigBool(key, value);
     } else if (key == "pretty_cursors") {
@@ -404,7 +407,7 @@ void PorymapConfig::parseConfigKeyValue(QString key, QString value) {
 
 QMap<QString, QString> PorymapConfig::getKeyValueMap() {
     QMap<QString, QString> map;
-    map.insert("recent_project", this->recentProject);
+    map.insert("recent_project", this->recentProjects.join(","));
     map.insert("reopen_on_launch", this->reopenOnLaunch ? "1" : "0");
     map.insert("pretty_cursors", this->prettyCursors ? "1" : "0");
     map.insert("map_sort_order", mapSortOrderMap.value(this->mapSortOrder));
@@ -460,8 +463,14 @@ QByteArray PorymapConfig::bytesFromString(QString in) {
     return ba;
 }
 
-void PorymapConfig::setRecentProject(QString project) {
-    this->recentProject = project;
+void PorymapConfig::addRecentProject(QString project) {
+    this->recentProjects.removeOne(project);
+    this->recentProjects.prepend(project);
+    this->save();
+}
+
+void PorymapConfig::setRecentProjects(QStringList projects) {
+    this->recentProjects = projects;
     this->save();
 }
 
@@ -599,7 +608,11 @@ void PorymapConfig::setProjectSettingsTab(int tab) {
 }
 
 QString PorymapConfig::getRecentProject() {
-    return this->recentProject;
+    return this->recentProjects.value(0);
+}
+
+QStringList PorymapConfig::getRecentProjects() {
+    return this->recentProjects;
 }
 
 bool PorymapConfig::getReopenOnLaunch() {


### PR DESCRIPTION
Closes #568 

Also moved handling of `setWindowDisabled` to `openProject`, so it doesn't need to be handled by every caller of `openProject`/`openRecentProject`.