### PR TITLE
Update help buttons, chart help text

### DIFF
--- a/forms/customscriptseditor.ui
+++ b/forms/customscriptseditor.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>540</width>
+    <width>582</width>
     <height>355</height>
    </rect>
   </property>
@@ -33,21 +33,30 @@
     <item>
      <widget class="QFrame" name="window">
       <property name="frameShape">
-       <enum>QFrame::StyledPanel</enum>
+       <enum>QFrame::Shape::StyledPanel</enum>
       </property>
       <property name="frameShadow">
-       <enum>QFrame::Raised</enum>
+       <enum>QFrame::Shadow::Raised</enum>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout_2">
        <item>
         <widget class="QFrame" name="header">
          <property name="frameShape">
-          <enum>QFrame::StyledPanel</enum>
-         </property>
-         <property name="frameShadow">
-          <enum>QFrame::Raised</enum>
+          <enum>QFrame::Shape::StyledPanel</enum>
          </property>
          <layout class="QHBoxLayout" name="horizontalLayout">
+          <property name="leftMargin">
+           <number>6</number>
+          </property>
+          <property name="topMargin">
+           <number>6</number>
+          </property>
+          <property name="rightMargin">
+           <number>6</number>
+          </property>
+          <property name="bottomMargin">
+           <number>6</number>
+          </property>
           <item>
            <widget class="QPushButton" name="button_CreateNewScript">
             <property name="toolTip">
@@ -91,9 +100,9 @@
            </widget>
           </item>
           <item>
-           <spacer name="horizontalSpacer_header">
+           <spacer name="horizontalSpacer">
             <property name="orientation">
-             <enum>Qt::Horizontal</enum>
+             <enum>Qt::Orientation::Horizontal</enum>
             </property>
             <property name="sizeHint" stdset="0">
              <size>
@@ -103,34 +112,32 @@
             </property>
            </spacer>
           </item>
+          <item>
+           <spacer name="horizontalSpacer_header">
+            <property name="orientation">
+             <enum>Qt::Orientation::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>40</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+          <item>
+           <widget class="QToolButton" name="button_Help">
+            <property name="text">
+             <string>...</string>
+            </property>
+            <property name="icon">
+             <iconset resource="../resources/images.qrc">
+              <normaloff>:/icons/help.ico</normaloff>:/icons/help.ico</iconset>
+            </property>
+           </widget>
+          </item>
          </layout>
         </widget>
-       </item>
-       <item>
-        <widget class="QLabel" name="label_Manual">
-         <property name="text">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;a href=&quot;https://huderlem.github.io/porymap/manual/scripting-capabilities.html&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0069d9;&quot;&gt;Help&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-         </property>
-         <property name="openExternalLinks">
-          <bool>true</bool>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <spacer name="verticalSpacer">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeType">
-          <enum>QSizePolicy::Minimum</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>5</height>
-          </size>
-         </property>
-        </spacer>
        </item>
        <item>
         <widget class="QLabel" name="label_ListHeader">
@@ -142,32 +149,32 @@
        <item>
         <widget class="QListWidget" name="list">
          <property name="editTriggers">
-          <set>QAbstractItemView::NoEditTriggers</set>
+          <set>QAbstractItemView::EditTrigger::NoEditTriggers</set>
          </property>
          <property name="showDropIndicator" stdset="0">
           <bool>false</bool>
          </property>
          <property name="dragDropMode">
-          <enum>QAbstractItemView::DragOnly</enum>
+          <enum>QAbstractItemView::DragDropMode::DragOnly</enum>
          </property>
          <property name="defaultDropAction">
-          <enum>Qt::IgnoreAction</enum>
+          <enum>Qt::DropAction::IgnoreAction</enum>
          </property>
          <property name="selectionMode">
-          <enum>QAbstractItemView::ExtendedSelection</enum>
+          <enum>QAbstractItemView::SelectionMode::ExtendedSelection</enum>
          </property>
          <property name="textElideMode">
-          <enum>Qt::ElideLeft</enum>
+          <enum>Qt::TextElideMode::ElideLeft</enum>
          </property>
          <property name="movement">
-          <enum>QListView::Free</enum>
+          <enum>QListView::Movement::Free</enum>
          </property>
         </widget>
        </item>
        <item>
         <widget class="QDialogButtonBox" name="buttonBox">
          <property name="standardButtons">
-          <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+          <set>QDialogButtonBox::StandardButton::Cancel|QDialogButtonBox::StandardButton::Ok</set>
          </property>
         </widget>
        </item>

--- a/forms/projectsettingseditor.ui
+++ b/forms/projectsettingseditor.ui
@@ -125,7 +125,7 @@
                <item row="1" column="6">
                 <spacer name="horizontalSpacer">
                  <property name="orientation">
-                  <enum>Qt::Horizontal</enum>
+                  <enum>Qt::Orientation::Horizontal</enum>
                  </property>
                  <property name="sizeHint" stdset="0">
                   <size>
@@ -194,10 +194,10 @@
                <item row="1" column="3">
                 <spacer name="horizontalSpacer_4">
                  <property name="orientation">
-                  <enum>Qt::Horizontal</enum>
+                  <enum>Qt::Orientation::Horizontal</enum>
                  </property>
                  <property name="sizeType">
-                  <enum>QSizePolicy::Maximum</enum>
+                  <enum>QSizePolicy::Policy::Maximum</enum>
                  </property>
                  <property name="sizeHint" stdset="0">
                   <size>
@@ -276,10 +276,10 @@
                <string notr="true">.QFrame { border: 1px solid red; }</string>
               </property>
               <property name="frameShape">
-               <enum>QFrame::StyledPanel</enum>
+               <enum>QFrame::Shape::StyledPanel</enum>
               </property>
               <property name="frameShadow">
-               <enum>QFrame::Raised</enum>
+               <enum>QFrame::Shadow::Raised</enum>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_3">
                <item>
@@ -287,7 +287,6 @@
                  <property name="font">
                   <font>
                    <pointsize>12</pointsize>
-                   <weight>75</weight>
                    <bold>true</bold>
                   </font>
                  </property>
@@ -319,7 +318,7 @@
                   <item>
                    <spacer name="horizontalSpacer_6">
                     <property name="orientation">
-                     <enum>Qt::Horizontal</enum>
+                     <enum>Qt::Orientation::Horizontal</enum>
                     </property>
                     <property name="sizeHint" stdset="0">
                      <size>
@@ -338,7 +337,7 @@
             <item>
              <spacer name="verticalSpacer_3">
               <property name="orientation">
-               <enum>Qt::Vertical</enum>
+               <enum>Qt::Orientation::Vertical</enum>
               </property>
               <property name="sizeHint" stdset="0">
                <size>
@@ -567,10 +566,10 @@
                <string notr="true">.QFrame { border: 1px solid red; }</string>
               </property>
               <property name="frameShape">
-               <enum>QFrame::StyledPanel</enum>
+               <enum>QFrame::Shape::StyledPanel</enum>
               </property>
               <property name="frameShadow">
-               <enum>QFrame::Raised</enum>
+               <enum>QFrame::Shadow::Raised</enum>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_18">
                <item>
@@ -578,7 +577,6 @@
                  <property name="font">
                   <font>
                    <pointsize>12</pointsize>
-                   <weight>75</weight>
                    <bold>true</bold>
                   </font>
                  </property>
@@ -693,7 +691,7 @@
                   <item row="0" column="2">
                    <spacer name="horizontalSpacer_3">
                     <property name="orientation">
-                     <enum>Qt::Horizontal</enum>
+                     <enum>Qt::Orientation::Horizontal</enum>
                     </property>
                     <property name="sizeHint" stdset="0">
                      <size>
@@ -712,7 +710,7 @@
             <item>
              <spacer name="verticalSpacer_5">
               <property name="orientation">
-               <enum>Qt::Vertical</enum>
+               <enum>Qt::Orientation::Vertical</enum>
               </property>
               <property name="sizeHint" stdset="0">
                <size>
@@ -783,10 +781,10 @@
                <string notr="true">.QFrame { border: 1px solid red; }</string>
               </property>
               <property name="frameShape">
-               <enum>QFrame::StyledPanel</enum>
+               <enum>QFrame::Shape::StyledPanel</enum>
               </property>
               <property name="frameShadow">
-               <enum>QFrame::Raised</enum>
+               <enum>QFrame::Shadow::Raised</enum>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_13">
                <item>
@@ -794,7 +792,6 @@
                  <property name="font">
                   <font>
                    <pointsize>12</pointsize>
-                   <weight>75</weight>
                    <bold>true</bold>
                   </font>
                  </property>
@@ -839,10 +836,10 @@
                   <item row="1" column="0">
                    <spacer name="verticalSpacer">
                     <property name="orientation">
-                     <enum>Qt::Vertical</enum>
+                     <enum>Qt::Orientation::Vertical</enum>
                     </property>
                     <property name="sizeType">
-                     <enum>QSizePolicy::Maximum</enum>
+                     <enum>QSizePolicy::Policy::Maximum</enum>
                     </property>
                     <property name="sizeHint" stdset="0">
                      <size>
@@ -924,10 +921,10 @@
                   <item row="9" column="0">
                    <spacer name="verticalSpacer_6">
                     <property name="orientation">
-                     <enum>Qt::Vertical</enum>
+                     <enum>Qt::Orientation::Vertical</enum>
                     </property>
                     <property name="sizeType">
-                     <enum>QSizePolicy::MinimumExpanding</enum>
+                     <enum>QSizePolicy::Policy::MinimumExpanding</enum>
                     </property>
                     <property name="sizeHint" stdset="0">
                      <size>
@@ -975,7 +972,7 @@
             <item>
              <spacer name="verticalSpacer_2">
               <property name="orientation">
-               <enum>Qt::Vertical</enum>
+               <enum>Qt::Orientation::Vertical</enum>
               </property>
               <property name="sizeHint" stdset="0">
                <size>
@@ -1212,7 +1209,7 @@
                   <bool>true</bool>
                  </property>
                  <property name="textInteractionFlags">
-                  <set>Qt::NoTextInteraction</set>
+                  <set>Qt::TextInteractionFlag::NoTextInteraction</set>
                  </property>
                  <property name="placeholderText">
                   <string>Use the dropbown and buttons to add behaviors to the list...</string>
@@ -1242,10 +1239,10 @@
                <string notr="true">.QFrame { border: 1px solid red; }</string>
               </property>
               <property name="frameShape">
-               <enum>QFrame::StyledPanel</enum>
+               <enum>QFrame::Shape::StyledPanel</enum>
               </property>
               <property name="frameShadow">
-               <enum>QFrame::Raised</enum>
+               <enum>QFrame::Shadow::Raised</enum>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_15">
                <item>
@@ -1253,7 +1250,6 @@
                  <property name="font">
                   <font>
                    <pointsize>12</pointsize>
-                   <weight>75</weight>
                    <bold>true</bold>
                   </font>
                  </property>
@@ -1316,7 +1312,7 @@
                   <item row="0" column="2">
                    <spacer name="horizontalSpacer_2">
                     <property name="orientation">
-                     <enum>Qt::Horizontal</enum>
+                     <enum>Qt::Orientation::Horizontal</enum>
                     </property>
                     <property name="sizeHint" stdset="0">
                      <size>
@@ -1335,7 +1331,7 @@
             <item>
              <spacer name="verticalSpacer_4">
               <property name="orientation">
-               <enum>Qt::Vertical</enum>
+               <enum>Qt::Orientation::Vertical</enum>
               </property>
               <property name="sizeHint" stdset="0">
                <size>
@@ -1372,18 +1368,13 @@
            </property>
            <layout class="QVBoxLayout" name="verticalLayout_10">
             <item>
-             <widget class="QLabel" name="label_ProjectFilesHelp">
+             <widget class="QToolButton" name="button_HelpFiles">
               <property name="text">
-               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;a href=&quot;https://huderlem.github.io/porymap/manual/project-files.html#files&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0069d9;&quot;&gt;Help&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+               <string>...</string>
               </property>
-              <property name="textFormat">
-               <enum>Qt::RichText</enum>
-              </property>
-              <property name="alignment">
-               <set>Qt::AlignBottom|Qt::AlignLeading|Qt::AlignLeft</set>
-              </property>
-              <property name="openExternalLinks">
-               <bool>true</bool>
+              <property name="icon">
+               <iconset resource="../resources/images.qrc">
+                <normaloff>:/icons/help.ico</normaloff>:/icons/help.ico</iconset>
               </property>
              </widget>
             </item>
@@ -1419,7 +1410,7 @@
                     <x>0</x>
                     <y>0</y>
                     <width>533</width>
-                    <height>440</height>
+                    <height>428</height>
                    </rect>
                   </property>
                   <layout class="QFormLayout" name="layout_ProjectPaths">
@@ -1466,18 +1457,13 @@
            </property>
            <layout class="QVBoxLayout" name="verticalLayout_19">
             <item>
-             <widget class="QLabel" name="label_IdentifiersHelp">
+             <widget class="QToolButton" name="button_HelpIdentifiers">
               <property name="text">
-               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;a href=&quot;https://huderlem.github.io/porymap/manual/project-files.html#identifiers&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0069d9;&quot;&gt;Help&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+               <string>...</string>
               </property>
-              <property name="textFormat">
-               <enum>Qt::RichText</enum>
-              </property>
-              <property name="alignment">
-               <set>Qt::AlignBottom|Qt::AlignLeading|Qt::AlignLeft</set>
-              </property>
-              <property name="openExternalLinks">
-               <bool>true</bool>
+              <property name="icon">
+               <iconset resource="../resources/images.qrc">
+                <normaloff>:/icons/help.ico</normaloff>:/icons/help.ico</iconset>
               </property>
              </widget>
             </item>
@@ -1513,7 +1499,7 @@
                     <x>0</x>
                     <y>0</y>
                     <width>533</width>
-                    <height>440</height>
+                    <height>428</height>
                    </rect>
                   </property>
                   <layout class="QFormLayout" name="layout_Identifiers">
@@ -1544,7 +1530,7 @@
     <item>
      <widget class="QDialogButtonBox" name="buttonBox">
       <property name="standardButtons">
-       <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok|QDialogButtonBox::RestoreDefaults</set>
+       <set>QDialogButtonBox::StandardButton::Cancel|QDialogButtonBox::StandardButton::Ok|QDialogButtonBox::StandardButton::RestoreDefaults</set>
       </property>
      </widget>
     </item>

--- a/include/ui/customscriptseditor.h
+++ b/include/ui/customscriptseditor.h
@@ -49,6 +49,7 @@ private:
     void restoreWindowState();
     void initShortcuts();
     QObjectList shortcutableObjects() const;
+    void openManual();
 
 private slots:
     void dialogButtonClicked(QAbstractButton *button);

--- a/include/ui/projectsettingseditor.h
+++ b/include/ui/projectsettingseditor.h
@@ -65,6 +65,8 @@ private:
     void updateMaskOverlapWarning(QLabel * warning, QList<UIntSpinBox*> masks);
     QStringList getWarpBehaviorsList();
     void setWarpBehaviorsList(QStringList list);
+    void openFilesHelp();
+    void openIdentifiersHelp();
 
 private slots:
     void dialogButtonClicked(QAbstractButton *button);

--- a/src/ui/customscriptseditor.cpp
+++ b/src/ui/customscriptseditor.cpp
@@ -23,6 +23,7 @@ CustomScriptsEditor::CustomScriptsEditor(QWidget *parent) :
     for (int i = 0; i < paths.length(); i++)
         this->displayScript(paths.at(i), enabled.at(i));
 
+    connect(ui->button_Help, &QAbstractButton::clicked, this, &CustomScriptsEditor::openManual);
     connect(ui->button_CreateNewScript, &QAbstractButton::clicked, this, &CustomScriptsEditor::createNewScript);
     connect(ui->button_LoadScript, &QAbstractButton::clicked, this, &CustomScriptsEditor::loadScript);
     connect(ui->button_RefreshScripts, &QAbstractButton::clicked, this, &CustomScriptsEditor::userRefreshScripts);
@@ -227,6 +228,11 @@ void CustomScriptsEditor::openScript(QListWidgetItem * item) {
 void CustomScriptsEditor::openSelectedScripts() {
     for (auto item : ui->list->selectedItems())
         this->openScript(item);
+}
+
+void CustomScriptsEditor::openManual() {
+    static const QUrl url("https://huderlem.github.io/porymap/manual/scripting-capabilities.html");
+    QDesktopServices::openUrl(url);
 }
 
 // When the user refreshes the scripts we show a little tooltip as feedback.

--- a/src/ui/projectsettingseditor.cpp
+++ b/src/ui/projectsettingseditor.cpp
@@ -37,6 +37,8 @@ ProjectSettingsEditor::~ProjectSettingsEditor()
 }
 
 void ProjectSettingsEditor::connectSignals() {
+    connect(ui->button_HelpFiles, &QAbstractButton::clicked, this, &ProjectSettingsEditor::openFilesHelp);
+    connect(ui->button_HelpIdentifiers, &QAbstractButton::clicked, this, &ProjectSettingsEditor::openIdentifiersHelp);
     connect(ui->buttonBox, &QDialogButtonBox::clicked, this, &ProjectSettingsEditor::dialogButtonClicked);
     connect(ui->button_ImportDefaultPrefabs, &QAbstractButton::clicked, this, &ProjectSettingsEditor::importDefaultPrefabsClicked);
     connect(ui->comboBox_BaseGameVersion, &QComboBox::currentTextChanged, this, &ProjectSettingsEditor::promptRestoreDefaults);
@@ -656,6 +658,16 @@ void ProjectSettingsEditor::dialogButtonClicked(QAbstractButton *button) {
         // "Restore Defaults" button
         this->promptRestoreDefaults();
     }
+}
+
+void ProjectSettingsEditor::openFilesHelp() {
+    static const QUrl url("https://huderlem.github.io/porymap/manual/project-files.html#files");
+    QDesktopServices::openUrl(url);
+}
+
+void ProjectSettingsEditor::openIdentifiersHelp() {
+    static const QUrl url("https://huderlem.github.io/porymap/manual/project-files.html#identifiers");
+    QDesktopServices::openUrl(url);
 }
 
 // Close event triggered by a project reload. User doesn't need any prompts, just close the window.

--- a/src/ui/wildmonchart.cpp
+++ b/src/ui/wildmonchart.cpp
@@ -82,6 +82,7 @@ void WildMonChart::clearTableData() {
     ui->comboBox_Species->clear();
     ui->comboBox_Group->clear();
     ui->comboBox_Group->setEnabled(false);
+    ui->label_Group->setEnabled(false);
 }
 
 // Extract all the data from the table that we need for the charts
@@ -152,7 +153,9 @@ void WildMonChart::readTable() {
     ui->comboBox_Species->addItems(getSpeciesNamesAlphabetical());
     ui->comboBox_Group->clear();
     ui->comboBox_Group->addItems(this->groupNames);
-    ui->comboBox_Group->setEnabled(usesGroupLabels());
+    bool enableGroupSelection = usesGroupLabels();
+    ui->comboBox_Group->setEnabled(enableGroupSelection);
+    ui->label_Group->setEnabled(enableGroupSelection);
 }
 
 void WildMonChart::refresh() {
@@ -438,23 +441,33 @@ void WildMonChart::limitChartAnimation() {
 
 void WildMonChart::showHelpDialog() {
     static const QString text = "This window provides some visualizations of the data in your current Wild Pokémon tab";
-    static const QString informative =
-        "The <b>Species Distribution</b> tab shows the cumulative encounter chance for each species "
+
+    // Describe the Species Distribution tab
+    static const QString speciesTabInfo =
+       "The <b>Species Distribution</b> tab shows the cumulative encounter chance for each species "
        "in the table. In other words, it answers the question \"What is the likelihood of encountering "
-       "each species in a single encounter?\""
-       "<br><br>"
+       "each species in a single encounter?\"";
+
+    // Describe the Level Distribution tab
+    static const QString levelTabInfo =
        "The <b>Level Distribution</b> tab shows the chance of encountering each species at a particular level. "
        "In the top left under <b>Group</b> you can select which encounter group to show data for. "
-       "In the top right under <b>Species</b> you can select which species to show data for. "
+       "In the top right you can enable <b>Individual Mode</b>. When enabled data will be shown for only the selected species."
        "<br><br>"
-       "<b>Individual Mode</b> on the <b>Level Distribution</b> tab toggles whether data is shown for all species in the table. "
-       "The percentages will update to reflect whether you're showing all species or just that individual species. "
        "In other words, while <b>Individual Mode</b> is checked the chart is answering the question \"If a species x "
        "is encountered, what is the likelihood that it will be level y\", and while <b>Individual Mode</b> is not checked, "
        "it answers the question \"For a single encounter, what is the likelihood of encountering a species x at level y.\"";
+
+    QString informativeText;
+    if (ui->tabWidget->currentWidget() == ui->tabSpecies) {
+        informativeText = speciesTabInfo;
+    } else if (ui->tabWidget->currentWidget() == ui->tabLevels) {
+        informativeText = levelTabInfo;
+    }
+
     QMessageBox msgBox(QMessageBox::Information, "porymap", text, QMessageBox::Close, this);
     msgBox.setTextFormat(Qt::RichText);
-    msgBox.setInformativeText(informative);
+    msgBox.setInformativeText(informativeText);
     msgBox.exec();
 }
 


### PR DESCRIPTION
Replace our old "Help" hyperlink labels with the new Help tool buttons: 
![help](https://github.com/user-attachments/assets/906ffe82-a186-4c30-9d8e-b6e7ed5305e8)

Also shortened the lengthy help text for the `Summary Charts` page by making it tab-specific (you can't change tabs while it's open anyway).