### PR TITLE
Stop changing settings if their features fail to load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project somewhat adheres to [Semantic Versioning](https://semver.org/sp
 The **"Breaking Changes"** listed below are changes that have been made in the decompilation projects (e.g. pokeemerald), which porymap requires in order to work properly. It also includes changes to the scripting API that may change the behavior of existing porymap scripts. If porymap is used with a project or API script that is not up-to-date with the breaking changes, then porymap will likely break or behave improperly.
 
 ## [Unreleased]
+### Changed
+- If settings-specific features like Wild Encounters fail to load they are now only disabled for that session
+
 ### Fixed
 - Fix the Tileset Editor selectors scrolling to the wrong selection when zoomed
 - Fix the Tileset Editor selectors getting extra white space when changing tilesets

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,13 @@ The **"Breaking Changes"** listed below are changes that have been made in the d
 
 ## [Unreleased]
 ### Changed
-- If settings-specific features like Wild Encounters fail to load they are now only disabled for that session
+- If Wild Encounters fail to load they are now only disabled for that session, and the settings remain unchanged.
+- Defaults are used if project constants are missing, rather than failing to open the project or changing settings.
 
 ### Fixed
-- Fix the Tileset Editor selectors scrolling to the wrong selection when zoomed
-- Fix the Tileset Editor selectors getting extra white space when changing tilesets
+- Fix the Tileset Editor selectors scrolling to the wrong selection when zoomed.
+- Fix the Tileset Editor selectors getting extra white space when changing tilesets.
+- Fix a crash when adding disabled events with the Pencil tool.
 
 ## [5.3.0] - 2024-01-15
 ### Added

--- a/include/mainwindow.h
+++ b/include/mainwindow.h
@@ -373,7 +373,6 @@ private:
     void initShortcuts();
     void initExtraShortcuts();
     void setProjectSpecificUI();
-    void setWildEncountersUIEnabled(bool enabled);
     void loadUserSettings();
     void applyMapListFilter(QString filterText);
     void restoreWindowState();

--- a/include/project.h
+++ b/include/project.h
@@ -54,6 +54,7 @@ public:
     QMap<int, QString> mapSectionValueToName;
     QMap<QString, EventGraphics*> eventGraphicsMap;
     QMap<QString, int> gfxDefines;
+    QString defaultSong;
     QStringList songNames;
     QStringList itemNames;
     QStringList flagNames;

--- a/include/project.h
+++ b/include/project.h
@@ -78,8 +78,6 @@ public:
     bool usingAsmTilesets;
     QString importExportPath;
     QSet<QString> disabledSettingsNames;
-    bool weatherEventConstantsLoaded;
-    bool secretBaseConstantsLoaded;
     bool wildEncountersLoaded;
 
     void set_root(QString);
@@ -165,8 +163,6 @@ public:
     void saveTilesetMetatiles(Tileset*);
     void saveTilesetTilesImage(Tileset*);
     void saveTilesetPalettes(Tileset*);
-
-    QString defaultSong;
     void appendTilesetLabel(QString label, QString isSecondaryStr);
     bool readTilesetLabels();
     bool readTilesetMetatileLabels();

--- a/include/project.h
+++ b/include/project.h
@@ -78,6 +78,9 @@ public:
     bool usingAsmTilesets;
     QString importExportPath;
     QSet<QString> disabledSettingsNames;
+    bool weatherEventConstantsLoaded;
+    bool secretBaseConstantsLoaded;
+    bool wildEncountersLoaded;
 
     void set_root(QString);
 
@@ -253,7 +256,6 @@ signals:
     void reloadProject();
     void uncheckMonitorFilesAction();
     void mapCacheCleared();
-    void disableWildEncountersUI();
 };
 
 #endif // PROJECT_H

--- a/src/core/events.cpp
+++ b/src/core/events.cpp
@@ -233,8 +233,8 @@ bool ObjectEvent::loadFromJson(QJsonObject json, Project *) {
 }
 
 void ObjectEvent::setDefaultValues(Project *project) {
-    this->setGfx(project->gfxDefines.keys().first());
-    this->setMovement(project->movementTypes.first());
+    this->setGfx(project->gfxDefines.keys().value(0, "0"));
+    this->setMovement(project->movementTypes.value(0, "0"));
     this->setScript("NULL");
     this->setTrainerType(project->trainerTypes.value(0, "0"));
     this->setFlag("0");
@@ -404,7 +404,7 @@ bool CloneObjectEvent::loadFromJson(QJsonObject json, Project *project) {
 }
 
 void CloneObjectEvent::setDefaultValues(Project *project) {
-    this->setGfx(project->gfxDefines.keys().first());
+    this->setGfx(project->gfxDefines.keys().value(0, "0"));
     this->setTargetID(1);
     if (this->getMap()) this->setTargetMap(this->getMap()->name);
 }
@@ -436,8 +436,8 @@ void CloneObjectEvent::loadPixmap(Project *project) {
         this->movement = clonedObject->getMovement();
     } else {
         // Invalid object specified, use default graphics data (as would be shown in-game)
-        this->gfx = project->gfxDefines.key(0);
-        this->movement = project->movementTypes.first();
+        this->gfx = project->gfxDefines.key(0, "0");
+        this->movement = project->movementTypes.value(0, "0");
     }
 
     EventGraphics *eventGfx = project->eventGraphicsMap.value(gfx, nullptr);
@@ -596,7 +596,7 @@ bool TriggerEvent::loadFromJson(QJsonObject json, Project *) {
 
 void TriggerEvent::setDefaultValues(Project *project) {
     this->setScriptLabel("NULL");
-    this->setScriptVar(project->varNames.first());
+    this->setScriptVar(project->varNames.value(0, "0"));
     this->setScriptVarValue("0");
     this->setElevation(0);
 }
@@ -665,7 +665,7 @@ bool WeatherTriggerEvent::loadFromJson(QJsonObject json, Project *) {
 }
 
 void WeatherTriggerEvent::setDefaultValues(Project *project) {
-    this->setWeather(project->coordEventWeatherNames.first());
+    this->setWeather(project->coordEventWeatherNames.value(0, "0"));
     this->setElevation(0);
 }
 
@@ -734,7 +734,7 @@ bool SignEvent::loadFromJson(QJsonObject json, Project *) {
 }
 
 void SignEvent::setDefaultValues(Project *project) {
-    this->setFacingDirection(project->bgEventFacingDirections.first());
+    this->setFacingDirection(project->bgEventFacingDirections.value(0, "0"));
     this->setScriptLabel("NULL");
     this->setElevation(0);
 }
@@ -819,8 +819,8 @@ bool HiddenItemEvent::loadFromJson(QJsonObject json, Project *) {
 }
 
 void HiddenItemEvent::setDefaultValues(Project *project) {
-    this->setItem(project->itemNames.first());
-    this->setFlag(project->flagNames.first());
+    this->setItem(project->itemNames.value(0, "0"));
+    this->setFlag(project->flagNames.value(0, "0"));
     if (projectConfig.getHiddenItemQuantityEnabled()) {
         this->setQuantity(1);
     }
@@ -898,7 +898,7 @@ bool SecretBaseEvent::loadFromJson(QJsonObject json, Project *) {
 }
 
 void SecretBaseEvent::setDefaultValues(Project *project) {
-    this->setBaseID(project->secretBaseIds.first());
+    this->setBaseID(project->secretBaseIds.value(0, "0"));
     this->setElevation(0);
 }
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -361,14 +361,12 @@ void MainWindow::markMapEdited() {
     }
 }
 
-void MainWindow::setWildEncountersUIEnabled(bool enabled) {
-    ui->mainTabBar->setTabEnabled(4, enabled);
-}
-
 // Update the UI using information we've read from the user's project files.
 void MainWindow::setProjectSpecificUI()
 {
-    this->setWildEncountersUIEnabled(userConfig.getEncounterJsonActive());
+    // Wild Encounters tab
+    // TODO: This index should come from an enum
+    ui->mainTabBar->setTabEnabled(4, editor->project->wildEncountersLoaded);
 
     bool hasFlags = projectConfig.getMapAllowFlagsEnabled();
     ui->checkBox_AllowRunning->setVisible(hasFlags);
@@ -378,8 +376,8 @@ void MainWindow::setProjectSpecificUI()
     ui->label_AllowBiking->setVisible(hasFlags);
     ui->label_AllowEscaping->setVisible(hasFlags);
 
-    ui->newEventToolButton->newWeatherTriggerAction->setVisible(projectConfig.getEventWeatherTriggerEnabled());
-    ui->newEventToolButton->newSecretBaseAction->setVisible(projectConfig.getEventSecretBaseEnabled());
+    ui->newEventToolButton->newWeatherTriggerAction->setVisible(editor->project->weatherEventConstantsLoaded);
+    ui->newEventToolButton->newSecretBaseAction->setVisible(editor->project->secretBaseConstantsLoaded);
     ui->newEventToolButton->newCloneObjectAction->setVisible(projectConfig.getEventCloneObjectEnabled());
 
     bool floorNumEnabled = projectConfig.getFloorNumberEnabled();
@@ -520,7 +518,6 @@ bool MainWindow::openProject(const QString &dir, bool initial) {
         editor->project = new Project(this);
         QObject::connect(editor->project, &Project::reloadProject, this, &MainWindow::on_action_Reload_Project_triggered);
         QObject::connect(editor->project, &Project::mapCacheCleared, this, &MainWindow::onMapCacheCleared);
-        QObject::connect(editor->project, &Project::disableWildEncountersUI, [this]() { this->setWildEncountersUIEnabled(false); });
         QObject::connect(editor->project, &Project::uncheckMonitorFilesAction, [this]() {
             porymapConfig.setMonitorFiles(false);
             if (this->preferenceEditor)
@@ -1767,7 +1764,7 @@ void MainWindow::on_mainTabBar_tabBarClicked(int index)
         editor->setEditingConnections();
     }
     if (index != 4) {
-        if (userConfig.getEncounterJsonActive())
+        if (editor->project && editor->project->wildEncountersLoaded)
             editor->saveEncounterTabData();
     }
     if (index != 1) {

--- a/src/project.cpp
+++ b/src/project.cpp
@@ -2339,6 +2339,8 @@ bool Project::readSongNames() {
         logWarn(QString("Failed to read song names from %1.").arg(filename));
 
     // Song names don't have a very useful order (esp. if we include SE_* values), so sort them alphabetically.
+    // The default song should be the first in the list, not the first alphabetically, so save that before sorting.
+    this->defaultSong = this->songNames.value(0, "0");
     this->songNames.sort();
     return true;
 }

--- a/src/scriptapi/apiutility.cpp
+++ b/src/scriptapi/apiutility.cpp
@@ -141,8 +141,8 @@ int ScriptUtility::getMainTab() {
 void ScriptUtility::setMainTab(int index) {
     if (!window || !window->ui || !window->ui->mainTabBar || index < 0 || index >= window->ui->mainTabBar->count())
         return;
-    // Can't select Wild Encounters tab if it's disabled
-    if (index == 4 && !userConfig.getEncounterJsonActive())
+    // Can't select tab if it's disabled
+    if (!window->ui->mainTabBar->isTabEnabled(index))
         return;
     window->on_mainTabBar_tabBarClicked(index);
 }

--- a/src/ui/newmappopup.cpp
+++ b/src/ui/newmappopup.cpp
@@ -175,7 +175,7 @@ void NewMapPopup::setDefaultSettings(Project *project) {
     settings.secondaryTilesetLabel = project->getDefaultSecondaryTilesetLabel();
     settings.type = project->mapTypes.value(0, "0");
     settings.location = project->mapSectionNameToValue.keys().value(0, "0");
-    settings.song = project->songNames.value(0, "0");
+    settings.song = project->defaultSong;
     settings.canFlyTo = false;
     settings.showLocationName = true;
     settings.allowRunning = false;

--- a/src/ui/newmappopup.cpp
+++ b/src/ui/newmappopup.cpp
@@ -33,7 +33,7 @@ void NewMapPopup::init() {
     ui->comboBox_NewMap_Group->addItems(project->groupNames);
     ui->comboBox_NewMap_Song->addItems(project->songNames);
     ui->comboBox_NewMap_Type->addItems(project->mapTypes);
-    ui->comboBox_NewMap_Location->addItems(project->mapSectionValueToName.values());
+    ui->comboBox_NewMap_Location->addItems(project->mapSectionNameToValue.keys());
 
     // Set spin box limits
     ui->spinBox_NewMap_Width->setMinimum(1);
@@ -173,9 +173,9 @@ void NewMapPopup::setDefaultSettings(Project *project) {
     settings.borderHeight = DEFAULT_BORDER_HEIGHT;
     settings.primaryTilesetLabel = project->getDefaultPrimaryTilesetLabel();
     settings.secondaryTilesetLabel = project->getDefaultSecondaryTilesetLabel();
-    settings.type = project->mapTypes.at(0);
-    settings.location = project->mapSectionValueToName.values().at(0);
-    settings.song = project->defaultSong;
+    settings.type = project->mapTypes.value(0, "0");
+    settings.location = project->mapSectionNameToValue.keys().value(0, "0");
+    settings.song = project->songNames.value(0, "0");
     settings.canFlyTo = false;
     settings.showLocationName = true;
     settings.allowRunning = false;
@@ -258,9 +258,9 @@ void NewMapPopup::on_pushButton_NewMap_Accept_clicked() {
     newMap->location = this->ui->comboBox_NewMap_Location->currentText();
     newMap->song = this->ui->comboBox_NewMap_Song->currentText();
     newMap->requiresFlash = false;
-    newMap->weather = this->project->weatherNames.value(0);
+    newMap->weather = this->project->weatherNames.value(0, "0");
     newMap->show_location = this->ui->checkBox_NewMap_Show_Location->isChecked();
-    newMap->battle_scene = this->project->mapBattleScenes.value(0);
+    newMap->battle_scene = this->project->mapBattleScenes.value(0, "0");
 
     if (this->existingLayout) {
         layout = this->project->mapLayouts.value(this->layoutId);


### PR DESCRIPTION
The settings for enabling Wild Encounters, Weather Trigger Events, and Secret Base Events may be changed if something they rely on fails to load. This can be confusing as users might not realize Porymap automatically changed their settings, and the feature won't resume working once the problem is resolved.

Now these features are only disabled for the session in which they failed to load.