### PR TITLE
Fix some issues with map connections after layout split

### DIFF
--- a/include/core/map.h
+++ b/include/core/map.h
@@ -91,7 +91,7 @@ public:
     void removeConnection(MapConnection *);
     void addConnection(MapConnection *);
     void loadConnection(MapConnection *);
-    QRect getConnectionRect(const QString &direction, Layout *fromLayout = nullptr);
+    QRect getConnectionRect(const QString &direction, Layout *fromLayout = nullptr) const;
     QPixmap renderConnection(const QString &direction, Layout *fromLayout = nullptr);
 
     QUndoStack* editHistory() const { return m_editHistory; }

--- a/include/editor.h
+++ b/include/editor.h
@@ -135,7 +135,7 @@ public:
 
     QList<QGraphicsPixmapItem*> borderItems;
     QGraphicsItemGroup *mapGrid = nullptr;
-    MapRuler *map_ruler = nullptr;
+    QPointer<MapRuler> map_ruler = nullptr;
 
     MovableRect *playerViewRect = nullptr;
     CursorTileRect *cursorMapTileRect = nullptr;
@@ -221,10 +221,7 @@ private:
     void clearMapGrid();
     void clearWildMonTables();
     void updateBorderVisibility();
-    void disconnectMapConnection(MapConnection *connection);
-    QPoint getConnectionOrigin(MapConnection *connection);
     void removeConnectionPixmap(MapConnection *connection);
-    void updateConnectionPixmap(ConnectionPixmapItem *connectionItem);
     void displayConnection(MapConnection *connection);
     void displayDivingConnection(MapConnection *connection);
     void setDivingMapName(QString mapName, QString direction);

--- a/include/ui/connectionpixmapitem.h
+++ b/include/ui/connectionpixmapitem.h
@@ -10,21 +10,19 @@
 class ConnectionPixmapItem : public QObject, public QGraphicsPixmapItem {
     Q_OBJECT
 public:
-    ConnectionPixmapItem(MapConnection* connection, int originX, int originY);
-    ConnectionPixmapItem(MapConnection* connection, QPoint origin);
+    ConnectionPixmapItem(MapConnection* connection);
 
     const QPointer<MapConnection> connection;
-
-    void setOrigin(int x, int y);
-    void setOrigin(QPoint pos);
 
     void setEditable(bool editable);
     bool getEditable();
 
     void setSelected(bool selected);
 
-    void updatePos();
     void render(bool ignoreCache = false);
+
+signals:
+    void positionChanged(qreal x, qreal y);
 
 private:
     QPixmap basePixmap;
@@ -35,6 +33,10 @@ private:
 
     static const int mWidth = 16;
     static const int mHeight = 16;
+
+    void updatePos();
+    void updateOrigin();
+    void refresh();
 
 protected:
     virtual QVariant itemChange(GraphicsItemChange change, const QVariant &value) override;

--- a/include/ui/connectionslistitem.h
+++ b/include/ui/connectionslistitem.h
@@ -23,7 +23,6 @@ public:
     explicit ConnectionsListItem(QWidget *parent, MapConnection *connection, const QStringList &mapNames);
     ~ConnectionsListItem();
 
-    void updateUI();
     void setSelected(bool selected);
 
 private:
@@ -32,6 +31,8 @@ private:
     Map *map;
     bool isSelected = false;
     unsigned actionId = 0;
+
+    void updateUI();
 
 protected:
     virtual void mousePressEvent(QMouseEvent*) override;

--- a/src/core/map.cpp
+++ b/src/core/map.cpp
@@ -90,7 +90,7 @@ int Map::getBorderHeight() const {
 // Get the portion of the map that can be rendered when rendered as a map connection.
 // Cardinal connections render the nearest segment of their map and within the bounds of the border draw distance,
 // Dive/Emerge connections are rendered normally within the bounds of their parent map.
-QRect Map::getConnectionRect(const QString &direction, Layout * fromLayout) {
+QRect Map::getConnectionRect(const QString &direction, Layout * fromLayout) const {
     int x = 0, y = 0;
     int w = getWidth(), h = getHeight();
 

--- a/src/ui/connectionslistitem.cpp
+++ b/src/ui/connectionslistitem.cpp
@@ -38,6 +38,11 @@ ConnectionsListItem::ConnectionsListItem(QWidget *parent, MapConnection * connec
     // Distinguish between move actions for the edit history
     connect(ui->spinBox_Offset, &QSpinBox::editingFinished, [this] { this->actionId++; });
 
+    // If the connection changes externally we want to update to reflect the change.
+    connect(connection, &MapConnection::offsetChanged, this, &ConnectionsListItem::updateUI);
+    connect(connection, &MapConnection::directionChanged, this, &ConnectionsListItem::updateUI);
+    connect(connection, &MapConnection::targetMapNameChanged, this, &ConnectionsListItem::updateUI);
+
     this->connection = connection;
     this->map = connection->parentMap();
     this->updateUI();


### PR DESCRIPTION
The map connection display items were relying on some lambda functions being safely disconnected, which was flimsy and broke after the layout split. The connection flow used to be:
- Connection data signals a change --> editor receives signal --> editor updates the pixmap, list item, and connection mask.

Now it uses the following, with no need for manual disconnection:
- Connection data signals a change --> pixmap and list item independently receive signal and update --> pixmap signals a change --> editor receives signal and updates connection mask.

Closes #640 
Closes #646 
Closes #647 
Closes #666 
Also incidentally fixed a use-after-free on the map ruler.