### PR TITLE
Keep metatile images on separate rows, fix metatile usage count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ The **"Breaking Changes"** listed below are changes that have been made in the d
 - Unrecognized map names in Event or Connections data will no longer be overwritten.
 - Map names and ``MAP_NAME`` constants are no longer required to match.
 - Porymap will no longer overwrite ``include/constants/map_groups.h`` or ``include/constants/layouts.h``.
+- Primary/secondary metatile images are now kept on separate rows, rather than blending together if the primary size is not divisible by 8.
 
 ### Fixed
 - Fix `Add Region Map...` not updating the region map settings file.
@@ -76,6 +77,7 @@ The **"Breaking Changes"** listed below are changes that have been made in the d
 - Fix some problems with tileset detection when importing maps from AdvanceMap.
 - Fix certain input fields allowing invalid identifiers, like names starting with numbers.
 - Fix crash in the Shortcuts Editor when applying changes after closing certain windows.
+- Fix `Display Metatile Usage Counts` sometimes changing the counts after repeated use.
 
 ## [5.4.1] - 2024-03-21
 ### Fixed

--- a/include/ui/metatileselector.h
+++ b/include/ui/metatileselector.h
@@ -79,6 +79,7 @@ private:
     bool positionIsValid(const QPoint &pos) const;
     bool selectionIsValid();
     void hoverChanged();
+    int numPrimaryMetatilesRounded() const;
 
 signals:
     void hoveredMetatileSelectionChanged(uint16_t);

--- a/include/ui/tileseteditormetatileselector.h
+++ b/include/ui/tileseteditormetatileselector.h
@@ -51,6 +51,7 @@ private:
     void drawCounts();
     QImage buildAllMetatilesImage();
     QImage buildImage(int metatileIdStart, int numMetatiles);
+    int numPrimaryMetatilesRounded() const;
 
 signals:
     void hoveredMetatileChanged(uint16_t);

--- a/src/project.cpp
+++ b/src/project.cpp
@@ -1056,7 +1056,7 @@ bool Project::loadLayoutTilesets(Layout *layout) {
     layout->tileset_primary = getTileset(layout->tileset_primary_label);
     if (!layout->tileset_primary) {
         QString defaultTileset = this->getDefaultPrimaryTilesetLabel();
-        logWarn(QString("Map layout %1 has invalid primary tileset '%2'. Using default '%3'").arg(layout->id).arg(layout->tileset_primary_label).arg(defaultTileset));
+        logWarn(QString("%1 has invalid primary tileset '%2'. Using default '%3'").arg(layout->name).arg(layout->tileset_primary_label).arg(defaultTileset));
         layout->tileset_primary_label = defaultTileset;
         layout->tileset_primary = getTileset(layout->tileset_primary_label);
         if (!layout->tileset_primary) {
@@ -1068,7 +1068,7 @@ bool Project::loadLayoutTilesets(Layout *layout) {
     layout->tileset_secondary = getTileset(layout->tileset_secondary_label);
     if (!layout->tileset_secondary) {
         QString defaultTileset = this->getDefaultSecondaryTilesetLabel();
-        logWarn(QString("Map layout %1 has invalid secondary tileset '%2'. Using default '%3'").arg(layout->id).arg(layout->tileset_secondary_label).arg(defaultTileset));
+        logWarn(QString("%1 has invalid secondary tileset '%2'. Using default '%3'").arg(layout->name).arg(layout->tileset_secondary_label).arg(defaultTileset));
         layout->tileset_secondary_label = defaultTileset;
         layout->tileset_secondary = getTileset(layout->tileset_secondary_label);
         if (!layout->tileset_secondary) {
@@ -1137,7 +1137,8 @@ bool Project::loadBlockdata(Layout *layout) {
     layout->lastCommitBlocks.layoutDimensions = QSize(layout->getWidth(), layout->getHeight());
 
     if (layout->blockdata.count() != layout->getWidth() * layout->getHeight()) {
-        logWarn(QString("Layout blockdata length %1 does not match dimensions %2x%3 (should be %4). Resizing blockdata.")
+        logWarn(QString("%1 blockdata length %2 does not match dimensions %3x%4 (should be %5). Resizing blockdata.")
+                .arg(layout->name)
                 .arg(layout->blockdata.count())
                 .arg(layout->getWidth())
                 .arg(layout->getHeight())
@@ -1174,7 +1175,8 @@ bool Project::loadLayoutBorder(Layout *layout) {
 
     int borderLength = layout->getBorderWidth() * layout->getBorderHeight();
     if (layout->border.count() != borderLength) {
-        logWarn(QString("Layout border blockdata length %1 must be %2. Resizing border blockdata.")
+        logWarn(QString("%1 border blockdata length %2 must be %3. Resizing border blockdata.")
+                .arg(layout->name)
                 .arg(layout->border.count())
                 .arg(borderLength));
         layout->border.resize(borderLength);

--- a/src/ui/metatileselector.cpp
+++ b/src/ui/metatileselector.cpp
@@ -9,12 +9,17 @@ QPoint MetatileSelector::getSelectionDimensions() {
     return SelectablePixmapItem::getSelectionDimensions();
 }
 
+int MetatileSelector::numPrimaryMetatilesRounded() const {
+    // We round up the number of primary metatiles to keep the tilesets on separate rows.
+    return ceil((double)this->primaryTileset->numMetatiles() / this->numMetatilesWide) * this->numMetatilesWide;
+}
+
 void MetatileSelector::draw() {
     if (!this->primaryTileset || !this->secondaryTileset) {
         this->setPixmap(QPixmap());
     }
 
-    int primaryLength = this->primaryTileset->numMetatiles();
+    int primaryLength = this->numPrimaryMetatilesRounded();
     int length_ = primaryLength + this->secondaryTileset->numMetatiles();
     int height_ = length_ / this->numMetatilesWide;
     if (length_ % this->numMetatilesWide != 0) {
@@ -149,7 +154,7 @@ void MetatileSelector::mouseReleaseEvent(QGraphicsSceneMouseEvent *event) {
 
 void MetatileSelector::hoverMoveEvent(QGraphicsSceneHoverEvent *event) {
     QPoint pos = this->getCellPos(event->pos());
-    if (!positionIsValid(pos) || this->cellPos == pos)
+    if (this->cellPos == pos)
         return;
 
     this->cellPos = pos;
@@ -199,10 +204,11 @@ void MetatileSelector::updateExternalSelectedMetatiles() {
 
 uint16_t MetatileSelector::getMetatileId(int x, int y) const {
     int index = y * this->numMetatilesWide + x;
-    if (index < this->primaryTileset->numMetatiles()) {
+    int numPrimary = this->numPrimaryMetatilesRounded();
+    if (index < numPrimary) {
         return static_cast<uint16_t>(index);
     } else {
-        return static_cast<uint16_t>(Project::getNumMetatilesPrimary() + index - this->primaryTileset->numMetatiles());
+        return static_cast<uint16_t>(Project::getNumMetatilesPrimary() + index - numPrimary);
     }
 }
 
@@ -215,7 +221,7 @@ QPoint MetatileSelector::getMetatileIdCoords(uint16_t metatileId) {
 
     int index = metatileId < Project::getNumMetatilesPrimary()
                 ? metatileId
-                : metatileId - Project::getNumMetatilesPrimary() + this->primaryTileset->numMetatiles();
+                : metatileId - Project::getNumMetatilesPrimary() + this->numPrimaryMetatilesRounded();
     return QPoint(index % this->numMetatilesWide, index / this->numMetatilesWide);
 }
 


### PR DESCRIPTION
Closes #656, re-enables the tileset dividing line feature, and fixes an incidental bug with how we were counting metatiles for `Display Metatile Usage Counts`.