### PR TITLE
Add events overlay to map view

### DIFF
--- a/forms/mainwindow.ui
+++ b/forms/mainwindow.ui
@@ -2882,6 +2882,7 @@
     <addaction name="actionPlayer_View_Rectangle"/>
     <addaction name="actionBetter_Cursors"/>
     <addaction name="actionDive_Emerge_Map"/>
+    <addaction name="actionShow_Events_In_Map_View"/>
     <addaction name="actionShow_Grid"/>
     <addaction name="actionGrid_Settings"/>
    </widget>
@@ -3234,6 +3235,17 @@
    </property>
    <property name="text">
     <string>Show Dive/Emerge Map</string>
+   </property>
+  </action>
+  <action name="actionShow_Events_In_Map_View">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="checked">
+    <bool>false</bool>
+   </property>
+   <property name="text">
+    <string>Show Events in Map View</string>
    </property>
   </action>
   <action name="actionShow_Grid">

--- a/include/config.h
+++ b/include/config.h
@@ -81,6 +81,7 @@ public:
         this->projectSettingsTab = 0;
         this->warpBehaviorWarningDisabled = false;
         this->eventDeleteWarningDisabled = false;
+        this->eventOverlayEnabled = false;
         this->checkForUpdates = true;
         this->lastUpdateCheckTime = QDateTime();
         this->lastUpdateCheckVersion = porymapVersion;
@@ -136,6 +137,7 @@ public:
     int projectSettingsTab;
     bool warpBehaviorWarningDisabled;
     bool eventDeleteWarningDisabled;
+    bool eventOverlayEnabled;
     bool checkForUpdates;
     QDateTime lastUpdateCheckTime;
     QVersionNumber lastUpdateCheckVersion;

--- a/include/editor.h
+++ b/include/editor.h
@@ -119,6 +119,7 @@ public:
     void redrawEvents(const QList<Event*> &events);
     void redrawEventPixmapItem(DraggablePixmapItem *item);
     QList<DraggablePixmapItem *> getEventPixmapItems();
+    qreal getEventOpacity(const Event *event) const;
 
     void updateCursorRectPos(int x, int y);
     void setCursorRectVisible(bool visible);
@@ -161,20 +162,10 @@ public:
     EditAction eventEditAction = EditAction::Select;
 
     enum class EditMode { None, Disabled, Metatiles, Collision, Header, Events, Connections, Encounters };
-    EditMode editMode = EditMode::None;
-    void setEditMode(EditMode mode) { this->editMode = mode; }
-    EditMode getEditMode() { return this->editMode; }
+    void setEditMode(EditMode editMode);
+    EditMode getEditMode() const { return this->editMode; }
 
     bool getEditingLayout();
-
-    void setEditorView();
-    
-    void setEditingMetatiles();
-    void setEditingCollision();
-    void setEditingHeader();
-    void setEditingEvents();
-    void setEditingConnections();
-    void setEditingEncounters();
 
     void setMapEditingButtonsEnabled(bool enabled);
 
@@ -210,6 +201,8 @@ private:
     const QImage defaultCollisionImgSheet = QImage(":/images/collisions.png");
     const QImage collisionPlaceholder = QImage(":/images/collisions_unknown.png");
     QPixmap collisionSheetPixmap;
+
+    EditMode editMode = EditMode::None;
 
     void clearMap();
     void clearMetatileSelector();

--- a/include/mainwindow.h
+++ b/include/mainwindow.h
@@ -261,6 +261,7 @@ private slots:
 
     void on_checkBox_MirrorConnections_stateChanged(int selected);
     void on_actionDive_Emerge_Map_triggered();
+    void on_actionShow_Events_In_Map_View_triggered();
     void on_groupBox_DiveMapOpacity_toggled(bool on);
     void on_slider_DiveEmergeMapOpacity_valueChanged(int value);
     void on_slider_DiveMapOpacity_valueChanged(int value);

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -394,6 +394,8 @@ void PorymapConfig::parseConfigKeyValue(QString key, QString value) {
         this->warpBehaviorWarningDisabled = getConfigBool(key, value);
     } else if (key == "event_delete_warning_disabled") {
         this->eventDeleteWarningDisabled = getConfigBool(key, value);
+    } else if (key == "event_overlay_enabled") {
+        this->eventOverlayEnabled = getConfigBool(key, value);
     } else if (key == "check_for_updates") {
         this->checkForUpdates = getConfigBool(key, value);
     } else if (key == "last_update_check_time") {
@@ -479,6 +481,7 @@ QMap<QString, QString> PorymapConfig::getKeyValueMap() {
     map.insert("project_settings_tab", QString::number(this->projectSettingsTab));
     map.insert("warp_behavior_warning_disabled", QString::number(this->warpBehaviorWarningDisabled));
     map.insert("event_delete_warning_disabled", QString::number(this->eventDeleteWarningDisabled));
+    map.insert("event_overlay_enabled", QString::number(this->eventOverlayEnabled));
     map.insert("check_for_updates", QString::number(this->checkForUpdates));
     map.insert("last_update_check_time", this->lastUpdateCheckTime.toUTC().toString());
     map.insert("last_update_check_version", this->lastUpdateCheckVersion.toString());

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -136,14 +136,14 @@ void Editor::setEditMode(EditMode editMode) {
         break;
     default:
         current_view = nullptr;
-        return;
+        break;
     }
 
     map_item->setEditsEnabled(this->editMode != EditMode::Connections);
     map_item->draw();
     collision_item->draw();
 
-    current_view->setVisible(true);
+    if (current_view) current_view->setVisible(true);
 
     updateBorderVisibility();
 

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -148,15 +148,14 @@ void Editor::setEditMode(EditMode editMode) {
     updateBorderVisibility();
 
     QUndoStack *editStack = this->map ? this->map->editHistory() : nullptr;
-    bool usesCursor = false;
-    if (getEditingLayout()) {
-        if (this->layout) editStack = &this->layout->editHistory;
-        usesCursor = true;
-        setMapEditingButtonsEnabled(true);
+    bool editingLayout = getEditingLayout();
+    if (editingLayout && this->layout) {
+        editStack = &this->layout->editHistory;
     }
     this->cursorMapTileRect->setSingleTileMode();
-    this->cursorMapTileRect->setActive(usesCursor);
+    this->cursorMapTileRect->setActive(editingLayout);
     this->editGroup.setActiveStack(editStack);
+    setMapEditingButtonsEnabled(editingLayout);
 
     if (this->editMode == EditMode::Events || oldEditMode == EditMode::Events) {
         // When switching to or from the Events tab the opacity of the events changes. Redraw the events to reflect that change.

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -523,16 +523,10 @@ void MainWindow::loadUserSettings() {
     ui->actionCursor_Tile_Outline->setChecked(porymapConfig.showCursorTile);
     this->editor->settings->cursorTileRectEnabled = porymapConfig.showCursorTile;
 
-    // Border
-    ui->checkBox_ToggleBorder->setChecked(porymapConfig.showBorder);
-
     // Grid
     const QSignalBlocker b_Grid(ui->checkBox_ToggleGrid);
     ui->actionShow_Grid->setChecked(porymapConfig.showGrid);
     ui->checkBox_ToggleGrid->setChecked(porymapConfig.showGrid);
-
-    // Mirror connections
-    ui->checkBox_MirrorConnections->setChecked(porymapConfig.mirrorConnectingMaps);
 
     // Collision opacity/transparency
     const QSignalBlocker b_CollisionTransparency(ui->horizontalSlider_CollisionTransparency);
@@ -552,6 +546,10 @@ void MainWindow::loadUserSettings() {
     const QSignalBlocker b_CollisionZoom(ui->horizontalSlider_CollisionZoom);
     ui->horizontalSlider_MetatileZoom->setValue(porymapConfig.metatilesZoom);
     ui->horizontalSlider_CollisionZoom->setValue(porymapConfig.collisionZoom);
+
+    ui->checkBox_MirrorConnections->setChecked(porymapConfig.mirrorConnectingMaps);
+    ui->checkBox_ToggleBorder->setChecked(porymapConfig.showBorder);
+    ui->actionShow_Events_In_Map_View->setChecked(porymapConfig.eventOverlayEnabled);
 
     setTheme(porymapConfig.theme);
     setDivingMapsVisible(porymapConfig.showDiveEmergeMaps);
@@ -1765,14 +1763,20 @@ void MainWindow::on_mapViewTab_tabBarClicked(int index)
     if (index != oldIndex)
         Scripting::cb_MapViewTabChanged(oldIndex, index);
 
+    static const QMap<int, Editor::EditMode> tabIndexToEditMode = {
+        {MapViewTab::Metatiles, Editor::EditMode::Metatiles},
+        {MapViewTab::Collision, Editor::EditMode::Collision},
+        {MapViewTab::Prefabs,   Editor::EditMode::Metatiles},
+    };
+    if (tabIndexToEditMode.contains(index)) {
+        editor->setEditMode(tabIndexToEditMode.value(index));
+    }
+
     if (index == MapViewTab::Metatiles) {
-        editor->setEditingMetatiles();
         refreshMetatileViews();
     } else if (index == MapViewTab::Collision) {
-        editor->setEditingCollision();
         refreshCollisionSelector();
     } else if (index == MapViewTab::Prefabs) {
-        editor->setEditingMetatiles();
         if (projectConfig.prefabFilepath.isEmpty() && !projectConfig.prefabImportPrompted) {
             // User hasn't set up prefabs and hasn't been prompted before.
             // Ask if they'd like to import the default prefabs file.
@@ -1799,19 +1803,26 @@ void MainWindow::on_mainTabBar_tabBarClicked(int index)
     };
     ui->mainStackedWidget->setCurrentIndex(tabIndexToStackIndex.value(index));
 
+    static const QMap<int, Editor::EditMode> tabIndexToEditMode = {
+        // MainTab::Map itself has no edit mode, depends on mapViewTab.
+        {MainTab::Events,      Editor::EditMode::Events},
+        {MainTab::Header,      Editor::EditMode::Header},
+        {MainTab::Connections, Editor::EditMode::Connections},
+        {MainTab::WildPokemon, Editor::EditMode::Encounters},
+    };
+    if (tabIndexToEditMode.contains(index)) {
+        editor->setEditMode(tabIndexToEditMode.value(index));
+    }
+
     if (index == MainTab::Map) {
         ui->stackedWidget_MapEvents->setCurrentIndex(0);
         on_mapViewTab_tabBarClicked(ui->mapViewTab->currentIndex());
         clickToolButtonFromEditAction(editor->mapEditAction);
     } else if (index == MainTab::Events) {
         ui->stackedWidget_MapEvents->setCurrentIndex(1);
-        editor->setEditingEvents();
         clickToolButtonFromEditAction(editor->eventEditAction);
     } else if (index == MainTab::Connections) {
-        editor->setEditingConnections();
         ui->graphicsView_Connections->setFocus(); // Avoid opening tab with focus on something editable
-    } else if (index == MainTab::WildPokemon) {
-        editor->setEditingEncounters();
     }
 
     if (!editor->map) return;
@@ -1859,6 +1870,11 @@ void MainWindow::on_actionCursor_Tile_Outline_triggered()
         this->editor->cursorMapTileRect->setVisible(enabled && this->editor->cursorMapTileRect->getActive());
         ui->graphicsView_Map->scene()->update();
     }
+}
+
+void MainWindow::on_actionShow_Events_In_Map_View_triggered() {
+    porymapConfig.eventOverlayEnabled = ui->actionShow_Events_In_Map_View->isChecked();
+    this->editor->redrawAllEvents();
 }
 
 void MainWindow::on_actionShow_Grid_triggered() {


### PR DESCRIPTION
Adds a `View > Show Events in Map View` setting that will show a transparent overlay of the events while on the `Map` or `Connections` tabs.

Closes #620 