### PR TITLE
Combine parsing error messages

### DIFF
--- a/include/core/parseutil.h
+++ b/include/core/parseutil.h
@@ -44,25 +44,24 @@ class ParseUtil
 public:
     ParseUtil();
     void set_root(const QString &dir);
-    static QString readTextFile(const QString &path);
+    static QString readTextFile(const QString &path, QString *error = nullptr);
     void invalidateTextFile(const QString &path);
     static int textFileLineCount(const QString &path);
     QList<QStringList> parseAsm(const QString &filename);
     QStringList readCArray(const QString &filename, const QString &label);
     QMap<QString, QStringList> readCArrayMulti(const QString &filename);
-    QMap<QString, QString> readNamedIndexCArray(const QString &text, const QString &label);
+    QMap<QString, QString> readNamedIndexCArray(const QString &text, const QString &label, QString *error = nullptr);
     QString readCIncbin(const QString &text, const QString &label);
     QMap<QString, QString> readCIncbinMulti(const QString &filepath);
     QStringList readCIncbinArray(const QString &filename, const QString &label);
-    QMap<QString, int> readCDefinesByRegex(const QString &filename, const QStringList &regexList);
-    QMap<QString, int> readCDefinesByName(const QString &filename, const QStringList &names);
-    QStringList readCDefineNames(const QString &filename, const QStringList &regexList);
+    QMap<QString, int> readCDefinesByRegex(const QString &filename, const QStringList &regexList, QString *error = nullptr);
+    QMap<QString, int> readCDefinesByName(const QString &filename, const QStringList &names, QString *error = nullptr);
+    QStringList readCDefineNames(const QString &filename, const QStringList &regexList, QString *error = nullptr);
     tsl::ordered_map<QString, QHash<QString, QString>> readCStructs(const QString &, const QString & = "", const QHash<int, QString>& = {});
     QList<QStringList> getLabelMacros(const QList<QStringList>&, const QString&);
     QStringList getLabelValues(const QList<QStringList>&, const QString&);
-    bool tryParseJsonFile(QJsonDocument *out, const QString &filepath);
-    bool tryParseOrderedJsonFile(poryjson::Json::object *out, const QString &filepath);
-    bool ensureFieldsExist(const QJsonObject &obj, const QList<QString> &fields);
+    bool tryParseJsonFile(QJsonDocument *out, const QString &filepath, QString *error = nullptr);
+    bool tryParseOrderedJsonFile(poryjson::Json::object *out, const QString &filepath, QString *error = nullptr);
 
     // Returns the 1-indexed line number for the definition of scriptLabel in the scripts file at filePath.
     // Returns 0 if a definition for scriptLabel cannot be found.
@@ -102,8 +101,8 @@ private:
         QMap<QString,QString> expressions; // Map of all define names encountered to their expressions
         QStringList filteredNames; // List of define names that matched the search text, in the order that they were encountered
     };
-    ParsedDefines readCDefines(const QString &filename, const QStringList &filterList, bool useRegex);
-    QMap<QString, int> evaluateCDefines(const QString &filename, const QStringList &filterList, bool useRegex);
+    ParsedDefines readCDefines(const QString &filename, const QStringList &filterList, bool useRegex, QString *error);
+    QMap<QString, int> evaluateCDefines(const QString &filename, const QStringList &filterList, bool useRegex, QString *error);
     bool defineNameMatchesFilter(const QString &name, const QStringList &filterList) const;
     bool defineNameMatchesFilter(const QString &name, const QList<QRegularExpression> &filterList) const;
 

--- a/include/lib/orderedjson.h
+++ b/include/lib/orderedjson.h
@@ -182,15 +182,15 @@ public:
 
     // Parse. If parse fails, return Json() and assign an error message to err.
     static Json parse(const QString & in,
-                      QString & err,
+                      QString * err = nullptr,
                       JsonParse strategy = JsonParse::STANDARD);
     static Json parse(const char * in,
-                      QString & err,
+                      QString * err = nullptr,
                       JsonParse strategy = JsonParse::STANDARD) {
         if (in) {
             return parse(QString(in), err, strategy);
         } else {
-            err = "null input";
+            if (err) *err = "null input";
             return nullptr;
         }
     }

--- a/src/lib/orderedjson.cpp
+++ b/src/lib/orderedjson.cpp
@@ -393,7 +393,7 @@ struct JsonParser final {
      */
     const QString &str;
     int i;
-    QString &err;
+    QString *err;
     bool failed;
     const JsonParse strategy;
 
@@ -407,8 +407,8 @@ struct JsonParser final {
 
     template <typename T>
     T fail(QString &&msg, const T err_ret) {
-        if (!failed)
-            err = std::move(msg);
+        if (!failed && err)
+            *err = std::move(msg);
         failed = true;
         return err_ret;
     }
@@ -775,7 +775,7 @@ struct JsonParser final {
 };
 }//namespace {
 
-Json Json::parse(const QString &in, QString &err, JsonParse strategy) {
+Json Json::parse(const QString &in, QString *err, JsonParse strategy) {
     JsonParser parser { in, 0, err, false, strategy };
     Json result = parser.parse_json(0);
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -915,7 +915,7 @@ void MainWindow::setLayoutOnlyMode(bool layoutOnly) {
     this->ui->mainTabBar->setTabEnabled(MainTab::Events, mapEditingEnabled);
     this->ui->mainTabBar->setTabEnabled(MainTab::Header, mapEditingEnabled);
     this->ui->mainTabBar->setTabEnabled(MainTab::Connections, mapEditingEnabled);
-    this->ui->mainTabBar->setTabEnabled(MainTab::WildPokemon, mapEditingEnabled);
+    this->ui->mainTabBar->setTabEnabled(MainTab::WildPokemon, mapEditingEnabled && editor->project->wildEncountersLoaded);
 
     this->ui->comboBox_LayoutSelector->setEnabled(mapEditingEnabled);
 }

--- a/src/ui/prefab.cpp
+++ b/src/ui/prefab.cpp
@@ -27,8 +27,12 @@ void Prefab::loadPrefabs() {
     QJsonDocument prefabDoc;
 
     QString validPath = Project::getExistingFilepath(filepath);
-    if (validPath.isEmpty() || !parser.tryParseJsonFile(&prefabDoc, validPath)) {
-        logError(QString("Failed to read prefab data from %1").arg(filepath));
+    if (validPath.isEmpty())
+        return;
+
+    QString error;
+    if (!parser.tryParseJsonFile(&prefabDoc, validPath, &error)) {
+        logError(QString("Failed to read prefab data from %1: %2").arg(filepath).arg(error));
         return;
     }
     filepath = validPath;

--- a/src/ui/regionmapeditor.cpp
+++ b/src/ui/regionmapeditor.cpp
@@ -120,26 +120,20 @@ bool RegionMapEditor::saveRegionMapEntries() {
 void buildEmeraldDefaults(poryjson::Json &json) {
     ParseUtil parser;
     QString emeraldDefault = parser.readTextFile(":/text/region_map_default_emerald.json");
-
-    QString err;
-    json = poryjson::Json::parse(emeraldDefault, err);
+    json = poryjson::Json::parse(emeraldDefault);
 }
 
 void buildRubyDefaults(poryjson::Json &json) {
     ParseUtil parser;
     QString emeraldDefault = parser.readTextFile(":/text/region_map_default_ruby.json");
-
-    QString err;
-    json = poryjson::Json::parse(emeraldDefault, err);
+    json = poryjson::Json::parse(emeraldDefault);
 }
 
 void buildFireredDefaults(poryjson::Json &json) {
 
     ParseUtil parser;
     QString fireredDefault = parser.readTextFile(":/text/region_map_default_firered.json");    
-
-    QString err;
-    json = poryjson::Json::parse(fireredDefault, err);
+    json = poryjson::Json::parse(fireredDefault);
 }
 
 poryjson::Json RegionMapEditor::buildDefaultJson() {
@@ -199,8 +193,7 @@ bool RegionMapEditor::buildConfigDialog() {
         poryjson::Json::object newJson;
         poryjson::Json::array mapArr;
         for (auto item : regionMapList->findItems("*", Qt::MatchWildcard)) {
-            QString err;
-            poryjson::Json itemJson = poryjson::Json::parse(item->data(Qt::UserRole).toString(), err);
+            poryjson::Json itemJson = poryjson::Json::parse(item->data(Qt::UserRole).toString());
             mapArr.append(itemJson);
         }
         newJson["region_maps"] = mapArr;
@@ -213,8 +206,7 @@ bool RegionMapEditor::buildConfigDialog() {
     connect(regionMapList, &QListWidget::itemDoubleClicked, [this, &rmConfigJsonUpdate, updateMapList, regionMapList](QListWidgetItem *item) {
         int itemIndex = regionMapList->row(item);
 
-        QString err;
-        poryjson::Json clickedJson = poryjson::Json::parse(item->data(Qt::UserRole).toString(), err);
+        poryjson::Json clickedJson = poryjson::Json::parse(item->data(Qt::UserRole).toString());
 
         RegionMapPropertiesDialog dialog(this);
         dialog.setProject(this->project);


### PR DESCRIPTION
Closes #589 
Also fixes a regression that was re-enabling the `Wild Pokemon` tab if it had been disabled due to a parsing error.