### PR TITLE
Add in-game reload message

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -87,6 +87,7 @@ public:
         this->lastUpdateCheckVersion = porymapVersion;
         this->rateLimitTimes.clear();
         this->eventSelectionShapeMode = QGraphicsPixmapItem::MaskShape;
+        this->shownInGameReloadMessage = false;
     }
     void addRecentProject(QString project);
     void setRecentProjects(QStringList projects);
@@ -146,6 +147,7 @@ public:
     QByteArray wildMonChartGeometry;
     QByteArray newMapDialogGeometry;
     QByteArray newLayoutDialogGeometry;
+    bool shownInGameReloadMessage;
 
 protected:
     virtual QString getConfigFilepath() override;

--- a/include/editor.h
+++ b/include/editor.h
@@ -57,9 +57,8 @@ public:
     GridSettings gridSettings;
 
     void setProject(Project * project);
-    void save();
-    void saveProject();
-    void saveUiFields();
+    void saveAll();
+    void saveCurrent();
     void saveEncounterTabData();
 
     void closeProject();
@@ -204,6 +203,7 @@ private:
 
     EditMode editMode = EditMode::None;
 
+    void save(bool currentOnly);
     void clearMap();
     void clearMetatileSelector();
     void clearMovementPermissionSelector();

--- a/include/mainwindow.h
+++ b/include/mainwindow.h
@@ -175,7 +175,7 @@ private slots:
     void on_action_Reload_Project_triggered();
     void on_action_Close_Project_triggered();
     void on_action_Save_Project_triggered();
-    void save(bool all = true);
+    void save(bool currentOnly = false);
 
     void openWarpMap(QString map_name, int event_id, Event::Group event_group);
 

--- a/include/mainwindow.h
+++ b/include/mainwindow.h
@@ -175,6 +175,7 @@ private slots:
     void on_action_Reload_Project_triggered();
     void on_action_Close_Project_triggered();
     void on_action_Save_Project_triggered();
+    void save(bool all = true);
 
     void openWarpMap(QString map_name, int event_id, Event::Group event_group);
 

--- a/include/project.h
+++ b/include/project.h
@@ -167,13 +167,13 @@ public:
     void loadTilesetMetatileLabels(Tileset*);
     void readTilesetPaths(Tileset* tileset);
 
+    void saveAll();
+    void saveGlobalData();
     void saveLayout(Layout *);
     void saveLayoutBlockdata(Layout *);
     void saveLayoutBorder(Layout *);
     void writeBlockdata(QString, const Blockdata &);
-    void saveAllMaps();
-    void saveMap(Map *);
-    void saveAllDataStructures();
+    void saveMap(Map *map, bool skipLayout = false);
     void saveConfig();
     void saveMapLayouts();
     void saveMapGroups();

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -422,6 +422,8 @@ void PorymapConfig::parseConfigKeyValue(QString key, QString value) {
         } else {
             logWarn(QString("Invalid config value for %1: '%2'. Must be 'mask' or 'bounding_rect'.").arg(key).arg(value));
         }
+    } else if (key == "shown_in_game_reload_message") {
+        this->shownInGameReloadMessage = getConfigBool(key, value);
     } else {
         logWarn(QString("Invalid config key found in config file %1: '%2'").arg(this->getConfigFilepath()).arg(key));
     }
@@ -492,6 +494,7 @@ QMap<QString, QString> PorymapConfig::getKeyValueMap() {
             map.insert("rate_limit_time/" + i.key().toString(), time.toUTC().toString());
     }
     map.insert("event_selection_shape_mode", (this->eventSelectionShapeMode == QGraphicsPixmapItem::MaskShape) ? "mask" : "bounding_rect");
+    map.insert("shown_in_game_reload_message", this->shownInGameReloadMessage ? "1" : "0");
     
     return map;
 }

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -69,28 +69,30 @@ Editor::~Editor()
     closeProject();
 }
 
-void Editor::saveProject() {
-    if (project) {
-        saveUiFields();
-        project->saveAllMaps();
-        project->saveAllDataStructures();
-    }
+void Editor::saveCurrent() {
+    save(true);
 }
 
-void Editor::save() {
-    if (this->project && this->map) {
-        saveUiFields();
-        this->project->saveMap(this->map);
-        this->project->saveAllDataStructures();
-    }
-    else if (this->project && this->layout) {
-        this->project->saveLayout(this->layout);
-        this->project->saveAllDataStructures();
-    }
+void Editor::saveAll() {
+    save(false);
 }
 
-void Editor::saveUiFields() {
+void Editor::save(bool currentOnly) {
+    if (!this->project)
+        return;
+
     saveEncounterTabData();
+
+    if (currentOnly) {
+        if (this->map) {
+            this->project->saveMap(this->map);
+        } else if (this->layout) {
+            this->project->saveLayout(this->layout);
+        }
+        this->project->saveGlobalData();
+    } else {
+        this->project->saveAll();
+    }
 }
 
 void Editor::setProject(Project * project) {
@@ -651,6 +653,9 @@ void Editor::configureEncounterJSON(QWidget *window) {
 }
 
 void Editor::saveEncounterTabData() {
+    if (!this->map || !this->project)
+        return;
+
     // This function does not save to disk so it is safe to use before user clicks Save.
     QStackedWidget *stack = ui->stackedWidget_WildMons;
     QComboBox *labelCombo = ui->comboBox_EncounterGroupLabel;

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1307,12 +1307,6 @@ void MainWindow::onNewMapCreated(Map *newMap, const QString &groupName) {
         addNewEvent(Event::Type::HealLocation);
     }
 
-    // TODO: Creating a new map shouldn't be automatically saved.
-    //       For one, it takes away the option to discard the new map.
-    //       For two, if the new map uses an existing layout, any unsaved changes to that layout will also be saved.
-    editor->project->saveMap(newMap);
-    editor->project->saveAllDataStructures();
-
     // Add new map to the map lists
     this->mapGroupModel->insertMapItem(newMap->name(), groupName);
     this->mapLocationModel->insertMapItem(newMap->name(), newMap->header()->location());
@@ -1328,7 +1322,12 @@ void MainWindow::onNewMapCreated(Map *newMap, const QString &groupName) {
         ui->comboBox_EmergeMap->insertItem(mapIndex, newMap->name());
     }
 
-    userSetMap(newMap->name());
+    if (userSetMap(newMap->name())) {
+        // TODO: Creating a new map shouldn't be automatically saved.
+        //       For one, it takes away the option to discard the new map.
+        //       For two, if the new map uses an existing layout, any unsaved changes to that layout will also be saved.
+        save(true);
+    }
 }
 
 // Called any time a new layout is created (including as a byproduct of creating a new map)
@@ -1551,14 +1550,19 @@ void MainWindow::updateMapList() {
 }
 
 void MainWindow::on_action_Save_Project_triggered() {
-    editor->saveProject();
-    updateWindowTitle();
-    updateMapList();
-    saveGlobalConfigs();
+    save(false);
 }
 
 void MainWindow::on_action_Save_triggered() {
-    editor->save();
+    save(true);
+}
+
+void MainWindow::save(bool currentOnly) {
+    if (currentOnly) {
+        this->editor->saveCurrent();
+    } else {
+        this->editor->saveAll();
+    }
     updateWindowTitle();
     updateMapList();
     saveGlobalConfigs();
@@ -3008,7 +3012,7 @@ bool MainWindow::closeProject() {
 
         auto reply = msgBox.exec();
         if (reply == QMessageBox::Yes) {
-            editor->saveProject();
+            save();
         } else if (reply == QMessageBox::No) {
             logWarn("Closing project with unsaved changes.");
         } else if (reply == QMessageBox::Cancel) {

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1565,6 +1565,15 @@ void MainWindow::save(bool currentOnly) {
     }
     updateWindowTitle();
     updateMapList();
+
+    if (!porymapConfig.shownInGameReloadMessage) {
+        // Show a one-time warning that the user may need to reload their map to see their new changes.
+        static const QString message = QStringLiteral("Reload your map in-game!\n\nIf your game is currently saved on a map you have edited, "
+                                                      "the changes may not appear until you leave the map and return.");
+        InfoMessage::show(message, this);
+        porymapConfig.shownInGameReloadMessage = true;
+    }
+
     saveGlobalConfigs();
 }
 

--- a/src/project.cpp
+++ b/src/project.cpp
@@ -1155,12 +1155,17 @@ void Project::writeBlockdata(QString path, const Blockdata &blockdata) {
     }
 }
 
-void Project::saveAllMaps() {
-    for (auto *map : mapCache.values())
-        saveMap(map);
+void Project::saveAll() {
+    for (auto map : this->mapCache) {
+        saveMap(map, true); // Avoid double-saving the layouts
+    }
+    for (auto layout : this->mapLayouts) {
+        saveLayout(layout);
+    }
+    saveGlobalData();
 }
 
-void Project::saveMap(Map *map) {
+void Project::saveMap(Map *map, bool skipLayout) {
     // Create/Modify a few collateral files for brand new maps.
     const QString folderPath = projectConfig.getFilePath(ProjectFilePath::data_map_folders) + map->name();
     const QString fullPath = QString("%1/%2").arg(this->root).arg(folderPath);
@@ -1289,12 +1294,15 @@ void Project::saveMap(Map *map) {
     jsonDoc.dump(&mapFile);
     mapFile.close();
 
-    saveLayout(map->layout());
+    if (!skipLayout) saveLayout(map->layout());
 
     map->setClean();
 }
 
 void Project::saveLayout(Layout *layout) {
+    if (!layout || !layout->loaded)
+        return;
+
     saveLayoutBorder(layout);
     saveLayoutBlockdata(layout);
 
@@ -1317,7 +1325,7 @@ void Project::updateLayout(Layout *layout) {
     }
 }
 
-void Project::saveAllDataStructures() {
+void Project::saveGlobalData() {
     saveMapLayouts();
     saveMapGroups();
     saveRegionMapSections();


### PR DESCRIPTION
Closes #680.

Also fixes some crashes and incorrect behavior introduced to `File > Save All` after the layout split.