### PR TITLE
Improve #define parsing speed

### DIFF
--- a/include/core/parseutil.h
+++ b/include/core/parseutil.h
@@ -104,7 +104,8 @@ private:
     };
     ParsedDefines readCDefines(const QString &filename, const QStringList &filterList, bool useRegex);
     QMap<QString, int> evaluateCDefines(const QString &filename, const QStringList &filterList, bool useRegex);
-    bool defineNameMatchesFilter(const QString &name, const QStringList &filterList, bool useRegex);
+    bool defineNameMatchesFilter(const QString &name, const QStringList &filterList) const;
+    bool defineNameMatchesFilter(const QString &name, const QList<QRegularExpression> &filterList) const;
 
     static const QRegularExpression re_incScriptLabel;
     static const QRegularExpression re_globalIncScriptLabel;


### PR DESCRIPTION
Makes `Project::load` ~20% faster by reading files with a lot of defines like `flags.h` and `items.h` more efficiently, though it’s a small change overall (opening a new project is ~5% faster)