### PR TITLE
Fix minor issues with project opening

### DIFF
--- a/include/mainwindow.h
+++ b/include/mainwindow.h
@@ -347,7 +347,8 @@ private:
     void sortMapList();
     void openSubWindow(QWidget * window);
     QString getExistingDirectory(QString);
-    bool openProject(QString dir);
+    bool openProject(const QString &dir, bool initial = false);
+    void showProjectOpenFailure();
     bool setInitialMap();
     void setRecentMap(QString map_name);
     QStandardItem* createMapItem(QString mapName, int groupNum, int inGroupNum);
@@ -377,7 +378,6 @@ private:
     void applyMapListFilter(QString filterText);
     void restoreWindowState();
     void setTheme(QString);
-    bool openRecentProject();
     void updateTilesetEditor();
     Event::Group getEventGroupFromTabWidget(QWidget *tab);
     void closeSupplementaryWindows();

--- a/src/scriptapi/scripting.cpp
+++ b/src/scriptapi/scripting.cpp
@@ -23,6 +23,7 @@ QMap<CallbackType, QString> callbackFunctions = {
 Scripting *instance = nullptr;
 
 void Scripting::init(MainWindow *mainWindow) {
+    mainWindow->ui->graphicsView_Map->clearOverlayMap();
     if (instance) {
         instance->engine->setInterrupted(true);
         instance->scriptUtility->clearActions();


### PR DESCRIPTION
- Fix `Open Recent Project` not clearing the API overlay, and not triggering the project closed script callback
- Fix `Open Recent Project` not showing an error message when trying to open non-existent directories.
- Non-existent directories are now hidden from the `Open Recent Project` menu list

Internally the various special handling for project opening was combined into `openProject` to help avoid issues like this in the future.