### PR TITLE
Limit the maximum number of events

### DIFF
--- a/forms/projectsettingseditor.ui
+++ b/forms/projectsettingseditor.ui
@@ -1342,6 +1342,29 @@
                 </widget>
                </item>
                <item>
+                <widget class="QWidget" name="widget_MaxEvents" native="true">
+                 <layout class="QFormLayout" name="formLayout_4">
+                  <item row="0" column="0">
+                   <widget class="QLabel" name="label_MaxEvents">
+                    <property name="text">
+                     <string>Maximum Events per Event group</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="0" column="1">
+                   <widget class="NoScrollSpinBox" name="spinBox_MaxEvents">
+                    <property name="toolTip">
+                     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Maps cannot have more than this number of events in each event group. Object events are additionally limited by 'define_obj_event_count' on the Identifiers tab.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                    </property>
+                    <property name="minimum">
+                     <number>1</number>
+                    </property>
+                   </widget>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+               <item>
                 <widget class="QGroupBox" name="groupBox_Events">
                  <property name="title">
                   <string/>

--- a/include/config.h
+++ b/include/config.h
@@ -319,6 +319,7 @@ public:
         this->unusedTileNormal = 0x3014;
         this->unusedTileCovered = 0x0000;
         this->unusedTileSplit = 0x0000;
+        this->maxEventsPerGroup = 255;
         this->identifiers.clear();
         this->readKeys.clear();
     }
@@ -388,6 +389,7 @@ public:
     int collisionSheetWidth;
     int collisionSheetHeight;
     QList<uint32_t> warpBehaviors;
+    int maxEventsPerGroup;
 
 protected:
     virtual QString getConfigFilepath() override;

--- a/include/core/events.h
+++ b/include/core/events.h
@@ -186,9 +186,9 @@ public:
     void setIdName(QString newIdName) { this->idName = newIdName; }
     QString getIdName() const { return this->idName; }
 
-    static QString eventGroupToString(Event::Group group);
-    static QString eventTypeToString(Event::Type type);
-    static Event::Type eventTypeFromString(QString type);
+    static QString groupToString(Event::Group group);
+    static QString typeToString(Event::Type type);
+    static Event::Type typeFromString(QString type);
     static void clearIcons();
     static void setIcons();
 

--- a/include/core/map.h
+++ b/include/core/map.h
@@ -85,6 +85,7 @@ public:
     void removeEvent(Event *);
     void addEvent(Event *);
     int getIndexOfEvent(Event *) const;
+    bool hasEvent(Event *) const;
 
     void deleteConnections();
     QList<MapConnection*> getConnections() const;

--- a/include/editor.h
+++ b/include/editor.h
@@ -110,9 +110,9 @@ public:
 
     DraggablePixmapItem *addEventPixmapItem(Event *event);
     void removeEventPixmapItem(Event *event);
-    bool eventLimitReached(Map *, Event::Type);
+    bool canAddEvents(const QList<Event*> &events);
     void selectMapEvent(DraggablePixmapItem *item, bool toggle = false);
-    DraggablePixmapItem *addNewEvent(Event::Type type);
+    Event *addNewEvent(Event::Type type);
     void updateSelectedEvents();
     void duplicateSelectedEvents();
     void redrawAllEvents();
@@ -185,7 +185,6 @@ public:
     void shouldReselectEvents();
     void scaleMapView(int);
     static void openInTextEditor(const QString &path, int lineNum = 0);
-    bool eventLimitReached(Event::Type type);
     void setCollisionGraphics();
 
 public slots:

--- a/include/editor.h
+++ b/include/editor.h
@@ -111,14 +111,13 @@ public:
     DraggablePixmapItem *addEventPixmapItem(Event *event);
     void removeEventPixmapItem(Event *event);
     bool canAddEvents(const QList<Event*> &events);
-    void selectMapEvent(DraggablePixmapItem *item, bool toggle = false);
+    void selectMapEvent(Event *event, bool toggle = false);
     Event *addNewEvent(Event::Type type);
-    void updateSelectedEvents();
+    void updateEvents();
     void duplicateSelectedEvents();
     void redrawAllEvents();
     void redrawEvents(const QList<Event*> &events);
     void redrawEventPixmapItem(DraggablePixmapItem *item);
-    QList<DraggablePixmapItem *> getEventPixmapItems();
     qreal getEventOpacity(const Event *event) const;
 
     void updateCursorRectPos(int x, int y);
@@ -153,7 +152,7 @@ public:
     CurrentSelectedMetatilesPixmapItem *current_metatile_selection_item = nullptr;
     QPointer<MovementPermissionsSelector> movement_permissions_selector_item = nullptr;
 
-    QList<DraggablePixmapItem *> *selected_events = nullptr;
+    QList<Event*> selectedEvents;
     QPointer<ConnectionPixmapItem> selected_connection_item = nullptr;
     QPointer<MapConnection> connection_to_select = nullptr;
 

--- a/include/mainwindow.h
+++ b/include/mainwindow.h
@@ -332,7 +332,7 @@ private:
 
     MapHeaderForm *mapHeaderForm = nullptr;
 
-    QMap<Event::Group, DraggablePixmapItem*> lastSelectedEvent;
+    QMap<Event::Group, Event*> lastSelectedEvent;
 
     bool isProgrammaticEventTabChange;
 

--- a/include/mainwindow.h
+++ b/include/mainwindow.h
@@ -218,7 +218,6 @@ private slots:
     void on_actionMove_triggered();
     void on_actionMap_Shift_triggered();
 
-    void addNewEvent(Event::Type type);
     void tryAddEventTab(QWidget * tab);
     void displayEventTabs();
     void updateSelectedEvents();

--- a/include/project.h
+++ b/include/project.h
@@ -245,7 +245,7 @@ public:
     static int getMapDataSize(int width, int height);
     static bool mapDimensionsValid(int width, int height);
     bool calculateDefaultMapSize();
-    static int getMaxObjectEvents();
+    int getMaxEvents(Event::Group group);
     static QString getEmptyMapsecName();
     static QString getMapGroupPrefix();
 
@@ -263,6 +263,8 @@ private:
     void ignoreWatchedFileTemporarily(QString filepath);
     void recordFileChange(const QString &filepath);
 
+    int maxEventsPerGroup;
+    int maxObjectEvents;
     static int num_tiles_primary;
     static int num_tiles_total;
     static int num_metatiles_primary;
@@ -270,7 +272,6 @@ private:
     static int num_pals_total;
     static int max_map_data_size;
     static int default_map_dimension;
-    static int max_object_events;
 
 signals:
     void fileChanged(const QString &filepath);

--- a/include/project.h
+++ b/include/project.h
@@ -157,6 +157,7 @@ public:
 
     void initTopLevelMapFields();
     bool readMapJson(const QString &mapName, QJsonDocument * out);
+    bool loadMapEvent(Map *map, const QJsonObject &json, Event::Type defaultType = Event::Type::None);
     bool loadMapData(Map*);
     bool readMapLayouts();
     Layout *loadLayout(QString layoutId);

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -803,6 +803,8 @@ void ProjectConfig::parseConfigKeyValue(QString key, QString value) {
         const QStringList behaviorList = value.split(",", Qt::SkipEmptyParts);
         for (auto s : behaviorList)
             this->warpBehaviors.append(getConfigUint32(key, s));
+    } else if (key == "max_events_per_group") {
+        this->maxEventsPerGroup = getConfigInteger(key, value, 1, INT_MAX, 255);
     } else {
         logWarn(QString("Invalid config key found in config file %1: '%2'").arg(this->getConfigFilepath()).arg(key));
     }
@@ -898,6 +900,7 @@ QMap<QString, QString> ProjectConfig::getKeyValueMap() {
     for (const auto &value : this->warpBehaviors)
         warpBehaviorStrs.append("0x" + QString("%1").arg(value, 2, 16, QChar('0')).toUpper());
     map.insert("warp_behaviors", warpBehaviorStrs.join(","));
+    map.insert("max_events_per_group", QString::number(this->maxEventsPerGroup));
 
     return map;
 }

--- a/src/core/editcommands.cpp
+++ b/src/core/editcommands.cpp
@@ -328,10 +328,7 @@ void EventCreate::redo() {
 
     map->addEvent(event);
     editor->addEventPixmapItem(event);
-
-    // select this event
-    editor->selected_events->clear();
-    editor->selectMapEvent(event->getPixmapItem());
+    editor->selectMapEvent(event);
 }
 
 void EventCreate::undo() {
@@ -374,9 +371,9 @@ void EventDelete::redo() {
         editor->removeEventPixmapItem(event);
     }
 
-    editor->selected_events->clear();
+    editor->selectedEvents.clear();
     if (nextSelectedEvent)
-        editor->selected_events->append(nextSelectedEvent->getPixmapItem());
+        editor->selectedEvents.append(nextSelectedEvent);
     editor->shouldReselectEvents();
 }
 
@@ -386,11 +383,7 @@ void EventDelete::undo() {
         editor->addEventPixmapItem(event);
     }
 
-    // select these events
-    editor->selected_events->clear();
-    for (Event *event : selectedEvents) {
-        editor->selected_events->append(event->getPixmapItem());
-    }
+    editor->selectedEvents = selectedEvents;
     editor->shouldReselectEvents();
 
     QUndoCommand::undo();
@@ -427,11 +420,7 @@ void EventDuplicate::redo() {
         editor->addEventPixmapItem(event);
     }
 
-    // select these events
-    editor->selected_events->clear();
-    for (Event *event : selectedEvents) {
-        editor->selected_events->append(event->getPixmapItem());
-    }
+    editor->selectedEvents = selectedEvents;
     editor->shouldReselectEvents();
 }
 

--- a/src/core/events.cpp
+++ b/src/core/events.cpp
@@ -75,70 +75,36 @@ void Event::modify() {
     this->map->modify();
 }
 
-QString Event::eventGroupToString(Event::Group group) {
-    switch (group) {
-    case Event::Group::Object:
-        return "Object";
-    case Event::Group::Warp:
-        return "Warp";
-    case Event::Group::Coord:
-        return "Trigger";
-    case Event::Group::Bg:
-        return "BG";
-    case Event::Group::Heal:
-        return "Heal Location";
-    default:
-        return "";
-    }
+const QMap<Event::Group, QString> groupToStringMap = {
+    {Event::Group::Object, "Object"},
+    {Event::Group::Warp, "Warp"},
+    {Event::Group::Coord, "Trigger"},
+    {Event::Group::Bg, "BG"},
+    {Event::Group::Heal, "Heal Location"},
+};
+
+QString Event::groupToString(Event::Group group) {
+    return groupToStringMap.value(group);
 }
 
-QString Event::eventTypeToString(Event::Type type) {
-    switch (type) {
-    case Event::Type::Object:
-        return "event_object";
-    case Event::Type::CloneObject:
-        return "event_clone_object";
-    case Event::Type::Warp:
-        return "event_warp";
-    case Event::Type::Trigger:
-        return "event_trigger";
-    case Event::Type::WeatherTrigger:
-        return "event_weather_trigger";
-    case Event::Type::Sign:
-        return "event_sign";
-    case Event::Type::HiddenItem:
-        return "event_hidden_item";
-    case Event::Type::SecretBase:
-        return "event_secret_base";
-    case Event::Type::HealLocation:
-        return "event_heal_location";
-    default:
-        return "";
-    }
+const QMap<Event::Type, QString> typeToStringMap = {
+    {Event::Type::Object, "object"},
+    {Event::Type::CloneObject, "clone_object"},
+    {Event::Type::Warp, "warp"},
+    {Event::Type::Trigger, "trigger"},
+    {Event::Type::WeatherTrigger, "weather"},
+    {Event::Type::Sign, "sign"},
+    {Event::Type::HiddenItem, "hidden_item"},
+    {Event::Type::SecretBase, "secret_base"},
+    {Event::Type::HealLocation, "heal_location"},
+};
+
+QString Event::typeToString(Event::Type type) {
+    return typeToStringMap.value(type);
 }
 
-Event::Type Event::eventTypeFromString(QString type) {
-    if (type == "event_object") {
-        return Event::Type::Object;
-    } else if (type == "event_clone_object") {
-        return Event::Type::CloneObject;
-    } else if (type == "event_warp") {
-        return Event::Type::Warp;
-    } else if (type == "event_trigger") {
-        return Event::Type::Trigger;
-    } else if (type == "event_weather_trigger") {
-        return Event::Type::WeatherTrigger;
-    } else if (type == "event_sign") {
-        return Event::Type::Sign;
-    } else if (type == "event_hidden_item") {
-        return Event::Type::HiddenItem;
-    } else if (type == "event_secret_base") {
-        return Event::Type::SecretBase;
-    } else if (type == "event_heal_location") {
-        return Event::Type::HealLocation;
-    } else {
-        return Event::Type::None;
-    }
+Event::Type Event::typeFromString(QString type) {
+    return typeToStringMap.key(type, Event::Type::None);
 }
 
 void Event::loadPixmap(Project *) {

--- a/src/core/events.cpp
+++ b/src/core/events.cpp
@@ -155,6 +155,7 @@ Event *ObjectEvent::duplicate() const {
     copy->setX(this->getX());
     copy->setY(this->getY());
     copy->setElevation(this->getElevation());
+    copy->setIdName(this->getIdName());
     copy->setGfx(this->getGfx());
     copy->setMovement(this->getMovement());
     copy->setRadiusX(this->getRadiusX());
@@ -182,6 +183,9 @@ OrderedJson::object ObjectEvent::buildEventJson(Project *) {
     if (projectConfig.eventCloneObjectEnabled) {
         objectJson["type"] = "object";
     }
+    QString idName = this->getIdName();
+    if (!idName.isEmpty())
+        objectJson["local_id"] = idName;
     objectJson["graphics_id"] = this->getGfx();
     objectJson["x"] = this->getX();
     objectJson["y"] = this->getY();
@@ -202,6 +206,7 @@ bool ObjectEvent::loadFromJson(const QJsonObject &json, Project *) {
     this->setX(ParseUtil::jsonToInt(json["x"]));
     this->setY(ParseUtil::jsonToInt(json["y"]));
     this->setElevation(ParseUtil::jsonToInt(json["elevation"]));
+    this->setIdName(ParseUtil::jsonToQString(json["local_id"]));
     this->setGfx(ParseUtil::jsonToQString(json["graphics_id"]));
     this->setMovement(ParseUtil::jsonToQString(json["movement_type"]));
     this->setRadiusX(ParseUtil::jsonToInt(json["movement_range_x"]));
@@ -229,6 +234,7 @@ void ObjectEvent::setDefaultValues(Project *project) {
 }
 
 const QSet<QString> expectedObjectFields = {
+    "local_id",
     "graphics_id",
     "elevation",
     "movement_type",
@@ -334,6 +340,7 @@ Event *CloneObjectEvent::duplicate() const {
     copy->setX(this->getX());
     copy->setY(this->getY());
     copy->setElevation(this->getElevation());
+    copy->setIdName(this->getIdName());
     copy->setGfx(this->getGfx());
     copy->setTargetID(this->getTargetID());
     copy->setTargetMap(this->getTargetMap());
@@ -354,6 +361,9 @@ OrderedJson::object CloneObjectEvent::buildEventJson(Project *project) {
     OrderedJson::object cloneJson;
 
     cloneJson["type"] = "clone";
+    QString idName = this->getIdName();
+    if (!idName.isEmpty())
+        cloneJson["local_id"] = idName;
     cloneJson["graphics_id"] = this->getGfx();
     cloneJson["x"] = this->getX();
     cloneJson["y"] = this->getY();
@@ -368,6 +378,7 @@ OrderedJson::object CloneObjectEvent::buildEventJson(Project *project) {
 bool CloneObjectEvent::loadFromJson(const QJsonObject &json, Project *project) {
     this->setX(ParseUtil::jsonToInt(json["x"]));
     this->setY(ParseUtil::jsonToInt(json["y"]));
+    this->setIdName(ParseUtil::jsonToQString(json["local_id"]));
     this->setGfx(ParseUtil::jsonToQString(json["graphics_id"]));
     this->setTargetID(ParseUtil::jsonToInt(json["target_local_id"]));
 
@@ -390,6 +401,7 @@ void CloneObjectEvent::setDefaultValues(Project *project) {
 
 const QSet<QString> expectedCloneObjectFields = {
     "type",
+    "local_id",
     "graphics_id",
     "target_local_id",
     "target_map",

--- a/src/core/map.cpp
+++ b/src/core/map.cpp
@@ -229,6 +229,10 @@ int Map::getIndexOfEvent(Event *event) const {
     return m_events.value(event->getEventGroup()).indexOf(event);
 }
 
+bool Map::hasEvent(Event *event) const {
+    return getIndexOfEvent(event) >= 0;
+}
+
 void Map::deleteConnections() {
     qDeleteAll(m_ownedConnections);
     m_ownedConnections.clear();

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -2092,7 +2092,7 @@ void Editor::duplicateSelectedEvents() {
         Event *original = selected_events->at(i)->event;
         Event::Type eventType = original->getEventType();
         if (eventLimitReached(eventType)) {
-            logWarn(QString("Skipping duplication, the map limit for events of type '%1' has been reached.").arg(Event::eventTypeToString(eventType)));
+            logWarn(QString("Skipping duplication, the map limit for events of type '%1' has been reached.").arg(Event::typeToString(eventType)));
             continue;
         }
         Event *duplicate = original->duplicate();

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1039,7 +1039,7 @@ void MainWindow::openWarpMap(QString map_name, int event_id, Event::Group event_
         }
     }
     // Can still warp to this map, but can't select the specified event
-    logWarn(QString("%1 %2 doesn't exist on map '%3'").arg(Event::eventGroupToString(event_group)).arg(event_id).arg(map_name));
+    logWarn(QString("%1 %2 doesn't exist on map '%3'").arg(Event::groupToString(event_group)).arg(event_id).arg(map_name));
 }
 
 void MainWindow::displayMapProperties() {
@@ -1639,7 +1639,7 @@ void MainWindow::copy() {
                 for (auto item : events) {
                     Event *event = item->event;
                     OrderedJson::object eventContainer;
-                    eventContainer["event_type"] = Event::eventTypeToString(event->getEventType());
+                    eventContainer["event_type"] = Event::typeToString(event->getEventType());
                     OrderedJson::object eventJson = event->buildEventJson(editor->project);
                     eventContainer["event"] = eventJson;
                     eventsArray.append(eventContainer);
@@ -1751,7 +1751,7 @@ void MainWindow::paste() {
                 for (QJsonValue event : events) {
                     // paste the event to the map
                     const QString typeString = event["event_type"].toString();
-                    Event::Type type = Event::eventTypeFromString(typeString);
+                    Event::Type type = Event::typeFromString(typeString);
 
                     if (this->editor->eventLimitReached(type)) {
                         logWarn(QString("Cannot paste event, the limit for type '%1' has been reached.").arg(typeString));
@@ -2009,7 +2009,7 @@ void MainWindow::addNewEvent(Event::Type type) {
 void MainWindow::tryAddEventTab(QWidget * tab) {
     auto group = getEventGroupFromTabWidget(tab);
     if (editor->map->getNumEvents(group))
-        ui->tabWidget_EventType->addTab(tab, QString("%1s").arg(Event::eventGroupToString(group)));
+        ui->tabWidget_EventType->addTab(tab, QString("%1s").arg(Event::groupToString(group)));
 }
 
 void MainWindow::displayEventTabs() {

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1027,18 +1027,13 @@ void MainWindow::openWarpMap(QString map_name, int event_id, Event::Group event_
 
     // Select the target event.
     int index = event_id - Event::getIndexOffset(event_group);
-    Event* event = editor->map->getEvent(event_group, index);
+    Event* event = this->editor->map->getEvent(event_group, index);
     if (event) {
-        auto item = event->getPixmapItem();
-        if (item) {
-            editor->selected_events->clear();
-            editor->selected_events->append(item);
-            editor->updateSelectedEvents();
-            return;
-        }
+        this->editor->selectMapEvent(event);
+    } else {
+        // Can still warp to this map, but can't select the specified event
+        logWarn(QString("%1 %2 doesn't exist on map '%3'").arg(Event::groupToString(event_group)).arg(event_id).arg(map_name));
     }
-    // Can still warp to this map, but can't select the specified event
-    logWarn(QString("%1 %2 doesn't exist on map '%3'").arg(Event::groupToString(event_group)).arg(event_id).arg(map_name));
 }
 
 void MainWindow::displayMapProperties() {
@@ -1628,15 +1623,8 @@ void MainWindow::copy() {
                 OrderedJson::object copyObject;
                 copyObject["object"] = "events";
 
-                QList<DraggablePixmapItem *> events;
-                if (editor->selected_events && editor->selected_events->length()) {
-                    events = *editor->selected_events;
-                }
-
                 OrderedJson::array eventsArray;
-
-                for (auto item : events) {
-                    Event *event = item->event;
+                for (const auto &event : this->editor->selectedEvents) {
                     OrderedJson::object eventContainer;
                     eventContainer["event_type"] = Event::typeToString(event->getEventType());
                     OrderedJson::object eventJson = event->buildEventJson(editor->project);
@@ -1997,31 +1985,32 @@ void MainWindow::displayEventTabs() {
 }
 
 void MainWindow::updateEvents() {
-    QList<DraggablePixmapItem *> items = editor->getEventPixmapItems();
-    for (auto i = this->lastSelectedEvent.cbegin(), end = this->lastSelectedEvent.cend(); i != end; i++) {
-        if (i.value() && !items.contains(i.value()))
-            this->lastSelectedEvent.insert(i.key(), nullptr);
+    if (this->editor->map) {
+        for (auto i = this->lastSelectedEvent.begin(); i != this->lastSelectedEvent.end(); i++) {
+            if (i.value() && !this->editor->map->hasEvent(i.value()))
+                this->lastSelectedEvent.insert(i.key(), nullptr);
+        }
     }
     displayEventTabs();
     updateSelectedEvents();
 }
 
 void MainWindow::updateSelectedEvents() {
-    QList<DraggablePixmapItem *> events;
+    QList<Event*> events;
 
-    if (editor->selected_events && editor->selected_events->length()) {
-        events = *editor->selected_events;
+    if (!this->editor->selectedEvents.isEmpty()) {
+        events = this->editor->selectedEvents;
     }
     else {
-        QList<Event *> all_events;
-        if (editor->map) {
-            all_events = editor->map->getEvents();
+        QList<Event *> allEvents;
+        if (this->editor->map) {
+            allEvents = this->editor->map->getEvents();
         }
-        if (all_events.length()) {
-            DraggablePixmapItem *selectedEvent = all_events.first()->getPixmapItem();
+        if (!allEvents.isEmpty()) {
+            Event *selectedEvent = allEvents.first();
             if (selectedEvent) {
-                editor->selected_events->append(selectedEvent);
-                editor->redrawEventPixmapItem(selectedEvent);
+                this->editor->selectedEvents.append(selectedEvent);
+                this->editor->redrawEventPixmapItem(selectedEvent->getPixmapItem());
                 events.append(selectedEvent);
             }
         }
@@ -2034,12 +2023,13 @@ void MainWindow::updateSelectedEvents() {
 
     if (events.length() == 1) {
         // single selected event case
-        Event *current = events[0]->event;
+        Event *current = events.constFirst();
         Event::Group eventGroup = current->getEventGroup();
         int event_offs = Event::getIndexOffset(eventGroup);
 
-        if (eventGroup != Event::Group::None)
-            this->lastSelectedEvent.insert(eventGroup, current->getPixmapItem());
+        if (eventGroup != Event::Group::None) {
+            this->lastSelectedEvent.insert(eventGroup, current);
+        }
 
         switch (eventGroup) {
         case Event::Group::Object: {
@@ -2110,8 +2100,7 @@ void MainWindow::updateSelectedEvents() {
     this->isProgrammaticEventTabChange = false;
 
     QList<QFrame *> frames;
-    for (DraggablePixmapItem *item : events) {
-        Event *event = item->event;
+    for (auto event : events) {
         EventFrame *eventFrame = event->createEventFrame();
         eventFrame->populate(this->editor->project);
         eventFrame->initialize();
@@ -2166,7 +2155,7 @@ Event::Group MainWindow::getEventGroupFromTabWidget(QWidget *tab) {
 void MainWindow::eventTabChanged(int index) {
     if (editor->map) {
         Event::Group group = getEventGroupFromTabWidget(ui->tabWidget_EventType->widget(index));
-        DraggablePixmapItem *selectedItem = this->lastSelectedEvent.value(group, nullptr);
+        Event *selectedEvent = this->lastSelectedEvent.value(group, nullptr);
 
         switch (group) {
         case Event::Group::Object:
@@ -2189,11 +2178,8 @@ void MainWindow::eventTabChanged(int index) {
         }
 
         if (!isProgrammaticEventTabChange) {
-            if (!selectedItem) {
-                Event *event = editor->map->getEvent(group, 0);
-                if (event) selectedItem = event->getPixmapItem();
-            }
-            if (selectedItem) editor->selectMapEvent(selectedItem);
+            if (!selectedEvent) selectedEvent = this->editor->map->getEvent(group, 0);
+            this->editor->selectMapEvent(selectedEvent);
         }
     }
 

--- a/src/ui/draggablepixmapitem.cpp
+++ b/src/ui/draggablepixmapitem.cpp
@@ -8,11 +8,11 @@ static unsigned currentActionId = 0;
 
 
 void DraggablePixmapItem::updatePosition() {
-    int x = event->getPixelX();
-    int y = event->getPixelY();
+    int x = this->event->getPixelX();
+    int y = this->event->getPixelY();
     setX(x);
     setY(y);
-    if (editor->selected_events && editor->selected_events->contains(this)) {
+    if (this->editor->selectedEvents.contains(this->event)) {
         setZValue(event->getY() + 1);
     } else {
         setZValue(event->getY());
@@ -40,10 +40,10 @@ void DraggablePixmapItem::mousePressEvent(QGraphicsSceneMouseEvent *mouse) {
     this->lastPos = Metatile::coordFromPixmapCoord(mouse->scenePos());
 
     bool selectionToggle = mouse->modifiers() & Qt::ControlModifier;
-    if (selectionToggle || !editor->selected_events->contains(this)) {
+    if (selectionToggle || !this->editor->selectedEvents.contains(this->event)) {
         // User is either toggling this selection on/off as part of a group selection,
         // or they're newly selecting just this item.
-        this->editor->selectMapEvent(this, selectionToggle);
+        this->editor->selectMapEvent(this->event, selectionToggle);
     } else {
         // This item is already selected and the user isn't toggling the selection, so there are 4 possibilities:
         // 1. This is the only selected event, and the selection is pointless.
@@ -84,10 +84,8 @@ void DraggablePixmapItem::mouseMoveEvent(QGraphicsSceneMouseEvent *mouse) {
     emit this->editor->map_item->hoveredMapMetatileChanged(pos);
 
     QList <Event *> selectedEvents;
-    if (editor->selected_events->contains(this)) {
-        for (DraggablePixmapItem *item : *editor->selected_events) {
-            selectedEvents.append(item->event);
-        }
+    if (this->editor->selectedEvents.contains(this->event)) {
+        selectedEvents = this->editor->selectedEvents;
     } else {
         selectedEvents.append(this->event);
     }
@@ -103,7 +101,7 @@ void DraggablePixmapItem::mouseReleaseEvent(QGraphicsSceneMouseEvent *mouse) {
     if (this->releaseSelectionQueued) {
         this->releaseSelectionQueued = false;
         if (Metatile::coordFromPixmapCoord(mouse->scenePos()) == this->lastPos)
-            this->editor->selectMapEvent(this);
+            this->editor->selectMapEvent(this->event);
     }
 }
 

--- a/src/ui/projectsettingseditor.cpp
+++ b/src/ui/projectsettingseditor.cpp
@@ -135,6 +135,7 @@ void ProjectSettingsEditor::initUi() {
     ui->spinBox_UnusedTileNormal->setMaximum(Tile::maxValue);
     ui->spinBox_UnusedTileCovered->setMaximum(Tile::maxValue);
     ui->spinBox_UnusedTileSplit->setMaximum(Tile::maxValue);
+    ui->spinBox_MaxEvents->setMaximum(INT_MAX);
 
     // The values for some of the settings we provide in this window can be determined using constants in the user's projects.
     // If the user has these constants we disable these settings in the UI -- they can modify them using their constants.
@@ -464,6 +465,7 @@ void ProjectSettingsEditor::refresh() {
     ui->spinBox_UnusedTileNormal->setValue(projectConfig.unusedTileNormal);
     ui->spinBox_UnusedTileCovered->setValue(projectConfig.unusedTileCovered);
     ui->spinBox_UnusedTileSplit->setValue(projectConfig.unusedTileSplit);
+    ui->spinBox_MaxEvents->setValue(projectConfig.maxEventsPerGroup);
 
     // Set (and sync) border metatile IDs
     this->setBorderMetatileIds(false, projectConfig.newMapBorderMetatileIds);
@@ -538,6 +540,7 @@ void ProjectSettingsEditor::save() {
     projectConfig.unusedTileNormal = ui->spinBox_UnusedTileNormal->value();
     projectConfig.unusedTileCovered = ui->spinBox_UnusedTileCovered->value();
     projectConfig.unusedTileSplit = ui->spinBox_UnusedTileSplit->value();
+    projectConfig.maxEventsPerGroup = ui->spinBox_MaxEvents->value();
 
     // Save line edit settings
     projectConfig.prefabFilepath = ui->lineEdit_PrefabsPath->text();


### PR DESCRIPTION
Porymap already enforces a maximum of `OBJ_EVENT_TEMPLATES_COUNT` on the number of object events, but doesn't limit any other event group. The default data types in the projects limit the number of events to 255. It shouldn't be common, but I did see someone actually hit this limit and get confused why things started breaking down, so Porymap enforces this limit now (and provides a setting to update the limit if users change the data types).

Also fixes an issue where duplicating or pasting multiple events at once could bypass the `OBJ_EVENT_TEMPLATES_COUNT` limit.

Internally this also does some refactoring in preparation for future changes to events, like supporting the `local_id` field and possibly customizable event types.