### PR TITLE
Add actual preview to Export Map Stitch Image

### DIFF
--- a/forms/mapimageexporter.ui
+++ b/forms/mapimageexporter.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>696</width>
-    <height>396</height>
+    <width>817</width>
+    <height>518</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -16,15 +16,299 @@
   <property name="sizeGripEnabled">
    <bool>true</bool>
   </property>
-  <layout class="QHBoxLayout" name="horizontalLayout">
-   <item>
-    <widget class="QGroupBox" name="groupBox">
+  <layout class="QGridLayout" name="gridLayout_4" columnstretch="2,1">
+   <item row="1" column="1">
+    <widget class="QFrame" name="frame_Options">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_Options">
+      <item>
+       <layout class="QFormLayout" name="formLayout">
+        <item row="0" column="0">
+         <widget class="QLabel" name="label_2">
+          <property name="text">
+           <string>Map</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="1">
+         <widget class="NoScrollComboBox" name="comboBox_MapSelection">
+          <property name="sizeAdjustPolicy">
+           <enum>QComboBox::SizeAdjustPolicy::AdjustToContents</enum>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <widget class="QGroupBox" name="groupBox_Events">
+        <property name="title">
+         <string>Events</string>
+        </property>
+        <layout class="QGridLayout" name="gridLayout_2">
+         <item row="0" column="0">
+          <layout class="QGridLayout" name="gridLayout_Event_Options">
+           <item row="0" column="1">
+            <widget class="QCheckBox" name="checkBox_Warps">
+             <property name="text">
+              <string>Warps</string>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="0">
+            <widget class="QCheckBox" name="checkBox_Objects">
+             <property name="text">
+              <string>Objects</string>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="2">
+            <widget class="QCheckBox" name="checkBox_BGs">
+             <property name="text">
+              <string>BGs</string>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="0">
+            <widget class="QCheckBox" name="checkBox_Triggers">
+             <property name="text">
+              <string>Triggers</string>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="1">
+            <widget class="QCheckBox" name="checkBox_HealSpots">
+             <property name="text">
+              <string>Heal Spots</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item>
+       <widget class="QGroupBox" name="groupBox_Connections">
+        <property name="title">
+         <string>Connections</string>
+        </property>
+        <layout class="QGridLayout" name="gridLayout_3">
+         <item row="0" column="0">
+          <layout class="QGridLayout" name="gridLayout_Connection_Options">
+           <item row="0" column="0">
+            <widget class="QCheckBox" name="checkBox_ConnectionUp">
+             <property name="text">
+              <string>Up</string>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="1">
+            <widget class="QCheckBox" name="checkBox_ConnectionDown">
+             <property name="text">
+              <string>Down</string>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="2">
+            <widget class="QCheckBox" name="checkBox_ConnectionLeft">
+             <property name="text">
+              <string>Left</string>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="3">
+            <widget class="QCheckBox" name="checkBox_ConnectionRight">
+             <property name="text">
+              <string>Right</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item>
+       <widget class="QGroupBox" name="groupBox_Misc">
+        <property name="title">
+         <string>Miscellaneous</string>
+        </property>
+        <layout class="QGridLayout" name="gridLayout_5">
+         <item row="0" column="0">
+          <layout class="QGridLayout" name="gridLayout_Misc_Options">
+           <item row="0" column="0">
+            <widget class="QCheckBox" name="checkBox_Grid">
+             <property name="text">
+              <string>Grid</string>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="0">
+            <widget class="QCheckBox" name="checkBox_Elevation">
+             <property name="text">
+              <string>Collision</string>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="1">
+            <widget class="QCheckBox" name="checkBox_Border">
+             <property name="text">
+              <string>Border</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item>
+       <widget class="QGroupBox" name="groupBox_Timelapse">
+        <property name="title">
+         <string>Timelapse</string>
+        </property>
+        <layout class="QGridLayout" name="gridLayout_7">
+         <item row="2" column="1">
+          <widget class="QSpinBox" name="spinBox_TimelapseDelay">
+           <property name="specialValueText">
+            <string/>
+           </property>
+           <property name="suffix">
+            <string>ms</string>
+           </property>
+           <property name="minimum">
+            <number>1</number>
+           </property>
+           <property name="maximum">
+            <number>2000</number>
+           </property>
+           <property name="value">
+            <number>200</number>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="0">
+          <widget class="QLabel" name="label">
+           <property name="text">
+            <string>Frame Delay</string>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="1">
+          <widget class="QSpinBox" name="spinBox_FrameSkip">
+           <property name="suffix">
+            <string/>
+           </property>
+           <property name="minimum">
+            <number>1</number>
+           </property>
+           <property name="maximum">
+            <number>999</number>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="0">
+          <widget class="QLabel" name="label_3">
+           <property name="text">
+            <string>Edit Frame Skip</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item>
+       <spacer name="verticalSpacer">
+        <property name="orientation">
+         <enum>Qt::Orientation::Vertical</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>20</width>
+          <height>40</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="checkBox_ActualSize">
+        <property name="text">
+         <string>Preview actual size</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_2">
+        <item>
+         <widget class="QPushButton" name="pushButton_Reset">
+          <property name="text">
+           <string>Reset</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="horizontalSpacer">
+          <property name="orientation">
+           <enum>Qt::Orientation::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item>
+         <widget class="QPushButton" name="pushButton_Cancel">
+          <property name="text">
+           <string>Cancel</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="pushButton_Save">
+          <property name="text">
+           <string>Save</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="QGroupBox" name="groupBox_Preview">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
      <property name="title">
       <string>Preview</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_6">
+      <property name="leftMargin">
+       <number>6</number>
+      </property>
+      <property name="topMargin">
+       <number>6</number>
+      </property>
+      <property name="rightMargin">
+       <number>6</number>
+      </property>
+      <property name="bottomMargin">
+       <number>6</number>
+      </property>
       <item row="0" column="0">
-       <widget class="QScrollArea" name="scrollArea">
+       <widget class="QScrollArea" name="scrollArea_Preview">
         <property name="widgetResizable">
          <bool>true</bool>
         </property>
@@ -33,12 +317,24 @@
           <rect>
            <x>0</x>
            <y>0</y>
-           <width>403</width>
-           <height>343</height>
+           <width>500</width>
+           <height>439</height>
           </rect>
          </property>
          <layout class="QGridLayout" name="gridLayout">
-          <item row="3" column="4">
+          <property name="leftMargin">
+           <number>0</number>
+          </property>
+          <property name="topMargin">
+           <number>0</number>
+          </property>
+          <property name="rightMargin">
+           <number>0</number>
+          </property>
+          <property name="bottomMargin">
+           <number>0</number>
+          </property>
+          <item row="2" column="3">
            <widget class="QGraphicsView" name="graphicsView_Preview">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
@@ -53,64 +349,12 @@
              <bool>false</bool>
             </property>
             <property name="sizeAdjustPolicy">
-             <enum>QAbstractScrollArea::AdjustIgnored</enum>
+             <enum>QAbstractScrollArea::SizeAdjustPolicy::AdjustIgnored</enum>
             </property>
             <property name="dragMode">
-             <enum>QGraphicsView::NoDrag</enum>
+             <enum>QGraphicsView::DragMode::NoDrag</enum>
             </property>
            </widget>
-          </item>
-          <item row="4" column="4">
-           <spacer name="verticalSpacer_South">
-            <property name="orientation">
-             <enum>Qt::Vertical</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>10</width>
-              <height>100</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-          <item row="0" column="4">
-           <spacer name="verticalSpacer_North">
-            <property name="orientation">
-             <enum>Qt::Vertical</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>10</width>
-              <height>100</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-          <item row="3" column="5">
-           <spacer name="horizontalSpacer_West">
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>100</width>
-              <height>10</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-          <item row="3" column="0">
-           <spacer name="horizontalSpacer_East">
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>100</width>
-              <height>10</height>
-             </size>
-            </property>
-           </spacer>
           </item>
          </layout>
         </widget>
@@ -119,256 +363,18 @@
      </layout>
     </widget>
    </item>
-   <item>
-    <layout class="QVBoxLayout" name="verticalLayout_Options">
-     <item>
-      <layout class="QFormLayout" name="formLayout">
-       <item row="0" column="0">
-        <widget class="QLabel" name="label_2">
-         <property name="text">
-          <string>Map</string>
-         </property>
-        </widget>
-       </item>
-       <item row="0" column="1">
-        <widget class="NoScrollComboBox" name="comboBox_MapSelection">
-         <property name="sizeAdjustPolicy">
-          <enum>QComboBox::AdjustToContents</enum>
-         </property>
-        </widget>
-       </item>
-      </layout>
-     </item>
-     <item>
-      <widget class="QGroupBox" name="groupBox_Events">
-       <property name="title">
-        <string>Events</string>
-       </property>
-       <layout class="QGridLayout" name="gridLayout_2">
-        <item row="0" column="0">
-         <layout class="QGridLayout" name="gridLayout_Event_Options">
-          <item row="0" column="1">
-           <widget class="QCheckBox" name="checkBox_Warps">
-            <property name="text">
-             <string>Warps</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="0">
-           <widget class="QCheckBox" name="checkBox_Objects">
-            <property name="text">
-             <string>Objects</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="2">
-           <widget class="QCheckBox" name="checkBox_BGs">
-            <property name="text">
-             <string>BGs</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="0">
-           <widget class="QCheckBox" name="checkBox_Triggers">
-            <property name="text">
-             <string>Triggers</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="1">
-           <widget class="QCheckBox" name="checkBox_HealSpots">
-            <property name="text">
-             <string>Heal Spots</string>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </item>
-       </layout>
-      </widget>
-     </item>
-     <item>
-      <widget class="QGroupBox" name="groupBox_Connections">
-       <property name="title">
-        <string>Connections</string>
-       </property>
-       <layout class="QGridLayout" name="gridLayout_3">
-        <item row="0" column="0">
-         <layout class="QGridLayout" name="gridLayout_Connection_Options">
-          <item row="0" column="0">
-           <widget class="QCheckBox" name="checkBox_ConnectionUp">
-            <property name="text">
-             <string>Up</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="1">
-           <widget class="QCheckBox" name="checkBox_ConnectionDown">
-            <property name="text">
-             <string>Down</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="2">
-           <widget class="QCheckBox" name="checkBox_ConnectionLeft">
-            <property name="text">
-             <string>Left</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="3">
-           <widget class="QCheckBox" name="checkBox_ConnectionRight">
-            <property name="text">
-             <string>Right</string>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </item>
-       </layout>
-      </widget>
-     </item>
-     <item>
-      <widget class="QGroupBox" name="groupBox_Misc">
-       <property name="title">
-        <string>Miscellaneous</string>
-       </property>
-       <layout class="QGridLayout" name="gridLayout_5">
-        <item row="0" column="0">
-         <layout class="QGridLayout" name="gridLayout_Misc_Options">
-          <item row="0" column="0">
-           <widget class="QCheckBox" name="checkBox_Grid">
-            <property name="text">
-             <string>Grid</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="0">
-           <widget class="QCheckBox" name="checkBox_Elevation">
-            <property name="text">
-             <string>Collision</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="1">
-           <widget class="QCheckBox" name="checkBox_Border">
-            <property name="text">
-             <string>Border</string>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </item>
-       </layout>
-      </widget>
-     </item>
-     <item>
-      <widget class="QGroupBox" name="groupBox_Timelapse">
-       <property name="title">
-        <string>Timelapse</string>
-       </property>
-       <layout class="QGridLayout" name="gridLayout_7">
-        <item row="2" column="1">
-         <widget class="QSpinBox" name="spinBox_TimelapseDelay">
-          <property name="specialValueText">
-           <string/>
-          </property>
-          <property name="suffix">
-           <string>ms</string>
-          </property>
-          <property name="minimum">
-           <number>1</number>
-          </property>
-          <property name="maximum">
-           <number>2000</number>
-          </property>
-          <property name="value">
-           <number>200</number>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="0">
-         <widget class="QLabel" name="label">
-          <property name="text">
-           <string>Frame Delay</string>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="1">
-         <widget class="QSpinBox" name="spinBox_FrameSkip">
-          <property name="suffix">
-           <string/>
-          </property>
-          <property name="minimum">
-           <number>1</number>
-          </property>
-          <property name="maximum">
-           <number>999</number>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="0">
-         <widget class="QLabel" name="label_3">
-          <property name="text">
-           <string>Edit Frame Skip</string>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </widget>
-     </item>
-     <item>
-      <spacer name="verticalSpacer">
-       <property name="orientation">
-        <enum>Qt::Vertical</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>20</width>
-         <height>40</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item>
-      <layout class="QHBoxLayout" name="horizontalLayout_2">
-       <item>
-        <widget class="QPushButton" name="pushButton_Reset">
-         <property name="text">
-          <string>Reset</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <spacer name="horizontalSpacer">
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>40</width>
-           <height>20</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item>
-        <widget class="QPushButton" name="pushButton_Cancel">
-         <property name="text">
-          <string>Cancel</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QPushButton" name="pushButton_Save">
-         <property name="text">
-          <string>Save</string>
-         </property>
-        </widget>
-       </item>
-      </layout>
-     </item>
-    </layout>
+   <item row="0" column="0" colspan="2">
+    <widget class="QLabel" name="label_Description">
+     <property name="text">
+      <string/>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignmentFlag::AlignCenter</set>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
    </item>
   </layout>
  </widget>

--- a/forms/mapimageexporter.ui
+++ b/forms/mapimageexporter.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>817</width>
-    <height>518</height>
+    <height>535</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -52,7 +52,28 @@
         <layout class="QGridLayout" name="gridLayout_2">
          <item row="0" column="0">
           <layout class="QGridLayout" name="gridLayout_Event_Options">
+           <item row="1" column="1">
+            <widget class="QCheckBox" name="checkBox_Triggers">
+             <property name="text">
+              <string>Triggers</string>
+             </property>
+            </widget>
+           </item>
            <item row="0" column="1">
+            <widget class="QCheckBox" name="checkBox_Objects">
+             <property name="text">
+              <string>Objects</string>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="2">
+            <widget class="QCheckBox" name="checkBox_HealLocations">
+             <property name="text">
+              <string>Heal Locations</string>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="2">
             <widget class="QCheckBox" name="checkBox_Warps">
              <property name="text">
               <string>Warps</string>
@@ -60,30 +81,16 @@
             </widget>
            </item>
            <item row="0" column="0">
-            <widget class="QCheckBox" name="checkBox_Objects">
+            <widget class="QCheckBox" name="checkBox_AllEvents">
              <property name="text">
-              <string>Objects</string>
-             </property>
-            </widget>
-           </item>
-           <item row="0" column="2">
-            <widget class="QCheckBox" name="checkBox_BGs">
-             <property name="text">
-              <string>BGs</string>
+              <string>All</string>
              </property>
             </widget>
            </item>
            <item row="1" column="0">
-            <widget class="QCheckBox" name="checkBox_Triggers">
+            <widget class="QCheckBox" name="checkBox_BGs">
              <property name="text">
-              <string>Triggers</string>
-             </property>
-            </widget>
-           </item>
-           <item row="1" column="1">
-            <widget class="QCheckBox" name="checkBox_HealSpots">
-             <property name="text">
-              <string>Heal Spots</string>
+              <string>BGs</string>
              </property>
             </widget>
            </item>
@@ -100,31 +107,38 @@
         <layout class="QGridLayout" name="gridLayout_3">
          <item row="0" column="0">
           <layout class="QGridLayout" name="gridLayout_Connection_Options">
-           <item row="0" column="0">
-            <widget class="QCheckBox" name="checkBox_ConnectionUp">
-             <property name="text">
-              <string>Up</string>
-             </property>
-            </widget>
-           </item>
-           <item row="0" column="1">
-            <widget class="QCheckBox" name="checkBox_ConnectionDown">
-             <property name="text">
-              <string>Down</string>
-             </property>
-            </widget>
-           </item>
-           <item row="0" column="2">
+           <item row="1" column="2">
             <widget class="QCheckBox" name="checkBox_ConnectionLeft">
              <property name="text">
               <string>Left</string>
              </property>
             </widget>
            </item>
-           <item row="0" column="3">
+           <item row="1" column="0">
+            <widget class="QCheckBox" name="checkBox_ConnectionUp">
+             <property name="text">
+              <string>Up</string>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="3">
             <widget class="QCheckBox" name="checkBox_ConnectionRight">
              <property name="text">
               <string>Right</string>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="1">
+            <widget class="QCheckBox" name="checkBox_ConnectionDown">
+             <property name="text">
+              <string>Down</string>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="0">
+            <widget class="QCheckBox" name="checkBox_AllConnections">
+             <property name="text">
+              <string>All</string>
              </property>
             </widget>
            </item>
@@ -317,8 +331,8 @@
           <rect>
            <x>0</x>
            <y>0</y>
-           <width>500</width>
-           <height>439</height>
+           <width>469</width>
+           <height>464</height>
           </rect>
          </property>
          <layout class="QGridLayout" name="gridLayout">

--- a/include/ui/mapimageexporter.h
+++ b/include/ui/mapimageexporter.h
@@ -16,6 +16,24 @@ enum ImageExporterMode {
     Timelapse,
 };
 
+struct ImageExporterSettings {
+    bool showObjects = false;
+    bool showWarps = false;
+    bool showBGs = false;
+    bool showTriggers = false;
+    bool showHealLocations = false;
+    bool showUpConnections = false;
+    bool showDownConnections = false;
+    bool showLeftConnections = false;
+    bool showRightConnections = false;
+    bool showGrid = false;
+    bool showBorder = false;
+    bool showCollision = false;
+    bool previewActualSize = false;
+    int timelapseSkipAmount = 1;
+    int timelapseDelayMs = 200;
+};
+
 class MapImageExporter : public QDialog
 {
     Q_OBJECT
@@ -33,21 +51,7 @@ private:
 
     QPixmap preview;
 
-    bool showObjects = false;
-    bool showWarps = false;
-    bool showBGs = false;
-    bool showTriggers = false;
-    bool showHealLocations = false;
-    bool showUpConnections = false;
-    bool showDownConnections = false;
-    bool showLeftConnections = false;
-    bool showRightConnections = false;
-    bool showGrid = false;
-    bool showBorder = false;
-    bool showCollision = false;
-    bool previewActualSize = false;
-    int timelapseSkipAmount = 1;
-    int timelapseDelayMs = 200;
+    ImageExporterSettings settings;
     ImageExporterMode mode = ImageExporterMode::Normal;
 
     void updatePreview();

--- a/include/ui/mapimageexporter.h
+++ b/include/ui/mapimageexporter.h
@@ -37,7 +37,7 @@ private:
     bool showWarps = false;
     bool showBGs = false;
     bool showTriggers = false;
-    bool showHealSpots = false;
+    bool showHealLocations = false;
     bool showUpConnections = false;
     bool showDownConnections = false;
     bool showLeftConnections = false;
@@ -67,20 +67,20 @@ private slots:
     void on_checkBox_Warps_stateChanged(int state);
     void on_checkBox_BGs_stateChanged(int state);
     void on_checkBox_Triggers_stateChanged(int state);
-    void on_checkBox_HealSpots_stateChanged(int state);
+    void on_checkBox_HealLocations_stateChanged(int state);
+    void on_checkBox_AllEvents_stateChanged(int state);
 
     void on_checkBox_ConnectionUp_stateChanged(int state);
     void on_checkBox_ConnectionDown_stateChanged(int state);
     void on_checkBox_ConnectionLeft_stateChanged(int state);
     void on_checkBox_ConnectionRight_stateChanged(int state);
+    void on_checkBox_AllConnections_stateChanged(int state);
 
     void on_checkBox_Elevation_stateChanged(int state);
     void on_checkBox_Grid_stateChanged(int state);
     void on_checkBox_Border_stateChanged(int state);
 
-    void on_pushButton_Save_pressed();
     void on_pushButton_Reset_pressed();
-    void on_pushButton_Cancel_pressed();
     void on_spinBox_TimelapseDelay_valueChanged(int delayMs);
     void on_spinBox_FrameSkip_valueChanged(int skip);
 

--- a/include/ui/mapimageexporter.h
+++ b/include/ui/mapimageexporter.h
@@ -45,16 +45,22 @@ private:
     bool showGrid = false;
     bool showBorder = false;
     bool showCollision = false;
+    bool previewActualSize = false;
     int timelapseSkipAmount = 1;
     int timelapseDelayMs = 200;
     ImageExporterMode mode = ImageExporterMode::Normal;
 
     void updatePreview();
+    void scalePreview();
     void updateShowBorderState();
     void saveImage();
     QPixmap getStitchedImage(QProgressDialog *progress, bool includeBorder);
     QPixmap getFormattedMapPixmap(Map *map, bool ignoreBorder = false);
     bool historyItemAppliesToFrame(const QUndoCommand *command);
+
+protected:
+    virtual void showEvent(QShowEvent *) override;
+    virtual void resizeEvent(QResizeEvent *) override;
 
 private slots:
     void on_checkBox_Objects_stateChanged(int state);
@@ -77,6 +83,8 @@ private slots:
     void on_pushButton_Cancel_pressed();
     void on_spinBox_TimelapseDelay_valueChanged(int delayMs);
     void on_spinBox_FrameSkip_valueChanged(int skip);
+
+    void on_checkBox_ActualSize_stateChanged(int state);
 };
 
 #endif // MAPIMAGEEXPORTER_H

--- a/src/ui/mapimageexporter.cpp
+++ b/src/ui/mapimageexporter.cpp
@@ -377,6 +377,7 @@ void MapImageExporter::updatePreview() {
         progress.setAutoClose(true);
         progress.setWindowModality(Qt::WindowModal);
         progress.setModal(true);
+        progress.setMinimumDuration(1000);
         this->preview = getStitchedImage(&progress, this->showBorder);
         progress.close();
     } else {


### PR DESCRIPTION
Closes #499 

Addresses confusion about what the "Stitch Image" feature does by displaying an actual preview of the image that will be created. The image can obviously be quite large, so the preview will now scale to fit the view. The original behavior for the preview (showing the image at the normal scale for the map editor) is preserved with a "Preview actual size" setting.

Also adds a brief description at the top of the window describing what the current image exporter will do.

Changing settings (which recreates the preview) is now likely to be significantly slower for most stitch images. I think this is a fine trade-off, having a real preview is valuable and I don't think toggling a bunch of settings is the main use case here.

(Final note, the diff in the form is mostly QtCreator relocating things. Aside from the label there were only some minor changes to give the preview more space)

UPDATE: Added an `All` setting for events so if someone wants to toggle on all the event settings for a stitch map they don't need to wait for it to update 5 times. Also noticed an unrelated bug that I'll fix later (the map connections used for the image export are the connections for the map in the editor -- which can change -- not the map in the export window).

![preview](https://github.com/user-attachments/assets/c10cf55c-5d43-4aec-b75e-72486ecc7367)


