### PR TITLE
Sort script dropdown, minor fixes

### DIFF
--- a/include/project.h
+++ b/include/project.h
@@ -199,8 +199,6 @@ public:
     static QString getScriptFileExtension(bool usePoryScript);
     QString getScriptDefaultString(bool usePoryScript, QString mapName) const;
     QStringList getEventScriptsFilePaths() const;
-    QCompleter *getEventScriptLabelCompleter(QStringList additionalScriptLabels);
-    QStringList getGlobalScriptLabels();
 
     QString getDefaultPrimaryTilesetLabel();
     QString getDefaultSecondaryTilesetLabel();
@@ -250,9 +248,6 @@ private:
     static int max_map_data_size;
     static int default_map_size;
     static int max_object_events;
-
-    QStringListModel eventScriptLabelModel;
-    QCompleter eventScriptLabelCompleter;
 
 signals:
     void reloadProject();

--- a/include/ui/eventframes.h
+++ b/include/ui/eventframes.h
@@ -31,6 +31,8 @@ public:
     void invalidateUi();
     void invalidateValues();
 
+    void populateScriptDropdown(NoScrollComboBox * combo, Project * project);
+
     virtual void setActive(bool active);
 
 public:
@@ -87,8 +89,6 @@ public:
 
 private:
     ObjectEvent *object;
-
-    QCompleter *scriptCompleter = nullptr;
 };
 
 
@@ -158,8 +158,6 @@ public:
 
 private:
     TriggerEvent *trigger;
-
-    QCompleter *scriptCompleter = nullptr;
 };
 
 
@@ -203,8 +201,6 @@ public:
 
 private:
     SignEvent *sign;
-
-    QCompleter *scriptCompleter = nullptr;
 };
 
 

--- a/src/core/map.cpp
+++ b/src/core/map.cpp
@@ -483,6 +483,7 @@ QStringList Map::getScriptLabels(Event::Group group) const {
 
     // Add scripts from map's scripts file, and empty names.
     scriptLabels.append(scriptsFileLabels);
+    scriptLabels.sort(Qt::CaseInsensitive);
     scriptLabels.prepend("0x0");
     scriptLabels.prepend("NULL");
 

--- a/src/project.cpp
+++ b/src/project.cpp
@@ -35,9 +35,7 @@ int Project::default_map_size = 20;
 int Project::max_object_events = 64;
 
 Project::Project(QWidget *parent) :
-    QObject(parent),
-    eventScriptLabelModel(this),
-    eventScriptLabelCompleter(this)
+    QObject(parent)
 {
     initSignals();
 }
@@ -2406,18 +2404,13 @@ bool Project::readMiscellaneousConstants() {
     return true;
 }
 
-QStringList Project::getGlobalScriptLabels() {
-    return this->eventScriptLabelModel.stringList();
-}
-
 bool Project::readEventScriptLabels() {
+    globalScriptLabels.clear();
     for (const auto &filePath : getEventScriptsFilePaths())
         globalScriptLabels << ParseUtil::getGlobalScriptLabels(filePath);
 
-    eventScriptLabelModel.setStringList(globalScriptLabels);
-    eventScriptLabelCompleter.setModel(&eventScriptLabelModel);
-    eventScriptLabelCompleter.setCaseSensitivity(Qt::CaseInsensitive);
-    eventScriptLabelCompleter.setFilterMode(Qt::MatchContains);
+    globalScriptLabels.sort(Qt::CaseInsensitive);
+    globalScriptLabels.removeDuplicates();
 
     return true;
 }
@@ -2476,13 +2469,6 @@ QStringList Project::getEventScriptsFilePaths() const {
         filePaths << it_inc_maps.next();
 
     return filePaths;
-}
-
-QCompleter *Project::getEventScriptLabelCompleter(QStringList additionalScriptLabels) {
-    additionalScriptLabels << globalScriptLabels;
-    additionalScriptLabels.removeDuplicates();
-    eventScriptLabelModel.setStringList(additionalScriptLabels);
-    return &eventScriptLabelCompleter;
 }
 
 void Project::setEventPixmap(Event *event, bool forceLoad) {

--- a/src/ui/eventframes.cpp
+++ b/src/ui/eventframes.cpp
@@ -168,6 +168,23 @@ void EventFrame::setActive(bool active) {
     this->blockSignals(!active);
 }
 
+void EventFrame::populateScriptDropdown(NoScrollComboBox * combo, Project * project) {
+    // The script dropdown is populated with scripts used by the map's events and from its scripts file.
+    if (this->event->getMap())
+        combo->addItems(this->event->getMap()->getScriptLabels());
+
+    // The dropdown's autocomplete has all script labels across the full project.
+    auto completer = new QCompleter(project->globalScriptLabels, combo);
+    completer->setCaseSensitivity(Qt::CaseInsensitive);
+    completer->setModelSorting(QCompleter::CaseInsensitivelySortedModel);
+    completer->setFilterMode(Qt::MatchContains);
+
+    // Improve display speed for the autocomplete popup
+    auto popup = (QListView *)completer->popup();
+    if (popup) popup->setUniformItemSizes(true);
+
+    combo->setCompleter(completer);
+}
 
 
 void ObjectFrame::setup() {
@@ -367,20 +384,7 @@ void ObjectFrame::populate(Project *project) {
     this->combo_flag->addItems(project->flagNames);
     this->combo_trainer_type->addItems(project->trainerTypes);
 
-    // The script dropdown is populated with scripts used by the map's events and from its scripts file.
-    QStringList scriptLabels;
-    if (this->object->getMap()) {
-        scriptLabels.append(this->object->getMap()->getScriptLabels());
-        this->combo_script->addItems(scriptLabels);
-    }
-
-    // The dropdown's autocomplete has all script labels across the full project.
-    scriptLabels.append(project->getGlobalScriptLabels());
-    scriptLabels.removeDuplicates();
-    this->scriptCompleter = new QCompleter(scriptLabels, this);
-    this->scriptCompleter->setCaseSensitivity(Qt::CaseInsensitive);
-    this->scriptCompleter->setFilterMode(Qt::MatchContains);
-    this->combo_script->setCompleter(this->scriptCompleter);
+    this->populateScriptDropdown(this->combo_script, project);
 }
 
 
@@ -637,20 +641,7 @@ void TriggerFrame::populate(Project *project) {
     // var combo
     this->combo_var->addItems(project->varNames);
 
-    // The script dropdown is populated with scripts used by the map's events and from its scripts file.
-    QStringList scriptLabels;
-    if (this->trigger->getMap()) {
-        scriptLabels.append(this->trigger->getMap()->getScriptLabels());
-        this->combo_script->addItems(scriptLabels);
-    }
-
-    // The dropdown's autocomplete has all script labels across the full project.
-    scriptLabels.append(project->getGlobalScriptLabels());
-    scriptLabels.removeDuplicates();
-    this->scriptCompleter = new QCompleter(scriptLabels, this);
-    this->scriptCompleter->setCaseSensitivity(Qt::CaseInsensitive);
-    this->scriptCompleter->setFilterMode(Qt::MatchContains);
-    this->combo_script->setCompleter(this->scriptCompleter);
+    this->populateScriptDropdown(this->combo_script, project);
 }
 
 
@@ -772,20 +763,7 @@ void SignFrame::populate(Project *project) {
     // facing dir
     this->combo_facing_dir->addItems(project->bgEventFacingDirections);
 
-    // The script dropdown is populated with scripts used by the map's events and from its scripts file.
-    QStringList scriptLabels;
-    if (this->sign->getMap()) {
-        scriptLabels.append(this->sign->getMap()->getScriptLabels());
-        this->combo_script->addItems(scriptLabels);
-    }
-
-    // The dropdown's autocomplete has all script labels across the full project.
-    scriptLabels.append(project->getGlobalScriptLabels());
-    scriptLabels.removeDuplicates();
-    this->scriptCompleter = new QCompleter(scriptLabels, this);
-    this->scriptCompleter->setCaseSensitivity(Qt::CaseInsensitive);
-    this->scriptCompleter->setFilterMode(Qt::MatchContains);
-    this->combo_script->setCompleter(this->scriptCompleter);
+    this->populateScriptDropdown(this->combo_script, project);
 }
 
 


### PR DESCRIPTION
- Fix an issue where deleted script labels could still appear in the autocomplete after project reload
- Noticeable improvements to the script autocomplete's speed (see gifs)
- Sort script labels alphabetically to make them easier to find (theoretically this also improves the autocomplete speed, but that change alone wasn't noticeable)
- Remove a bunch of dead code for the completer from before the event handling rewrite

Before:
![dropdown-slow](https://github.com/huderlem/porymap/assets/25753467/c5ea923b-c291-4bd7-9425-442e36e6b453)

After:
![dropdown-fast](https://github.com/huderlem/porymap/assets/25753467/660b43e9-aa81-42db-8c6a-e8219fbe8813)

