### PR TITLE
Misc fixes for selection images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The **"Breaking Changes"** listed below are changes that have been made in the d
 
 ### Fixed
 - Fix some minor visual issues with the various zoom sliders.
+- Smooth out scrolling when mouse is over tile/metatile images.
 - Fix the Tileset Editor selectors getting extra white space when changing tilesets.
 - Fix a crash when adding disabled events with the Pencil tool.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,10 @@ The **"Breaking Changes"** listed below are changes that have been made in the d
 ### Changed
 - If Wild Encounters fail to load they are now only disabled for that session, and the settings remain unchanged.
 - Defaults are used if project constants are missing, rather than failing to open the project or changing settings.
+- Selector images now center on the selection when eyedropping or zooming.
 
 ### Fixed
-- Fix the Tileset Editor selectors scrolling to the wrong selection when zoomed.
+- Fix some minor visual issues with the various zoom sliders.
 - Fix the Tileset Editor selectors getting extra white space when changing tilesets.
 - Fix a crash when adding disabled events with the Pencil tool.
 

--- a/forms/mainwindow.ui
+++ b/forms/mainwindow.ui
@@ -764,7 +764,7 @@
                               <property name="widgetResizable">
                                <bool>true</bool>
                               </property>
-                              <widget class="QWidget" name="scrollAreaWidgetContents_3">
+                              <widget class="QWidget" name="scrollAreaWidgetContents_BorderMetatiles">
                                <property name="geometry">
                                 <rect>
                                  <x>0</x>
@@ -883,7 +883,7 @@
                               <property name="widgetResizable">
                                <bool>true</bool>
                               </property>
-                              <widget class="QWidget" name="scrollAreaWidgetContents_6">
+                              <widget class="QWidget" name="scrollAreaWidgetContents_SelectedMetatiles">
                                <property name="geometry">
                                 <rect>
                                  <x>0</x>
@@ -984,7 +984,7 @@
                            <property name="alignment">
                             <set>Qt::AlignHCenter|Qt::AlignTop</set>
                            </property>
-                           <widget class="QWidget" name="scrollAreaWidgetContents_2">
+                           <widget class="QWidget" name="scrollAreaWidgetContents_MetatileSelector">
                             <property name="enabled">
                              <bool>true</bool>
                             </property>
@@ -1184,11 +1184,11 @@
                       </widget>
                      </item>
                      <item row="5" column="0" colspan="3">
-                      <widget class="QScrollArea" name="scrollArea_1">
+                      <widget class="QScrollArea" name="scrollArea_Collision">
                        <property name="widgetResizable">
                         <bool>true</bool>
                        </property>
-                       <widget class="QWidget" name="scrollAreaWidgetContents">
+                       <widget class="QWidget" name="scrollAreaWidgetContents_Collision">
                         <property name="geometry">
                          <rect>
                           <x>0</x>

--- a/forms/mainwindow.ui
+++ b/forms/mainwindow.ui
@@ -803,7 +803,7 @@
                                  </spacer>
                                 </item>
                                 <item>
-                                 <widget class="QGraphicsView" name="graphicsView_BorderMetatile">
+                                 <widget class="NoScrollGraphicsView" name="graphicsView_BorderMetatile">
                                   <property name="sizePolicy">
                                    <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
                                     <horstretch>0</horstretch>
@@ -922,7 +922,7 @@
                                  </spacer>
                                 </item>
                                 <item>
-                                 <widget class="QGraphicsView" name="graphicsView_currentMetatileSelection">
+                                 <widget class="NoScrollGraphicsView" name="graphicsView_currentMetatileSelection">
                                   <property name="sizePolicy">
                                    <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
                                     <horstretch>0</horstretch>
@@ -1032,7 +1032,7 @@
                               </spacer>
                              </item>
                              <item row="0" column="1">
-                              <widget class="QGraphicsView" name="graphicsView_Metatiles">
+                              <widget class="NoScrollGraphicsView" name="graphicsView_Metatiles">
                                <property name="enabled">
                                 <bool>true</bool>
                                </property>
@@ -1227,7 +1227,7 @@
                           </spacer>
                          </item>
                          <item row="2" column="1">
-                          <widget class="QGraphicsView" name="graphicsView_Collision">
+                          <widget class="NoScrollGraphicsView" name="graphicsView_Collision">
                            <property name="sizePolicy">
                             <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
                              <horstretch>0</horstretch>
@@ -3433,6 +3433,11 @@
   <customwidget>
    <class>MapView</class>
    <extends>QWidget</extends>
+   <header>mapview.h</header>
+  </customwidget>
+  <customwidget>
+   <class>NoScrollGraphicsView</class>
+   <extends>QGraphicsView</extends>
    <header>mapview.h</header>
   </customwidget>
  </customwidgets>

--- a/forms/tileseteditor.ui
+++ b/forms/tileseteditor.ui
@@ -86,7 +86,7 @@
              <number>6</number>
             </property>
             <item row="0" column="0">
-             <widget class="QGraphicsView" name="graphicsView_Metatiles">
+             <widget class="NoScrollGraphicsView" name="graphicsView_Metatiles">
               <property name="verticalScrollBarPolicy">
                <enum>Qt::ScrollBarAlwaysOff</enum>
               </property>
@@ -560,7 +560,7 @@
              <number>0</number>
             </property>
             <item row="0" column="0">
-             <widget class="QGraphicsView" name="graphicsView_Tiles">
+             <widget class="NoScrollGraphicsView" name="graphicsView_Tiles">
               <property name="verticalScrollBarPolicy">
                <enum>Qt::ScrollBarAlwaysOff</enum>
               </property>
@@ -805,6 +805,11 @@
    <class>NoScrollComboBox</class>
    <extends>QComboBox</extends>
    <header>noscrollcombobox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>NoScrollGraphicsView</class>
+   <extends>QGraphicsView</extends>
+   <header>mapview.h</header>
   </customwidget>
  </customwidgets>
  <resources>

--- a/forms/tileseteditor.ui
+++ b/forms/tileseteditor.ui
@@ -58,9 +58,9 @@
            <bool>true</bool>
           </property>
           <property name="alignment">
-           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+           <set>Qt::AlignHCenter|Qt::AlignTop</set>
           </property>
-          <widget class="QWidget" name="scrollAreaWidgetContents_2">
+          <widget class="QWidget" name="scrollAreaWidgetContents_Metatiles">
            <property name="geometry">
             <rect>
              <x>0</x>
@@ -85,20 +85,7 @@
             <property name="horizontalSpacing">
              <number>6</number>
             </property>
-            <item row="1" column="1">
-             <spacer name="verticalSpacer">
-              <property name="orientation">
-               <enum>Qt::Vertical</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>20</width>
-                <height>40</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-            <item row="0" column="1">
+            <item row="0" column="0">
              <widget class="QGraphicsView" name="graphicsView_Metatiles">
               <property name="verticalScrollBarPolicy">
                <enum>Qt::ScrollBarAlwaysOff</enum>
@@ -108,28 +95,15 @@
               </property>
              </widget>
             </item>
-            <item row="0" column="0">
-             <spacer name="horizontalSpacer_2">
+            <item row="1" column="0">
+             <spacer name="verticalSpacer">
               <property name="orientation">
-               <enum>Qt::Horizontal</enum>
+               <enum>Qt::Vertical</enum>
               </property>
               <property name="sizeHint" stdset="0">
                <size>
-                <width>40</width>
-                <height>20</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-            <item row="0" column="2">
-             <spacer name="horizontalSpacer">
-              <property name="orientation">
-               <enum>Qt::Horizontal</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>40</width>
-                <height>20</height>
+                <width>20</width>
+                <height>40</height>
                </size>
               </property>
              </spacer>
@@ -561,9 +535,9 @@
            <bool>true</bool>
           </property>
           <property name="alignment">
-           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+           <set>Qt::AlignHCenter|Qt::AlignTop</set>
           </property>
-          <widget class="QWidget" name="scrollAreaWidgetContents">
+          <widget class="QWidget" name="scrollAreaWidgetContents_Tiles">
            <property name="geometry">
             <rect>
              <x>0</x>
@@ -585,20 +559,7 @@
             <property name="bottomMargin">
              <number>0</number>
             </property>
-            <item row="0" column="2">
-             <spacer name="horizontalSpacer_4">
-              <property name="orientation">
-               <enum>Qt::Horizontal</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>40</width>
-                <height>20</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-            <item row="0" column="1">
+            <item row="0" column="0">
              <widget class="QGraphicsView" name="graphicsView_Tiles">
               <property name="verticalScrollBarPolicy">
                <enum>Qt::ScrollBarAlwaysOff</enum>
@@ -608,8 +569,8 @@
               </property>
              </widget>
             </item>
-            <item row="1" column="1">
-             <spacer name="verticalSpacer_4">
+            <item row="1" column="0">
+             <spacer name="verticalSpacer_2">
               <property name="orientation">
                <enum>Qt::Vertical</enum>
               </property>
@@ -617,19 +578,6 @@
                <size>
                 <width>20</width>
                 <height>40</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-            <item row="0" column="0">
-             <spacer name="horizontalSpacer_3">
-              <property name="orientation">
-               <enum>Qt::Horizontal</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>40</width>
-                <height>20</height>
                </size>
               </property>
              </spacer>

--- a/include/mainwindow.h
+++ b/include/mainwindow.h
@@ -390,7 +390,9 @@ private:
     void openProjectSettingsEditor(int tab);
     bool isProjectOpen();
     void showExportMapImageWindow(ImageExporterMode mode);
+    double getMetatilesZoomScale();
     void redrawMetatileSelection();
+    void scrollMetatileSelectorToSelection();
 
     QObjectList shortcutableObjects() const;
     void addCustomHeaderValue(QString key, QJsonValue value, bool isNew = false);

--- a/include/ui/graphicsview.h
+++ b/include/ui/graphicsview.h
@@ -4,12 +4,23 @@
 #include <QGraphicsView>
 #include <QMouseEvent>
 
-class ClickableGraphicsView : public QGraphicsView
+class NoScrollGraphicsView : public QGraphicsView
 {
     Q_OBJECT
 public:
-    ClickableGraphicsView() : QGraphicsView() {}
-    ClickableGraphicsView(QWidget *parent) : QGraphicsView(parent) {}
+    NoScrollGraphicsView(QWidget *parent = nullptr) : QGraphicsView(parent) {}
+
+protected:
+    void wheelEvent(QWheelEvent *event) {
+        event->ignore();
+    }
+};
+
+class ClickableGraphicsView : public NoScrollGraphicsView
+{
+    Q_OBJECT
+public:
+    ClickableGraphicsView(QWidget *parent = nullptr) : NoScrollGraphicsView(parent) {}
 
 public:
     void mouseReleaseEvent(QMouseEvent *event) override {

--- a/include/ui/metatileselector.h
+++ b/include/ui/metatileselector.h
@@ -45,13 +45,14 @@ public:
     QPoint getSelectionDimensions();
     void draw();
     bool select(uint16_t metatile);
-    bool selectFromMap(uint16_t metatileId, uint16_t collision, uint16_t elevation);
+    void selectFromMap(uint16_t metatileId, uint16_t collision, uint16_t elevation);
     void setTilesets(Tileset*, Tileset*);
     MetatileSelection getMetatileSelection();
     void setPrefabSelection(MetatileSelection selection);
     void setExternalSelection(int, int, QList<uint16_t>, QList<QPair<uint16_t, uint16_t>>);
     QPoint getMetatileIdCoordsOnWidget(uint16_t);
     void setMap(Map*);
+    bool isInternalSelection() const { return (!this->externalSelection && !this->prefabSelection); }
     Tileset *primaryTileset;
     Tileset *secondaryTileset;
 protected:

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1398,7 +1398,6 @@ void MainWindow::scrollMetatileSelectorToSelection() {
     pos += QPoint(size.x() - 1, size.y() - 1) * 16 / 2; // We want to focus on the center of the whole selection
     pos *= getMetatilesZoomScale();
 
-    // TODO: This snaps focus to the position if it's out of view. It should scroll slowly toward this target instead
     auto viewport = ui->scrollArea_MetatileSelector->viewport();
     ui->scrollArea_MetatileSelector->ensureVisible(pos.x(), pos.y(), viewport->width() / 2, viewport->height() / 2);
 }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -734,10 +734,10 @@ void MainWindow::refreshMapScene()
     ui->graphicsView_Metatiles->setFixedSize(editor->metatile_selector_item->pixmap().width() + 2, editor->metatile_selector_item->pixmap().height() + 2);
 
     ui->graphicsView_BorderMetatile->setScene(editor->scene_selected_border_metatiles);
-    ui->graphicsView_BorderMetatile->setFixedSize(editor->selected_border_metatiles_item->pixmap().width() + 2, editor->selected_border_metatiles_item->pixmap().height() + 2);
+    ui->graphicsView_BorderMetatile->setFixedSize(editor->selected_border_metatiles_item->pixmap().width(), editor->selected_border_metatiles_item->pixmap().height());
 
     ui->graphicsView_currentMetatileSelection->setScene(editor->scene_current_metatile_selection);
-    ui->graphicsView_currentMetatileSelection->setFixedSize(editor->current_metatile_selection_item->pixmap().width() + 2, editor->current_metatile_selection_item->pixmap().height() + 2);
+    ui->graphicsView_currentMetatileSelection->setFixedSize(editor->current_metatile_selection_item->pixmap().width(), editor->current_metatile_selection_item->pixmap().height());
 
     ui->graphicsView_Collision->setScene(editor->scene_collision_metatiles);
     //ui->graphicsView_Collision->setSceneRect(editor->scene_collision_metatiles->sceneRect());
@@ -1373,7 +1373,8 @@ void MainWindow::redrawMetatileSelection()
     transform.scale(scale, scale);
 
     ui->graphicsView_currentMetatileSelection->setTransform(transform);
-    ui->graphicsView_currentMetatileSelection->setFixedSize(editor->current_metatile_selection_item->pixmap().width() * scale + 2, editor->current_metatile_selection_item->pixmap().height() * scale + 2);
+    ui->graphicsView_currentMetatileSelection->setFixedSize(editor->current_metatile_selection_item->pixmap().width() * scale, editor->current_metatile_selection_item->pixmap().height() * scale);
+    ui->scrollAreaWidgetContents_SelectedMetatiles->adjustSize();
 
     QPoint size = editor->metatile_selector_item->getSelectionDimensions();
     if (size.x() == 1 && size.y() == 1) {
@@ -2828,8 +2829,11 @@ void MainWindow::on_horizontalSlider_MetatileZoom_valueChanged(int value) {
     ui->graphicsView_Metatiles->setFixedSize(size.width() + 2, size.height() + 2);
 
     ui->graphicsView_BorderMetatile->setTransform(transform);
-    ui->graphicsView_BorderMetatile->setFixedSize(ceil(static_cast<double>(editor->selected_border_metatiles_item->pixmap().width()) * scale) + 2,
-                                                  ceil(static_cast<double>(editor->selected_border_metatiles_item->pixmap().height()) * scale) + 2);
+    ui->graphicsView_BorderMetatile->setFixedSize(ceil(static_cast<double>(editor->selected_border_metatiles_item->pixmap().width()) * scale),
+                                                  ceil(static_cast<double>(editor->selected_border_metatiles_item->pixmap().height()) * scale));
+
+    ui->scrollAreaWidgetContents_MetatileSelector->adjustSize();
+    ui->scrollAreaWidgetContents_BorderMetatiles->adjustSize();
 
     redrawMetatileSelection();
 }
@@ -2847,6 +2851,7 @@ void MainWindow::on_horizontalSlider_CollisionZoom_valueChanged(int value) {
     ui->graphicsView_Collision->setResizeAnchor(QGraphicsView::NoAnchor);
     ui->graphicsView_Collision->setTransform(transform);
     ui->graphicsView_Collision->setFixedSize(size.width() + 2, size.height() + 2);
+    ui->scrollAreaWidgetContents_Collision->adjustSize();
 }
 
 void MainWindow::on_spinBox_SelectedCollision_valueChanged(int collision) {

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -734,10 +734,10 @@ void MainWindow::refreshMapScene()
     ui->graphicsView_Metatiles->setFixedSize(editor->metatile_selector_item->pixmap().width() + 2, editor->metatile_selector_item->pixmap().height() + 2);
 
     ui->graphicsView_BorderMetatile->setScene(editor->scene_selected_border_metatiles);
-    ui->graphicsView_BorderMetatile->setFixedSize(editor->selected_border_metatiles_item->pixmap().width(), editor->selected_border_metatiles_item->pixmap().height());
+    ui->graphicsView_BorderMetatile->setFixedSize(editor->selected_border_metatiles_item->pixmap().width() + 2, editor->selected_border_metatiles_item->pixmap().height() + 2);
 
     ui->graphicsView_currentMetatileSelection->setScene(editor->scene_current_metatile_selection);
-    ui->graphicsView_currentMetatileSelection->setFixedSize(editor->current_metatile_selection_item->pixmap().width(), editor->current_metatile_selection_item->pixmap().height());
+    ui->graphicsView_currentMetatileSelection->setFixedSize(editor->current_metatile_selection_item->pixmap().width() + 2, editor->current_metatile_selection_item->pixmap().height() + 2);
 
     ui->graphicsView_Collision->setScene(editor->scene_collision_metatiles);
     //ui->graphicsView_Collision->setSceneRect(editor->scene_collision_metatiles->sceneRect());
@@ -1371,12 +1371,16 @@ double MainWindow::getMetatilesZoomScale() {
 }
 
 void MainWindow::redrawMetatileSelection() {
+    QSize size(editor->current_metatile_selection_item->pixmap().width(), editor->current_metatile_selection_item->pixmap().height());
+    ui->graphicsView_currentMetatileSelection->setSceneRect(0, 0, size.width(), size.height());
+
     auto scale = getMetatilesZoomScale();
     QTransform transform;
     transform.scale(scale, scale);
+    size *= scale;
 
     ui->graphicsView_currentMetatileSelection->setTransform(transform);
-    ui->graphicsView_currentMetatileSelection->setFixedSize(editor->current_metatile_selection_item->pixmap().width() * scale, editor->current_metatile_selection_item->pixmap().height() * scale);
+    ui->graphicsView_currentMetatileSelection->setFixedSize(size.width() + 2, size.height() + 2);
     ui->scrollAreaWidgetContents_SelectedMetatiles->adjustSize();
 }
 
@@ -1394,6 +1398,7 @@ void MainWindow::scrollMetatileSelectorToSelection() {
     pos += QPoint(size.x() - 1, size.y() - 1) * 16 / 2; // We want to focus on the center of the whole selection
     pos *= getMetatilesZoomScale();
 
+    // TODO: This snaps focus to the position if it's out of view. It should scroll slowly toward this target instead
     auto viewport = ui->scrollArea_MetatileSelector->viewport();
     ui->scrollArea_MetatileSelector->ensureVisible(pos.x(), pos.y(), viewport->width() / 2, viewport->height() / 2);
 }
@@ -2845,8 +2850,8 @@ void MainWindow::on_horizontalSlider_MetatileZoom_valueChanged(int value) {
     ui->graphicsView_Metatiles->setFixedSize(size.width() + 2, size.height() + 2);
 
     ui->graphicsView_BorderMetatile->setTransform(transform);
-    ui->graphicsView_BorderMetatile->setFixedSize(ceil(static_cast<double>(editor->selected_border_metatiles_item->pixmap().width()) * scale),
-                                                  ceil(static_cast<double>(editor->selected_border_metatiles_item->pixmap().height()) * scale));
+    ui->graphicsView_BorderMetatile->setFixedSize(ceil(static_cast<double>(editor->selected_border_metatiles_item->pixmap().width()) * scale) + 2,
+                                                  ceil(static_cast<double>(editor->selected_border_metatiles_item->pixmap().height()) * scale) + 2);
 
     ui->scrollAreaWidgetContents_MetatileSelector->adjustSize();
     ui->scrollAreaWidgetContents_BorderMetatiles->adjustSize();

--- a/src/ui/metatileselector.cpp
+++ b/src/ui/metatileselector.cpp
@@ -59,12 +59,9 @@ bool MetatileSelector::select(uint16_t metatileId) {
     return true;
 }
 
-bool MetatileSelector::selectFromMap(uint16_t metatileId, uint16_t collision, uint16_t elevation) {
-    if (!Tileset::metatileIsValid(metatileId, this->primaryTileset, this->secondaryTileset)) return false;
-    this->select(metatileId);
-    this->selection.collisionItems.append(CollisionSelectionItem{true, collision, elevation});
-    this->selection.hasCollision = true;
-    return true;
+void MetatileSelector::selectFromMap(uint16_t metatileId, uint16_t collision, uint16_t elevation) {
+    QPair<uint16_t, uint16_t> movePermissions(collision, elevation);
+    this->setExternalSelection(1, 1, {metatileId}, {movePermissions});
 }
 
 void MetatileSelector::setTilesets(Tileset *primaryTileset, Tileset *secondaryTileset) {
@@ -99,6 +96,10 @@ void MetatileSelector::setExternalSelection(int width, int height, QList<uint16_
         if (!Tileset::metatileIsValid(metatileId, this->primaryTileset, this->secondaryTileset))
             metatileId = 0;
         this->selection.metatileItems.append(MetatileSelectionItem{true, metatileId});
+    }
+    if (this->selection.metatileItems.length() == 1) {
+        QPoint coords = this->getMetatileIdCoords(this->selection.metatileItems.first().metatileId);
+        SelectablePixmapItem::select(coords.x(), coords.y(), 0, 0);
     }
 
     this->draw();

--- a/src/ui/tileseteditor.cpp
+++ b/src/ui/tileseteditor.cpp
@@ -1204,6 +1204,8 @@ void TilesetEditor::redrawMetatileSelector() {
 
     QPoint pos = this->metatileSelector->getMetatileIdCoordsOnWidget(this->getSelectedMetatileId());
     pos *= scale;
+
+    this->ui->scrollAreaWidgetContents_Metatiles->adjustSize();
     this->ui->scrollArea_Metatiles->ensureVisible(pos.x(), pos.y(), 8 * scale, 8 * scale);
 }
 
@@ -1222,6 +1224,8 @@ void TilesetEditor::redrawTileSelector() {
 
     this->ui->graphicsView_Tiles->setTransform(transform);
     this->ui->graphicsView_Tiles->setFixedSize(size.width() + 2, size.height() + 2);
+
+    this->ui->scrollAreaWidgetContents_Tiles->adjustSize();
 
     auto tiles = this->tileSelector->getSelectedTiles();
     if (!tiles.isEmpty()) {

--- a/src/ui/tileseteditor.cpp
+++ b/src/ui/tileseteditor.cpp
@@ -1206,7 +1206,8 @@ void TilesetEditor::redrawMetatileSelector() {
     pos *= scale;
 
     this->ui->scrollAreaWidgetContents_Metatiles->adjustSize();
-    this->ui->scrollArea_Metatiles->ensureVisible(pos.x(), pos.y(), 8 * scale, 8 * scale);
+    auto viewport = this->ui->scrollArea_Metatiles->viewport();
+    this->ui->scrollArea_Metatiles->ensureVisible(pos.x(), pos.y(), viewport->width() / 2, viewport->height() / 2);
 }
 
 void TilesetEditor::on_horizontalSlider_TilesZoom_valueChanged(int value) {
@@ -1231,6 +1232,7 @@ void TilesetEditor::redrawTileSelector() {
     if (!tiles.isEmpty()) {
         QPoint pos = this->tileSelector->getTileCoordsOnWidget(tiles[0].tileId);
         pos *= scale;
-        this->ui->scrollArea_Tiles->ensureVisible(pos.x(), pos.y(), 8 * scale, 8 * scale);
+        auto viewport = this->ui->scrollArea_Tiles->viewport();
+        this->ui->scrollArea_Tiles->ensureVisible(pos.x(), pos.y(), viewport->width() / 2, viewport->height() / 2);
     }
 }

--- a/src/ui/tileseteditor.cpp
+++ b/src/ui/tileseteditor.cpp
@@ -333,9 +333,11 @@ void TilesetEditor::refresh() {
         }
     }
 
+    this->ui->graphicsView_Tiles->setSceneRect(0, 0, this->tileSelector->pixmap().width(), this->tileSelector->pixmap().height());
+    this->ui->graphicsView_Metatiles->setSceneRect(0, 0, this->metatileSelector->pixmap().width(), this->metatileSelector->pixmap().height());
+    this->ui->graphicsView_selectedTile->setFixedSize(this->selectedTilePixmapItem->pixmap().width() + 2, this->selectedTilePixmapItem->pixmap().height() + 2);
     this->redrawTileSelector();
     this->redrawMetatileSelector();
-    this->ui->graphicsView_selectedTile->setFixedSize(this->selectedTilePixmapItem->pixmap().width() + 2, this->selectedTilePixmapItem->pixmap().height() + 2);
 }
 
 void TilesetEditor::drawSelectedTiles() {
@@ -1191,7 +1193,6 @@ void TilesetEditor::on_horizontalSlider_MetatilesZoom_valueChanged(int value) {
 
 void TilesetEditor::redrawMetatileSelector() {
     QSize size(this->metatileSelector->pixmap().width(), this->metatileSelector->pixmap().height());
-    this->ui->graphicsView_Metatiles->setSceneRect(0, 0, size.width() + 2, size.height() + 2);
 
     double scale = pow(3.0, static_cast<double>(porymapConfig.getTilesetEditorMetatilesZoom() - 30) / 30.0);
     QTransform transform;
@@ -1213,7 +1214,6 @@ void TilesetEditor::on_horizontalSlider_TilesZoom_valueChanged(int value) {
 
 void TilesetEditor::redrawTileSelector() {
     QSize size(this->tileSelector->pixmap().width(), this->tileSelector->pixmap().height());
-    this->ui->graphicsView_Tiles->setSceneRect(0, 0, size.width() + 2, size.height() + 2);
 
     double scale = pow(3.0, static_cast<double>(porymapConfig.getTilesetEditorTilesZoom() - 30) / 30.0);
     QTransform transform;

--- a/src/ui/tileseteditor.cpp
+++ b/src/ui/tileseteditor.cpp
@@ -317,7 +317,6 @@ void TilesetEditor::refresh() {
     this->tileSelector->setTilesets(this->primaryTileset, this->secondaryTileset);
     this->metatileSelector->setTilesets(this->primaryTileset, this->secondaryTileset);
     this->metatileSelector->select(this->getSelectedMetatileId());
-    this->drawSelectedTiles();
 
     if (metatileSelector) {
         if (metatileSelector->selectorShowUnused || metatileSelector->selectorShowCounts) {
@@ -333,11 +332,9 @@ void TilesetEditor::refresh() {
         }
     }
 
-    this->ui->graphicsView_Tiles->setSceneRect(0, 0, this->tileSelector->pixmap().width(), this->tileSelector->pixmap().height());
-    this->ui->graphicsView_Metatiles->setSceneRect(0, 0, this->metatileSelector->pixmap().width(), this->metatileSelector->pixmap().height());
-    this->ui->graphicsView_selectedTile->setFixedSize(this->selectedTilePixmapItem->pixmap().width() + 2, this->selectedTilePixmapItem->pixmap().height() + 2);
     this->redrawTileSelector();
     this->redrawMetatileSelector();
+    this->drawSelectedTiles();
 }
 
 void TilesetEditor::drawSelectedTiles() {
@@ -363,7 +360,10 @@ void TilesetEditor::drawSelectedTiles() {
 
     this->selectedTilePixmapItem = new QGraphicsPixmapItem(QPixmap::fromImage(selectionImage));
     this->selectedTileScene->addItem(this->selectedTilePixmapItem);
-    this->ui->graphicsView_selectedTile->setFixedSize(this->selectedTilePixmapItem->pixmap().width() + 2, this->selectedTilePixmapItem->pixmap().height() + 2);
+
+    QSize size(this->selectedTilePixmapItem->pixmap().width(), this->selectedTilePixmapItem->pixmap().height());
+    this->ui->graphicsView_selectedTile->setSceneRect(0, 0, size.width(), size.height());
+    this->ui->graphicsView_selectedTile->setFixedSize(size.width() + 2, size.height() + 2);
 }
 
 void TilesetEditor::onHoveredMetatileChanged(uint16_t metatileId) {
@@ -1193,6 +1193,7 @@ void TilesetEditor::on_horizontalSlider_MetatilesZoom_valueChanged(int value) {
 
 void TilesetEditor::redrawMetatileSelector() {
     QSize size(this->metatileSelector->pixmap().width(), this->metatileSelector->pixmap().height());
+    this->ui->graphicsView_Metatiles->setSceneRect(0, 0, size.width(), size.height());
 
     double scale = pow(3.0, static_cast<double>(porymapConfig.getTilesetEditorMetatilesZoom() - 30) / 30.0);
     QTransform transform;
@@ -1217,6 +1218,7 @@ void TilesetEditor::on_horizontalSlider_TilesZoom_valueChanged(int value) {
 
 void TilesetEditor::redrawTileSelector() {
     QSize size(this->tileSelector->pixmap().width(), this->tileSelector->pixmap().height());
+    this->ui->graphicsView_Tiles->setSceneRect(0, 0, size.width(), size.height());
 
     double scale = pow(3.0, static_cast<double>(porymapConfig.getTilesetEditorTilesZoom() - 30) / 30.0);
     QTransform transform;


### PR DESCRIPTION
- Fixes #587 
- Fixes #591 
- Fixes some issues with selection/selector images getting extra whitespace
- Fixes poor scrolling response for graphics views nested in scroll areas
- Center the current selection in the selector when zooming or eyedropping. Possible `TODO` item, this snaps the view to the selection when zooming starts, it'd look nicer if the move was gradual 