### PR TITLE
Fix script engine memory leak

### DIFF
--- a/include/scripting.h
+++ b/include/scripting.h
@@ -30,8 +30,9 @@ class Scripting
 {
 public:
     Scripting(MainWindow *mainWindow);
-    static void stop();
+    ~Scripting();
     static void init(MainWindow *mainWindow);
+    static void stop();
     static void populateGlobalObject(MainWindow *mainWindow);
     static QJSEngine *getEngine();
     static void invokeAction(int actionIndex);

--- a/include/scriptutility.h
+++ b/include/scriptutility.h
@@ -10,7 +10,8 @@ class ScriptUtility : public QObject
 
 public:
     ScriptUtility(MainWindow *mainWindow);
-    void clearActions();
+    ~ScriptUtility();
+
     QString getActionFunctionName(int actionIndex);
     Q_INVOKABLE bool registerAction(QString functionName, QString actionName, QString shortcut = "");
     Q_INVOKABLE bool registerToggleAction(QString functionName, QString actionName, QString shortcut = "", bool checked = false);
@@ -59,6 +60,7 @@ private:
 
     MainWindow *window;
     QList<QAction *> registeredActions;
+    QSet<QTimer *> activeTimers;
     QHash<int, QString> actionMap;
 };
 

--- a/src/scriptapi/apiutility.cpp
+++ b/src/scriptapi/apiutility.cpp
@@ -7,6 +7,18 @@ ScriptUtility::ScriptUtility(MainWindow *mainWindow) {
     this->window = mainWindow;
 }
 
+ScriptUtility::~ScriptUtility() {
+    if (window && window->ui && window->ui->menuTools) {
+        for (auto action : this->registeredActions) {
+            window->ui->menuTools->removeAction(action);
+        }
+    }
+    for (auto timer : this->activeTimers) {
+        timer->stop();
+        delete timer;
+    }
+}
+
 bool ScriptUtility::registerAction(QString functionName, QString actionName, QString shortcut) {
     if (!window || !window->ui || !window->ui->menuTools)
         return false;
@@ -44,12 +56,6 @@ bool ScriptUtility::registerToggleAction(QString functionName, QString actionNam
     return true;
 }
 
-void ScriptUtility::clearActions() {
-    for (auto action : this->registeredActions) {
-        window->ui->menuTools->removeAction(action);
-    }
-}
-
 QString ScriptUtility::getActionFunctionName(int actionIndex) {
     return this->actionMap.value(actionIndex);
 }
@@ -58,11 +64,15 @@ void ScriptUtility::setTimeout(QJSValue callback, int milliseconds) {
   if (!callback.isCallable() || milliseconds < 0)
       return;
 
-    QTimer *timer = new QTimer(0);
+    QTimer *timer = new QTimer();
     connect(timer, &QTimer::timeout, [=](){
-        this->callTimeoutFunction(callback);
+        if (this->activeTimers.remove(timer)) {
+            this->callTimeoutFunction(callback);
+            timer->deleteLater();
+        }
     });
-    connect(timer, &QTimer::timeout, timer, &QTimer::deleteLater);
+
+    this->activeTimers.insert(timer);
     timer->setSingleShot(true);
     timer->start(milliseconds);
 }

--- a/src/scriptapi/scripting.cpp
+++ b/src/scriptapi/scripting.cpp
@@ -24,11 +24,6 @@ const QMap<CallbackType, QString> callbackFunctions = {
 Scripting *instance = nullptr;
 
 void Scripting::stop() {
-    if (!instance) return;
-    instance->engine->setInterrupted(true);
-    qDeleteAll(instance->imageCache);
-    delete instance->engine;
-    delete instance->scriptUtility;
     delete instance;
     instance = nullptr;
 }
@@ -52,6 +47,13 @@ Scripting::Scripting(MainWindow *mainWindow) {
     }
     this->loadModules(this->filepaths);
     this->scriptUtility = new ScriptUtility(mainWindow);
+}
+
+Scripting::~Scripting() {
+    this->engine->setInterrupted(true);
+    qDeleteAll(this->imageCache);
+    delete this->engine;
+    delete this->scriptUtility;
 }
 
 void Scripting::loadModules(QStringList moduleFiles) {

--- a/src/scriptapi/scripting.cpp
+++ b/src/scriptapi/scripting.cpp
@@ -1,8 +1,10 @@
+#include <QQmlEngine>
+
 #include "scripting.h"
 #include "log.h"
 #include "config.h"
 
-QMap<CallbackType, QString> callbackFunctions = {
+const QMap<CallbackType, QString> callbackFunctions = {
     {OnProjectOpened, "onProjectOpened"},
     {OnProjectClosed, "onProjectClosed"},
     {OnBlockChanged, "onBlockChanged"},
@@ -24,8 +26,9 @@ Scripting *instance = nullptr;
 void Scripting::stop() {
     if (!instance) return;
     instance->engine->setInterrupted(true);
-    instance->scriptUtility->clearActions();
     qDeleteAll(instance->imageCache);
+    delete instance->engine;
+    delete instance->scriptUtility;
     delete instance;
     instance = nullptr;
 }
@@ -39,7 +42,7 @@ void Scripting::init(MainWindow *mainWindow) {
 
 Scripting::Scripting(MainWindow *mainWindow) {
     this->mainWindow = mainWindow;
-    this->engine = new QJSEngine(mainWindow);
+    this->engine = new QJSEngine();
     this->engine->installExtensions(QJSEngine::ConsoleExtension);
     const QStringList paths = userConfig.getCustomScriptPaths();
     const QList<bool> enabled = userConfig.getCustomScriptsEnabled();
@@ -78,6 +81,11 @@ void Scripting::populateGlobalObject(MainWindow *mainWindow) {
     instance->engine->globalObject().setProperty("map", instance->engine->newQObject(mainWindow));
     instance->engine->globalObject().setProperty("overlay", instance->engine->newQObject(mainWindow->ui->graphicsView_Map));
     instance->engine->globalObject().setProperty("utility", instance->engine->newQObject(instance->scriptUtility));
+
+    // Note: QJSEngine also has these functions, but not in Qt 5.15.
+    QQmlEngine::setObjectOwnership(mainWindow, QQmlEngine::CppOwnership);
+    QQmlEngine::setObjectOwnership(mainWindow->ui->graphicsView_Map, QQmlEngine::CppOwnership);
+    QQmlEngine::setObjectOwnership(instance->scriptUtility, QQmlEngine::CppOwnership);
 
     QJSValue constants = instance->engine->newObject();
 


### PR DESCRIPTION
The script API was leaking the memory allocated for the `QJSEngine` and `ScriptUtility` (the former may be freed when Porymap is quit but not during project open/close). The engine was taking ownership of the main window, so deleting it would have caused a crash.

It was also possible to call `utility.setTimeout`, switch projects, and have the timeout trigger in the new project. Because the engine gets interrupted (and interruption errors are silenced) this wouldn't be visible to the user, but that was fixed anyway.