### PR TITLE
Interpret triple-layer metatiles from NUM_TILES_PER_METATILE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The **"Breaking Changes"** listed below are changes that have been made in the d
 - A notice will be displayed when attempting to open the "Dynamic" map, rather than nothing happening.
 - The base game version is now auto-detected if the project name contains only one of "emerald", "firered/leafgreen", or "ruby/sapphire".
 - It's now possible to cancel quitting if there are unsaved changes in sub-windows.
+- The triple-layer metatiles setting can now be set automatically using a project constant.
 
 ### Fixed
 - Fix `Add Region Map...` not updating the region map settings file.

--- a/docsrc/manual/project-files.rst
+++ b/docsrc/manual/project-files.rst
@@ -101,6 +101,7 @@ In addition to these files, there are some specific symbol and macro names that 
    ``define_metatiles_primary``, ``NUM_METATILES_IN_PRIMARY``, total metatiles are calculated using metatile ID mask
    ``define_pals_primary``, ``NUM_PALS_IN_PRIMARY``,
    ``define_pals_total``, ``NUM_PALS_TOTAL``, 
+   ``define_tiles_per_metatile``, ``NUM_TILES_PER_METATILE``, to determine if triple-layer metatiles are in use. Values other than 8 or 12 are ignored
    ``define_map_size``, ``MAX_MAP_DATA_SIZE``, to limit map dimensions
    ``define_mask_metatile``, ``MAPGRID_METATILE_ID_MASK``, optionally read to get settings on ``Maps`` tab
    ``define_mask_collision``, ``MAPGRID_COLLISION_MASK``, optionally read to get settings on ``Maps`` tab

--- a/include/config.h
+++ b/include/config.h
@@ -196,6 +196,7 @@ enum ProjectIdentifier {
     define_metatiles_primary,
     define_pals_primary,
     define_pals_total,
+    define_tiles_per_metatile,
     define_map_size,
     define_mask_metatile,
     define_mask_collision,

--- a/include/ui/projectsettingseditor.h
+++ b/include/ui/projectsettingseditor.h
@@ -61,7 +61,7 @@ private:
     void chooseImageFile(QLineEdit * filepathEdit);
     void chooseFile(QLineEdit * filepathEdit, const QString &description, const QString &extensions);
     QString stripProjectDir(QString s);
-    void disableParsedSetting(QWidget * widget, const QString &name, const QString &filepath);
+    bool disableParsedSetting(QWidget * widget, const QString &identifier, const QString &filepath);
     void updateMaskOverlapWarning(QLabel * warning, QList<UIntSpinBox*> masks);
     QStringList getWarpBehaviorsList();
     void setWarpBehaviorsList(QStringList list);

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -90,6 +90,7 @@ const QMap<ProjectIdentifier, QPair<QString, QString>> ProjectConfig::defaultIde
     {ProjectIdentifier::define_metatiles_primary,      {"define_metatiles_primary",      "NUM_METATILES_IN_PRIMARY"}},
     {ProjectIdentifier::define_pals_primary,           {"define_pals_primary",           "NUM_PALS_IN_PRIMARY"}},
     {ProjectIdentifier::define_pals_total,             {"define_pals_total",             "NUM_PALS_TOTAL"}},
+    {ProjectIdentifier::define_tiles_per_metatile,     {"define_tiles_per_metatile",     "NUM_TILES_PER_METATILE"}},
     {ProjectIdentifier::define_map_size,               {"define_map_size",               "MAX_MAP_DATA_SIZE"}},
     {ProjectIdentifier::define_mask_metatile,          {"define_mask_metatile",          "MAPGRID_METATILE_ID_MASK"}},
     {ProjectIdentifier::define_mask_collision,         {"define_mask_collision",         "MAPGRID_COLLISION_MASK"}},


### PR DESCRIPTION
Automatically update the triple-layer metatiles setting if the user has defined `NUM_TILES_PER_METATILE` as `8` or `12`. 