### PR TITLE
Set reasonable defaults for wild encounter rates

### DIFF
--- a/include/core/wildmoninfo.h
+++ b/include/core/wildmoninfo.h
@@ -29,6 +29,7 @@ struct EncounterField {
 
 typedef QVector<EncounterField> EncounterFields;
 
+void setDefaultEncounterRate(QString fieldName, int rate);
 WildMonInfo getDefaultMonInfo(EncounterField field);
 void combineEncounters(WildMonInfo &to, WildMonInfo from);
 

--- a/src/core/wildmoninfo.cpp
+++ b/src/core/wildmoninfo.cpp
@@ -1,12 +1,15 @@
 #include "wildmoninfo.h"
 #include "montabwidget.h"
 
-
+QMap<QString, int> defaultEncounterRates;
+void setDefaultEncounterRate(QString fieldName, int rate) {
+    defaultEncounterRates[fieldName] = rate;
+}
 
 WildMonInfo getDefaultMonInfo(EncounterField field) {
     WildMonInfo newInfo;
     newInfo.active = true;
-    newInfo.encounterRate = 0;
+    newInfo.encounterRate = defaultEncounterRates.value(field.name, 1);
 
     int size = field.encounterRates.size();
     while (size--)


### PR DESCRIPTION
Defaults for wild encounter rates are currently 0 (i.e., no encounters), which can be confusing.

The default is now the most commonly used value for each encounter type (calculated when the project is opened). If no existing encounter rate values are found, the default is 1.

Closes #570 