### PR TITLE
Render API images as pixmaps

### DIFF
--- a/include/ui/overlay.h
+++ b/include/ui/overlay.h
@@ -50,19 +50,19 @@ private:
     QColor fillColor;
 };
 
-class OverlayImage : public OverlayItem {
+class OverlayPixmap : public OverlayItem {
 public:
-    OverlayImage(int x, int y, QImage image) {
+    OverlayPixmap(int x, int y, QPixmap pixmap) {
         this->x = x;
         this->y = y;
-        this->image = image;
+        this->pixmap = pixmap;
     }
-    ~OverlayImage() {}
+    ~OverlayPixmap() {}
     virtual void render(QPainter *painter);
 private:
     int x;
     int y;
-    QImage image;
+    QPixmap pixmap;
 };
 
 class Overlay

--- a/src/ui/overlay.cpp
+++ b/src/ui/overlay.cpp
@@ -16,8 +16,8 @@ void OverlayPath::render(QPainter *painter) {
     painter->drawPath(this->path);
 }
 
-void OverlayImage::render(QPainter *painter) {
-    painter->drawImage(this->x, this->y, this->image);
+void OverlayPixmap::render(QPainter *painter) {
+    painter->drawPixmap(this->x, this->y, this->pixmap);
 }
 
 void Overlay::renderItems(QPainter *painter) {
@@ -244,7 +244,7 @@ bool Overlay::addImage(int x, int y, QString filepath, bool useCache, int width,
     if (setTransparency)
         image.setColor(0, qRgba(0, 0, 0, 0));
 
-    this->items.append(new OverlayImage(x, y, image));
+    this->items.append(new OverlayPixmap(x, y, QPixmap::fromImage(image)));
     return true;
 }
 
@@ -253,6 +253,6 @@ bool Overlay::addImage(int x, int y, QImage image) {
         logError(QString("Failed to load custom image"));
         return false;
     }
-    this->items.append(new OverlayImage(x, y, image));
+    this->items.append(new OverlayPixmap(x, y, QPixmap::fromImage(image)));
     return true;
 }


### PR DESCRIPTION
Profiled a few different scripts using the image functions in the API. Rendering images with `QPixmap` instead of `QImage` was around ~20% faster for most.