### PR TITLE
Stop enforcing heal locations table name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,9 @@ The **"Breaking Changes"** listed below are changes that have been made in the d
 - Add `metatile_behaviors`, `num_primary_palettes`, and `num_secondary_palettes` to `constants` in the API.
 
 ### Changed
-- The API functions `addImage` and `createImage` now support project-relative paths.
 - Metatile ID strings are now padded to their current max, not the overall max.
+- The name of the Heal Locations table is no longer enforced.
+- The API functions `addImage` and `createImage` now support project-relative paths.
 
 ### Fixed
 - Fix the event group tabs sometimes showing an event from the wrong group

--- a/docsrc/manual/project-files.rst
+++ b/docsrc/manual/project-files.rst
@@ -86,10 +86,11 @@ In addition to these files, there are some specific symbol and macro names that 
    ``symbol_obj_event_gfx_pointers``, ``gObjectEventGraphicsInfoPointers``, to map Object Event graphics IDs to graphics data
    ``symbol_pokemon_icon_table``, ``gMonIconTable``, to map species constants to icon images
    ``symbol_wild_encounters``, ``gWildMonHeaders``, output as the ``label`` property for the top-level wild ecounters JSON object
-   ``symbol_heal_locations``, ``sHealLocations``, only if ``Respawn Map/NPC`` is disabled
-   ``symbol_spawn_points``, ``sSpawnPoints``, only if ``Respawn Map/NPC`` is enabled
-   ``symbol_spawn_maps``, ``sWhiteoutRespawnHealCenterMapIdxs``, values for Heal Locations ``Respawn Map`` field
-   ``symbol_spawn_npcs``, ``sWhiteoutRespawnHealerNpcIds``, values for Heal Locations ``Respawn NPC`` field
+   ``symbol_heal_locations_type``, ``struct HealLocation``, the type for the Heal Locations table
+   ``symbol_heal_locations``, ``sHealLocations``, the default Heal Locations table name when ``Respawn Map/NPC`` is disabled
+   ``symbol_spawn_points``, ``sSpawnPoints``, the default Heal Locations table name when ``Respawn Map/NPC`` is enabled
+   ``symbol_spawn_maps``, ``u16 sWhiteoutRespawnHealCenterMapIdxs``, the type and table name for Heal Location ``Respawn Map`` values
+   ``symbol_spawn_npcs``, ``u8 sWhiteoutRespawnHealerNpcIds``, the type and table name for Heal Location ``Respawn NPC`` values
    ``symbol_attribute_table``, ``sMetatileAttrMasks``, optionally read to get settings on ``Tilesets`` tab
    ``symbol_tilesets_prefix``, ``gTileset_``, for new tileset names and to extract base tileset names
    ``define_obj_event_count``, ``OBJECT_EVENT_TEMPLATES_COUNT``, to limit total Object Events

--- a/include/config.h
+++ b/include/config.h
@@ -189,6 +189,7 @@ enum ProjectIdentifier {
     symbol_obj_event_gfx_pointers,
     symbol_pokemon_icon_table,
     symbol_wild_encounters,
+    symbol_heal_locations_type,
     symbol_heal_locations,
     symbol_spawn_points,
     symbol_spawn_maps,

--- a/include/project.h
+++ b/include/project.h
@@ -93,6 +93,7 @@ public:
     };
     DataQualifiers getDataQualifiers(QString, QString);
     DataQualifiers healLocationDataQualifiers;
+    QString healLocationsTableName;
 
     QMap<QString, Map*> mapCache;
     Map* loadMap(QString);
@@ -238,7 +239,6 @@ private:
 
     void saveHealLocationsData(Map *map);
     void saveHealLocationsConstants();
-    QString getHealLocationsTableName();
 
     void ignoreWatchedFileTemporarily(QString filepath);
 

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -74,10 +74,11 @@ const QMap<ProjectIdentifier, QPair<QString, QString>> ProjectConfig::defaultIde
     {ProjectIdentifier::symbol_obj_event_gfx_pointers, {"symbol_obj_event_gfx_pointers", "gObjectEventGraphicsInfoPointers"}},
     {ProjectIdentifier::symbol_pokemon_icon_table,     {"symbol_pokemon_icon_table",     "gMonIconTable"}},
     {ProjectIdentifier::symbol_wild_encounters,        {"symbol_wild_encounters",        "gWildMonHeaders"}},
+    {ProjectIdentifier::symbol_heal_locations_type,    {"symbol_heal_locations_type",    "struct HealLocation"}},
     {ProjectIdentifier::symbol_heal_locations,         {"symbol_heal_locations",         "sHealLocations"}},
     {ProjectIdentifier::symbol_spawn_points,           {"symbol_spawn_points",           "sSpawnPoints"}},
-    {ProjectIdentifier::symbol_spawn_maps,             {"symbol_spawn_maps",             "sWhiteoutRespawnHealCenterMapIdxs"}},
-    {ProjectIdentifier::symbol_spawn_npcs,             {"symbol_spawn_npcs",             "sWhiteoutRespawnHealerNpcIds"}},
+    {ProjectIdentifier::symbol_spawn_maps,             {"symbol_spawn_maps",             "u16 sWhiteoutRespawnHealCenterMapIdxs"}},
+    {ProjectIdentifier::symbol_spawn_npcs,             {"symbol_spawn_npcs",             "u8 sWhiteoutRespawnHealerNpcIds"}},
     {ProjectIdentifier::symbol_attribute_table,        {"symbol_attribute_table",        "sMetatileAttrMasks"}},
     {ProjectIdentifier::symbol_tilesets_prefix,        {"symbol_tilesets_prefix",        "gTileset_"}},
     // Defines


### PR DESCRIPTION
Currently Porymap requires a specific name for the Heal Locations table, which changes depending on a project setting. If the setting is changed (or a user gives the table their own name) Porymap will overwrite the table name with the one it expects, and the user's project will be unlikely to compile.

Now Porymap will record the table name and output that name regardless of settings.