### PR TITLE
Only show the file watcher warning when Porymap is active

### DIFF
--- a/include/mainwindow.h
+++ b/include/mainwindow.h
@@ -367,7 +367,7 @@ private:
     void scrollMapListToCurrentMap(MapTree *list);
     void scrollMapListToCurrentLayout(MapTree *list);
     void resetMapListFilters();
-    void showFileWatcherWarning(QString filepath);
+    void showFileWatcherWarning();
     QString getExistingDirectory(QString);
     bool openProject(QString dir, bool initial = false);
     bool closeProject();

--- a/include/project.h
+++ b/include/project.h
@@ -71,7 +71,7 @@ public:
     QMap<QString, QString> facingDirections;
     ParseUtil parser;
     QFileSystemWatcher fileWatcher;
-    QMap<QString, qint64> modifiedFileTimestamps;
+    QSet<QString> modifiedFiles;
     bool usingAsmTilesets;
     QSet<QString> disabledSettingsNames;
     QSet<QString> topLevelMapFields;
@@ -252,6 +252,7 @@ public:
 
 private:
     QMap<QString, QString> mapSectionDisplayNames;
+    QMap<QString, qint64> modifiedFileTimestamps;
 
     void updateLayout(Layout *);
 
@@ -259,6 +260,7 @@ private:
     void setNewLayoutBorder(Layout *layout);
 
     void ignoreWatchedFileTemporarily(QString filepath);
+    void recordFileChange(const QString &filepath);
 
     static int num_tiles_primary;
     static int num_tiles_total;
@@ -270,7 +272,7 @@ private:
     static int max_object_events;
 
 signals:
-    void fileChanged(QString filepath);
+    void fileChanged(const QString &filepath);
     void mapLoaded(Map *map);
     void mapCreated(Map *newMap, const QString &groupName);
     void layoutCreated(Layout *newLayout);


### PR DESCRIPTION
The file watcher's warning is useful, but Porymap constantly trying to get my attention when I switch to the project gets annoying (on macOS at least, even opening a file counts as a file change to `QFileSystemWatcher`).

Now the project will record these file changes, and it will wait to show the warning until Porymap is the active application. If multiple files were changed it will list all of them in a single warning.