### PR TITLE
Event speed improvements

### DIFF
--- a/forms/preferenceeditor.ui
+++ b/forms/preferenceeditor.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>522</width>
-    <height>493</height>
+    <width>530</width>
+    <height>432</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -19,244 +19,302 @@
      <number>9</number>
     </property>
     <item>
-     <widget class="QGroupBox" name="groupBox">
-      <property name="title">
-       <string>Miscellaneous</string>
+     <widget class="QTabWidget" name="tabWidget">
+      <property name="currentIndex">
+       <number>0</number>
       </property>
-      <layout class="QVBoxLayout" name="verticalLayout_2">
-       <item>
-        <widget class="QCheckBox" name="checkBox_MonitorProjectFiles">
-         <property name="toolTip">
-          <string>If checked, a prompt to reload your project will appear if relevant project files are edited</string>
-         </property>
-         <property name="text">
-          <string>Monitor project files</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QCheckBox" name="checkBox_OpenRecentProject">
-         <property name="toolTip">
-          <string>If checked, Porymap will automatically open your most recently opened project on startup</string>
-         </property>
-         <property name="text">
-          <string>Open recent project on launch</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QCheckBox" name="checkBox_CheckForUpdates">
-         <property name="toolTip">
-          <string>If checked, Porymap will automatically alert you on startup if a new release is available</string>
-         </property>
-         <property name="text">
-          <string>Automatically check for updates</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QCheckBox" name="checkBox_DisableEventWarning">
-         <property name="toolTip">
-          <string>If checked, no warning will be shown when deleting an event that has an associated #define that may also be deleted.</string>
-         </property>
-         <property name="text">
-          <string>Disable warning when deleting events with IDs</string>
-         </property>
-        </widget>
-       </item>
-      </layout>
-     </widget>
-    </item>
-    <item>
-     <widget class="QGroupBox" name="groupBox_EventSelectionMode">
-      <property name="title">
-       <string>Event Selection Mode</string>
-      </property>
-      <layout class="QVBoxLayout" name="verticalLayout_EventSelectionMode">
-       <item>
-        <widget class="QRadioButton" name="radioButton_OnSprite">
-         <property name="toolTip">
-          <string>If enabled, an event can be selected by clicking directly on the opaque pixels of its sprite. This may be preferable when events are overlapping.</string>
-         </property>
-         <property name="text">
-          <string>Select by clicking on sprite</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QRadioButton" name="radioButton_WithinRect">
-         <property name="toolTip">
-          <string>If enabled, an event can be selected by clicking anywhere within its sprite dimensions. This may be preferable for events with small or mostly transparent sprites.</string>
-         </property>
-         <property name="text">
-          <string>Select by clicking within bounding rectangle</string>
-         </property>
-        </widget>
-       </item>
-      </layout>
-     </widget>
-    </item>
-    <item>
-     <widget class="QGroupBox" name="groupBox_Themes">
-      <property name="sizePolicy">
-       <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-        <horstretch>0</horstretch>
-        <verstretch>0</verstretch>
-       </sizepolicy>
-      </property>
-      <property name="title">
-       <string>Application Theme</string>
-      </property>
-     </widget>
-    </item>
-    <item>
-     <widget class="QGroupBox" name="groupBox_TextEditor">
-      <property name="title">
-       <string>Preferred Text Editor</string>
-      </property>
-      <layout class="QGridLayout" name="gridLayout">
-       <property name="leftMargin">
-        <number>0</number>
-       </property>
-       <property name="topMargin">
-        <number>0</number>
-       </property>
-       <property name="rightMargin">
-        <number>0</number>
-       </property>
-       <property name="bottomMargin">
-        <number>0</number>
-       </property>
-       <property name="spacing">
-        <number>0</number>
-       </property>
-       <item row="2" column="0">
-        <widget class="QScrollArea" name="scrollArea_TextEditor">
-         <property name="frameShape">
-          <enum>QFrame::NoFrame</enum>
-         </property>
-         <property name="widgetResizable">
-          <bool>true</bool>
-         </property>
-         <widget class="QWidget" name="scrollAreaWidgetContents_TextEditor">
-          <property name="geometry">
-           <rect>
-            <x>0</x>
-            <y>0</y>
-            <width>492</width>
-            <height>327</height>
-           </rect>
+      <widget class="QWidget" name="tab_General">
+       <attribute name="title">
+        <string>General</string>
+       </attribute>
+       <layout class="QVBoxLayout" name="verticalLayout_5">
+        <property name="leftMargin">
+         <number>12</number>
+        </property>
+        <property name="rightMargin">
+         <number>12</number>
+        </property>
+        <property name="bottomMargin">
+         <number>12</number>
+        </property>
+        <item>
+         <widget class="QCheckBox" name="checkBox_MonitorProjectFiles">
+          <property name="toolTip">
+           <string>If checked, a prompt to reload your project will appear if relevant project files are edited</string>
           </property>
-          <layout class="QGridLayout" name="gridLayout_2">
-           <property name="sizeConstraint">
-            <enum>QLayout::SetMinimumSize</enum>
-           </property>
-           <item row="6" column="0" colspan="2">
-            <widget class="QLabel" name="label_TextEditorGotoLineHelp">
-             <property name="text">
-              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When this command is set a button will appear next to the &lt;span style=&quot; font-weight:600; font-style:italic;&quot;&gt;Script&lt;/span&gt; combo-box in the &lt;span style=&quot; font-weight:600; font-style:italic;&quot;&gt;Events&lt;/span&gt; tab which executes this command.&lt;span style=&quot; font-weight:600;&quot;&gt; %F&lt;/span&gt; will be substituted with the file path of the script and &lt;span style=&quot; font-weight:600;&quot;&gt;%L&lt;/span&gt; will be substituted with the line number of the script in that file. &lt;span style=&quot; font-weight:600;&quot;&gt;%F &lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;must&lt;/span&gt; be given if &lt;span style=&quot; font-weight:600;&quot;&gt;%L&lt;/span&gt; is given. If &lt;span style=&quot; font-weight:600;&quot;&gt;%F&lt;/span&gt; is &lt;span style=&quot; font-style:italic;&quot;&gt;not&lt;/span&gt; given then the script's file path will be added to the end of the command. If the script can't be found then the current map's scripts file is opened.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-             </property>
-             <property name="alignment">
-              <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-             </property>
-             <property name="wordWrap">
-              <bool>true</bool>
-             </property>
-            </widget>
-           </item>
-           <item row="5" column="0">
-            <widget class="QLabel" name="label_TextEditorGotoLine">
-             <property name="text">
-              <string>Goto Line Command</string>
-             </property>
-            </widget>
-           </item>
-           <item row="0" column="1">
-            <widget class="QLineEdit" name="lineEdit_TextEditorOpenFolder">
+          <property name="text">
+           <string>Monitor project files</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QCheckBox" name="checkBox_OpenRecentProject">
+          <property name="toolTip">
+           <string>If checked, Porymap will automatically open your most recently opened project on startup</string>
+          </property>
+          <property name="text">
+           <string>Open recent project on launch</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QCheckBox" name="checkBox_CheckForUpdates">
+          <property name="toolTip">
+           <string>If checked, Porymap will automatically alert you on startup if a new release is available</string>
+          </property>
+          <property name="text">
+           <string>Automatically check for updates</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QGroupBox" name="groupBox_Themes">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="title">
+           <string>Application Theme</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="verticalSpacer_4">
+          <property name="orientation">
+           <enum>Qt::Orientation::Vertical</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>20</width>
+            <height>40</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+       </layout>
+      </widget>
+      <widget class="QWidget" name="tab_Events">
+       <attribute name="title">
+        <string>Events</string>
+       </attribute>
+       <layout class="QVBoxLayout" name="verticalLayout_3">
+        <property name="leftMargin">
+         <number>12</number>
+        </property>
+        <property name="rightMargin">
+         <number>12</number>
+        </property>
+        <property name="bottomMargin">
+         <number>12</number>
+        </property>
+        <item>
+         <widget class="QCheckBox" name="checkBox_DisableEventWarning">
+          <property name="toolTip">
+           <string>If checked, no warning will be shown when deleting an event that has an associated #define that may also be deleted.</string>
+          </property>
+          <property name="text">
+           <string>Disable warning when deleting events with IDs</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QCheckBox" name="checkBox_AutocompleteAllScripts">
+          <property name="toolTip">
+           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If checked, the list of suggestions when typing in an Event's Script field will include all global script labels in the project. Enabling this setting will make Porymap's startup slower.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          </property>
+          <property name="text">
+           <string>Autocomplete Script labels using all possible scripts</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QGroupBox" name="groupBox_EventSelectionMode">
+          <property name="title">
+           <string>Selection Mode</string>
+          </property>
+          <layout class="QVBoxLayout" name="verticalLayout_EventSelectionMode">
+           <item>
+            <widget class="QRadioButton" name="radioButton_OnSprite">
              <property name="toolTip">
-              <string>The shell command for your preferred text editor (possibly an absolute path if the program doesn't exist in your PATH).</string>
+              <string>If enabled, an event can be selected by clicking directly on the opaque pixels of its sprite. This may be preferable when events are overlapping.</string>
              </property>
-             <property name="placeholderText">
-              <string>e.g. code %D</string>
-             </property>
-             <property name="clearButtonEnabled">
-              <bool>true</bool>
-             </property>
-            </widget>
-           </item>
-           <item row="1" column="0" colspan="2">
-            <widget class="QLabel" name="label_TextEditorOpenFolderHelp">
              <property name="text">
-              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This is the command that is executed when clicking &lt;span style=&quot; font-weight:600; font-style:italic;&quot;&gt;Open Project in Text Editor&lt;/span&gt; in the &lt;span style=&quot; font-weight:600; font-style:italic;&quot;&gt;Tools&lt;/span&gt; menu. &lt;span style=&quot; font-weight:600;&quot;&gt;%D&lt;/span&gt; will be substituted with the project's root directory. If &lt;span style=&quot; font-weight:600;&quot;&gt;%D&lt;/span&gt; is &lt;span style=&quot; font-style:italic;&quot;&gt;not&lt;/span&gt; specified then the project directory will be added to the end of the command.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-             </property>
-             <property name="alignment">
-              <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-             </property>
-             <property name="wordWrap">
-              <bool>true</bool>
+              <string>Select by clicking on sprite</string>
              </property>
             </widget>
            </item>
-           <item row="0" column="0">
-            <widget class="QLabel" name="label_TextEditorOpenFolder">
-             <property name="text">
-              <string>Open Directory Command</string>
-             </property>
-            </widget>
-           </item>
-           <item row="5" column="1">
-            <widget class="QLineEdit" name="lineEdit_TextEditorGotoLine">
+           <item>
+            <widget class="QRadioButton" name="radioButton_WithinRect">
              <property name="toolTip">
-              <string>The shell command for your preferred text editor to open a file to a specific line number (possibly an absolute path if the program doesn't exist in your PATH).</string>
+              <string>If enabled, an event can be selected by clicking anywhere within its sprite dimensions. This may be preferable for events with small or mostly transparent sprites.</string>
              </property>
-             <property name="placeholderText">
-              <string>e.g. code --goto %F:%L</string>
-             </property>
-             <property name="clearButtonEnabled">
-              <bool>true</bool>
+             <property name="text">
+              <string>Select by clicking within bounding rectangle</string>
              </property>
             </widget>
-           </item>
-           <item row="2" column="0" colspan="2">
-            <spacer name="verticalSpacer_2">
-             <property name="orientation">
-              <enum>Qt::Vertical</enum>
-             </property>
-             <property name="sizeType">
-              <enum>QSizePolicy::Fixed</enum>
-             </property>
-             <property name="sizeHint" stdset="0">
-              <size>
-               <width>20</width>
-               <height>15</height>
-              </size>
-             </property>
-            </spacer>
-           </item>
-           <item row="7" column="0" colspan="2">
-            <spacer name="verticalSpacer">
-             <property name="orientation">
-              <enum>Qt::Vertical</enum>
-             </property>
-             <property name="sizeHint" stdset="0">
-              <size>
-               <width>20</width>
-               <height>40</height>
-              </size>
-             </property>
-            </spacer>
            </item>
           </layout>
          </widget>
-        </widget>
-       </item>
-      </layout>
+        </item>
+        <item>
+         <spacer name="verticalSpacer_3">
+          <property name="orientation">
+           <enum>Qt::Orientation::Vertical</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>20</width>
+            <height>40</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+       </layout>
+      </widget>
+      <widget class="QWidget" name="tab">
+       <attribute name="title">
+        <string>Text Editor</string>
+       </attribute>
+       <layout class="QVBoxLayout" name="verticalLayout_4">
+        <property name="leftMargin">
+         <number>12</number>
+        </property>
+        <property name="rightMargin">
+         <number>12</number>
+        </property>
+        <property name="bottomMargin">
+         <number>12</number>
+        </property>
+        <item>
+         <widget class="QScrollArea" name="scrollArea_TextEditor">
+          <property name="frameShape">
+           <enum>QFrame::Shape::NoFrame</enum>
+          </property>
+          <property name="widgetResizable">
+           <bool>true</bool>
+          </property>
+          <widget class="QWidget" name="scrollAreaWidgetContents_TextEditor">
+           <property name="geometry">
+            <rect>
+             <x>0</x>
+             <y>0</y>
+             <width>476</width>
+             <height>343</height>
+            </rect>
+           </property>
+           <layout class="QGridLayout" name="gridLayout_2">
+            <property name="sizeConstraint">
+             <enum>QLayout::SizeConstraint::SetMinimumSize</enum>
+            </property>
+            <item row="6" column="0" colspan="2">
+             <widget class="QLabel" name="label_TextEditorGotoLineHelp">
+              <property name="text">
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When this command is set a button will appear next to the &lt;span style=&quot; font-weight:600; font-style:italic;&quot;&gt;Script&lt;/span&gt; combo-box in the &lt;span style=&quot; font-weight:600; font-style:italic;&quot;&gt;Events&lt;/span&gt; tab which executes this command.&lt;span style=&quot; font-weight:600;&quot;&gt; %F&lt;/span&gt; will be substituted with the file path of the script and &lt;span style=&quot; font-weight:600;&quot;&gt;%L&lt;/span&gt; will be substituted with the line number of the script in that file. &lt;span style=&quot; font-weight:600;&quot;&gt;%F &lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;must&lt;/span&gt; be given if &lt;span style=&quot; font-weight:600;&quot;&gt;%L&lt;/span&gt; is given. If &lt;span style=&quot; font-weight:600;&quot;&gt;%F&lt;/span&gt; is &lt;span style=&quot; font-style:italic;&quot;&gt;not&lt;/span&gt; given then the script's file path will be added to the end of the command. If the script can't be found then the current map's scripts file is opened.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+              </property>
+              <property name="alignment">
+               <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignTop</set>
+              </property>
+              <property name="wordWrap">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item row="5" column="0">
+             <widget class="QLabel" name="label_TextEditorGotoLine">
+              <property name="text">
+               <string>Goto Line Command</string>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="1">
+             <widget class="QLineEdit" name="lineEdit_TextEditorOpenFolder">
+              <property name="toolTip">
+               <string>The shell command for your preferred text editor (possibly an absolute path if the program doesn't exist in your PATH).</string>
+              </property>
+              <property name="placeholderText">
+               <string>e.g. code %D</string>
+              </property>
+              <property name="clearButtonEnabled">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="0" colspan="2">
+             <widget class="QLabel" name="label_TextEditorOpenFolderHelp">
+              <property name="text">
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This is the command that is executed when clicking &lt;span style=&quot; font-weight:600; font-style:italic;&quot;&gt;Open Project in Text Editor&lt;/span&gt; in the &lt;span style=&quot; font-weight:600; font-style:italic;&quot;&gt;Tools&lt;/span&gt; menu. &lt;span style=&quot; font-weight:600;&quot;&gt;%D&lt;/span&gt; will be substituted with the project's root directory. If &lt;span style=&quot; font-weight:600;&quot;&gt;%D&lt;/span&gt; is &lt;span style=&quot; font-style:italic;&quot;&gt;not&lt;/span&gt; specified then the project directory will be added to the end of the command.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+              </property>
+              <property name="alignment">
+               <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignTop</set>
+              </property>
+              <property name="wordWrap">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="0">
+             <widget class="QLabel" name="label_TextEditorOpenFolder">
+              <property name="text">
+               <string>Open Directory Command</string>
+              </property>
+             </widget>
+            </item>
+            <item row="5" column="1">
+             <widget class="QLineEdit" name="lineEdit_TextEditorGotoLine">
+              <property name="toolTip">
+               <string>The shell command for your preferred text editor to open a file to a specific line number (possibly an absolute path if the program doesn't exist in your PATH).</string>
+              </property>
+              <property name="placeholderText">
+               <string>e.g. code --goto %F:%L</string>
+              </property>
+              <property name="clearButtonEnabled">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item row="2" column="0" colspan="2">
+             <spacer name="verticalSpacer_2">
+              <property name="orientation">
+               <enum>Qt::Orientation::Vertical</enum>
+              </property>
+              <property name="sizeType">
+               <enum>QSizePolicy::Policy::Fixed</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>20</width>
+                <height>15</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+            <item row="7" column="0" colspan="2">
+             <spacer name="verticalSpacer">
+              <property name="orientation">
+               <enum>Qt::Orientation::Vertical</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>20</width>
+                <height>40</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+           </layout>
+          </widget>
+         </widget>
+        </item>
+       </layout>
+      </widget>
      </widget>
     </item>
     <item>
      <widget class="QDialogButtonBox" name="buttonBox">
       <property name="standardButtons">
-       <set>QDialogButtonBox::Apply|QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+       <set>QDialogButtonBox::StandardButton::Apply|QDialogButtonBox::StandardButton::Cancel|QDialogButtonBox::StandardButton::Ok</set>
       </property>
      </widget>
     </item>

--- a/include/config.h
+++ b/include/config.h
@@ -79,6 +79,7 @@ public:
         this->textEditorGotoLine = "";
         this->paletteEditorBitDepth = 24;
         this->projectSettingsTab = 0;
+        this->loadAllEventScripts = false;
         this->warpBehaviorWarningDisabled = false;
         this->eventDeleteWarningDisabled = false;
         this->eventOverlayEnabled = false;
@@ -135,6 +136,7 @@ public:
     QString textEditorGotoLine;
     int paletteEditorBitDepth;
     int projectSettingsTab;
+    bool loadAllEventScripts;
     bool warpBehaviorWarningDisabled;
     bool eventDeleteWarningDisabled;
     bool eventOverlayEnabled;

--- a/include/core/events.h
+++ b/include/core/events.h
@@ -41,14 +41,6 @@ public:
     virtual void visitSign(SignEvent *) = 0;
 };
 
-struct EventGraphics
-{
-    QImage spritesheet;
-    int spriteWidth;
-    int spriteHeight;
-    bool inanimate;
-};
-
 
 ///
 /// Event base class -- purely virtual
@@ -64,11 +56,7 @@ public:
     Event& operator=(const Event &other) = delete;
 
 protected:
-    Event() {
-        this->spriteWidth = 16;
-        this->spriteHeight = 16;
-        this->usingSprite = false;
-    }
+    Event() {}
 
 // public enums & static methods
 public:
@@ -143,8 +131,8 @@ public:
     int getZ() const { return this->elevation; }
     int getElevation() const { return this->elevation; }
 
-    int getPixelX() const { return (this->x * 16) - qMax(0, (this->spriteWidth - 16) / 2); }
-    int getPixelY() const { return (this->y * 16) - qMax(0, this->spriteHeight - 16); }
+    int getPixelX() const { return (this->x * 16) - qMax(0, (pixmap.width() - 16) / 2); }
+    int getPixelY() const { return (this->y * 16) - qMax(0, pixmap.height() - 16); }
 
     virtual EventFrame *getEventFrame();
     virtual EventFrame *createEventFrame() = 0;
@@ -172,14 +160,8 @@ public:
     void setPixmapItem(DraggablePixmapItem *item);
     DraggablePixmapItem *getPixmapItem() const { return this->pixmapItem; }
 
-    void setUsingSprite(bool newUsingSprite) { this->usingSprite = newUsingSprite; }
-    bool getUsingSprite() const { return this->usingSprite; }
-
-    void setSpriteWidth(int newSpriteWidth) { this->spriteWidth = newSpriteWidth; }
-    int getspriteWidth() const { return this->spriteWidth; }
-
-    void setSpriteHeight(int newSpriteHeight) { this->spriteHeight = newSpriteHeight; }
-    int getspriteHeight() const { return this->spriteHeight; }
+    void setUsesDefaultPixmap(bool newUsesDefaultPixmap) { this->usesDefaultPixmap = newUsesDefaultPixmap; }
+    bool getUsesDefaultPixmap() const { return this->usesDefaultPixmap; }
 
     int getEventIndex();
 
@@ -204,9 +186,7 @@ protected:
     int y = 0;
     int elevation = 0;
 
-    int spriteWidth = 16;
-    int spriteHeight = 16;
-    bool usingSprite = false;
+    bool usesDefaultPixmap = true;
 
     // Some events can have an associated #define name that should be unique to this event.
     // e.g. object events can have a 'LOCALID', or Heal Locations have a 'HEAL_LOCATION' id.
@@ -272,10 +252,6 @@ public:
 
     void setFlag(QString newFlag) { this->flag = newFlag; }
     QString getFlag() const { return this->flag; }
-
-public:
-    void setFrameFromMovement(QString movement);
-    void setPixmapFromSpritesheet(EventGraphics * gfx);
 
 
 protected:

--- a/include/core/events.h
+++ b/include/core/events.h
@@ -107,8 +107,6 @@ public:
 
     static Event* create(Event::Type type);
 
-    static QMap<Event::Group, const QPixmap*> icons;
-
 // standard public methods
 public:
 
@@ -171,8 +169,6 @@ public:
     static QString groupToString(Event::Group group);
     static QString typeToString(Event::Type type);
     static Event::Type typeFromString(QString type);
-    static void clearIcons();
-    static void setIcons();
 
 // protected attributes
 protected:

--- a/include/project.h
+++ b/include/project.h
@@ -219,6 +219,7 @@ public:
     static QString getScriptFileExtension(bool usePoryScript);
     QString getScriptDefaultString(bool usePoryScript, QString mapName) const;
     QStringList getEventScriptsFilePaths() const;
+    void insertGlobalScriptLabels(QStringList &scriptLabels) const;
 
     QString getDefaultPrimaryTilesetLabel() const;
     QString getDefaultSecondaryTilesetLabel() const;

--- a/include/project.h
+++ b/include/project.h
@@ -298,6 +298,7 @@ signals:
     void mapSectionDisplayNameChanged(const QString &idName, const QString &displayName);
     void mapSectionIdNamesChanged(const QStringList &idNames);
     void mapsExcluded(const QStringList &excludedMapNames);
+    void eventScriptLabelsRead();
 };
 
 #endif // PROJECT_H

--- a/include/project.h
+++ b/include/project.h
@@ -45,7 +45,6 @@ public:
     QStringList layoutIdsMaster;
     QMap<QString, Layout*> mapLayouts;
     QMap<QString, Layout*> mapLayoutsMaster;
-    QMap<QString, EventGraphics*> eventGraphicsMap;
     QMap<QString, int> gfxDefines;
     QString defaultSong;
     QStringList songNames;
@@ -68,7 +67,6 @@ public:
     QMap<QString, uint16_t> unusedMetatileLabels;
     QMap<QString, uint32_t> metatileBehaviorMap;
     QMap<uint32_t, QString> metatileBehaviorMapInverse;
-    QMap<QString, QString> facingDirections;
     ParseUtil parser;
     QFileSystemWatcher fileWatcher;
     QSet<QString> modifiedFiles;
@@ -210,7 +208,10 @@ public:
     bool readFieldmapMasks();
     QMap<QString, QMap<QString, QString>> readObjEventGfxInfo();
 
-    void setEventPixmap(Event *event, bool forceLoad = false);
+    QPixmap getEventPixmap(const QString &gfxName, const QString &movementName);
+    QPixmap getEventPixmap(const QString &gfxName, int frame, bool hFlip);
+    QPixmap getEventPixmap(Event::Group group);
+    void loadEventPixmap(Event *event, bool forceLoad = false);
 
     QString fixPalettePath(QString path);
     QString fixGraphicPath(QString path);
@@ -254,6 +255,18 @@ public:
 private:
     QMap<QString, QString> mapSectionDisplayNames;
     QMap<QString, qint64> modifiedFileTimestamps;
+    QMap<QString, QString> facingDirections;
+
+    struct EventGraphics
+    {
+        QString filepath;
+        bool loaded = false;
+        QImage spritesheet;
+        int spriteWidth = -1;
+        int spriteHeight = -1;
+        bool inanimate = false;
+    };
+    QMap<QString, EventGraphics*> eventGraphicsMap;
 
     void updateLayout(Layout *);
 

--- a/include/ui/eventframes.h
+++ b/include/ui/eventframes.h
@@ -31,8 +31,6 @@ public:
     void invalidateUi();
     void invalidateValues();
 
-    void populateScriptDropdown(NoScrollComboBox * combo, Project * project);
-
     virtual void setActive(bool active);
 
 public:
@@ -58,6 +56,8 @@ protected:
     bool populated = false;
     bool initialized = false;
     bool connected = false;
+
+    void populateScriptDropdown(NoScrollComboBox * combo, Project * project);
 
 private:
     Event *event;

--- a/include/ui/preferenceeditor.h
+++ b/include/ui/preferenceeditor.h
@@ -23,6 +23,7 @@ public:
 signals:
     void preferencesSaved();
     void themeChanged(const QString &theme);
+    void scriptSettingsChanged(bool on);
 
 private:
     Ui::PreferenceEditor *ui;

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -390,6 +390,8 @@ void PorymapConfig::parseConfigKeyValue(QString key, QString value) {
         }
     } else if (key == "project_settings_tab") {
         this->projectSettingsTab = getConfigInteger(key, value, 0);
+    } else if (key == "load_all_event_scripts") {
+        this->loadAllEventScripts = getConfigBool(key, value);
     } else if (key == "warp_behavior_warning_disabled") {
         this->warpBehaviorWarningDisabled = getConfigBool(key, value);
     } else if (key == "event_delete_warning_disabled") {
@@ -479,6 +481,7 @@ QMap<QString, QString> PorymapConfig::getKeyValueMap() {
     map.insert("text_editor_goto_line", this->textEditorGotoLine);
     map.insert("palette_editor_bit_depth", QString::number(this->paletteEditorBitDepth));
     map.insert("project_settings_tab", QString::number(this->projectSettingsTab));
+    map.insert("load_all_event_scripts", QString::number(this->loadAllEventScripts));
     map.insert("warp_behavior_warning_disabled", QString::number(this->warpBehaviorWarningDisabled));
     map.insert("event_delete_warning_disabled", QString::number(this->eventDeleteWarningDisabled));
     map.insert("event_overlay_enabled", QString::number(this->eventOverlayEnabled));

--- a/src/core/events.cpp
+++ b/src/core/events.cpp
@@ -4,8 +4,6 @@
 #include "project.h"
 #include "config.h"
 
-QMap<Event::Group, const QPixmap*> Event::icons;
-
 Event* Event::create(Event::Type type) {
     switch (type) {
     case Event::Type::Object: return new ObjectEvent();
@@ -108,46 +106,10 @@ Event::Type Event::typeFromString(QString type) {
 }
 
 void Event::loadPixmap(Project *project) {
-    const QPixmap * pixmap = Event::icons.value(this->getEventGroup());
-    this->pixmap = pixmap ? *pixmap : QPixmap();
+    this->pixmap = project->getEventPixmap(this->getEventGroup());
     this->usesDefaultPixmap = true;
 }
 
-void Event::clearIcons() {
-    qDeleteAll(icons);
-    icons.clear();
-}
-
-void Event::setIcons() {
-    clearIcons();
-    const int w = 16;
-    const int h = 16;
-    static const QPixmap defaultIcons = QPixmap(":/images/Entities_16x16.png");
-
-    // Custom event icons may be provided by the user.
-    const int numIcons = qMin(defaultIcons.width() / w, static_cast<int>(Event::Group::None));
-    for (int i = 0; i < numIcons; i++) {
-        Event::Group group = static_cast<Event::Group>(i);
-        QString customIconPath = projectConfig.getEventIconPath(group);
-        if (customIconPath.isEmpty()) {
-            // No custom icon specified, use the default icon.
-            icons[group] = new QPixmap(defaultIcons.copy(i * w, 0, w, h));
-            continue;
-        }
-
-        // Try to load custom icon
-        QString validPath = Project::getExistingFilepath(customIconPath);
-        if (!validPath.isEmpty()) customIconPath = validPath; // Otherwise allow it to fail with the original path
-        const QPixmap customIcon = QPixmap(customIconPath);
-        if (customIcon.isNull()) {
-            // Custom icon failed to load, use the default icon.
-            icons[group] = new QPixmap(defaultIcons.copy(i * w, 0, w, h));
-            logWarn(QString("Failed to load custom event icon '%1', using default icon.").arg(customIconPath));
-        } else {
-            icons[group] = new QPixmap(customIcon.scaled(w, h));
-        }
-    }
-}
 
 
 Event *ObjectEvent::duplicate() const {

--- a/src/core/map.cpp
+++ b/src/core/map.cpp
@@ -152,13 +152,12 @@ QStringList Map::getScriptLabels(Event::Group group) {
         scriptLabels = scriptTracker.getScripts();
     }
 
-    // Add scripts from map's scripts file, and empty names.
+    // Add labels from the map's scripts file
     scriptLabels.append(m_scriptsFileLabels);
     scriptLabels.sort(Qt::CaseInsensitive);
-    scriptLabels.prepend("0x0");
-    scriptLabels.prepend("NULL");
-
     scriptLabels.removeAll("");
+    scriptLabels.removeAll("0");
+    scriptLabels.removeAll("0x0");
     scriptLabels.removeDuplicates();
 
     return scriptLabels;

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -13,6 +13,7 @@
 #include "customattributesframe.h"
 #include "validator.h"
 #include "message.h"
+#include "eventframes.h"
 #include <QCheckBox>
 #include <QPainter>
 #include <QMouseEvent>

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -1670,7 +1670,7 @@ void Editor::displayMapEvents() {
 }
 
 DraggablePixmapItem *Editor::addEventPixmapItem(Event *event) {
-    this->project->setEventPixmap(event);
+    this->project->loadEventPixmap(event);
     auto item = new DraggablePixmapItem(event, this);
     redrawEventPixmapItem(item);
     this->events_group->addToGroup(item);
@@ -1955,13 +1955,13 @@ qreal Editor::getEventOpacity(const Event *event) const {
     // - On the Events tab, and the event has a custom sprite (1.0)
     if (this->editMode != EditMode::Events)
         return porymapConfig.eventOverlayEnabled ? 0.5 : 0.0;
-    return event->getUsingSprite() ? 1.0 : 0.7;
+    return event->getUsesDefaultPixmap() ? 0.7 : 1.0;
 }
 
 void Editor::redrawEventPixmapItem(DraggablePixmapItem *item) {
     if (item && item->event && !item->event->getPixmap().isNull()) {
         item->setOpacity(getEventOpacity(item->event));
-        project->setEventPixmap(item->event, true);
+        project->loadEventPixmap(item->event, true);
         item->setPixmap(item->event->getPixmap());
         item->setShapeMode(porymapConfig.eventSelectionShapeMode);
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -2719,12 +2719,10 @@ void MainWindow::on_actionOpen_Config_Folder_triggered() {
 void MainWindow::on_actionPreferences_triggered() {
     if (!preferenceEditor) {
         preferenceEditor = new PreferenceEditor(this);
-        connect(preferenceEditor, &PreferenceEditor::themeChanged,
-                this, &MainWindow::setTheme);
-        connect(preferenceEditor, &PreferenceEditor::themeChanged,
-                editor, &Editor::maskNonVisibleConnectionTiles);
-        connect(preferenceEditor, &PreferenceEditor::preferencesSaved,
-                this, &MainWindow::togglePreferenceSpecificUi);
+        connect(preferenceEditor, &PreferenceEditor::themeChanged, this, &MainWindow::setTheme);
+        connect(preferenceEditor, &PreferenceEditor::themeChanged, editor, &Editor::maskNonVisibleConnectionTiles);
+        connect(preferenceEditor, &PreferenceEditor::preferencesSaved, this, &MainWindow::togglePreferenceSpecificUi);
+        connect(preferenceEditor, &PreferenceEditor::scriptSettingsChanged, editor->project, &Project::readEventScriptLabels);
     }
 
     openSubWindow(preferenceEditor);
@@ -2739,8 +2737,9 @@ void MainWindow::togglePreferenceSpecificUi() {
     if (this->updatePromoter)
         this->updatePromoter->updatePreferences();
 
-    // Redraw all events to use updated porymapConfig.eventSelectionShapeMode
-    this->editor->redrawAllEvents();
+    // Changes to porymapConfig.loadAllEventScripts or porymapConfig.eventSelectionShapeMode
+    // require us to repopulate the EventFrames and redraw event pixmaps, respectively.
+    this->editor->updateEvents();
 }
 
 void MainWindow::openProjectSettingsEditor(int tab) {

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1103,7 +1103,6 @@ bool MainWindow::setProjectUI() {
     ui->newEventToolButton->newSecretBaseAction->setVisible(projectConfig.eventSecretBaseEnabled);
     ui->newEventToolButton->newCloneObjectAction->setVisible(projectConfig.eventCloneObjectEnabled);
 
-    Event::setIcons();
     editor->setCollisionGraphics();
     ui->spinBox_SelectedElevation->setMaximum(Block::getMaxElevation());
     ui->spinBox_SelectedCollision->setMaximum(Block::getMaxCollision());
@@ -1161,8 +1160,6 @@ void MainWindow::clearProjectUI() {
     delete this->layoutTreeModel;
     delete this->layoutListProxyModel;
     resetMapListFilters();
-
-    Event::clearIcons();
 }
 
 void MainWindow::scrollMapList(MapTree *list, const QString &itemName) {

--- a/src/project.cpp
+++ b/src/project.cpp
@@ -2720,7 +2720,8 @@ bool Project::readEventGraphics() {
 
         // Strip the address-of operator to get the pointer's name. We'll use this name to get data about the event's sprite.
         // If we don't recognize the name, ignore it. The event will use a default sprite.
-        QString info_label = pointerMap[gfxName].replace("&", "");
+        QString info_label = pointerMap.value(gfxName);
+        info_label.replace("&", "");
         if (!gfxInfos.contains(info_label))
             continue;
         const QHash<QString, QString> gfxInfoAttributes = gfxInfos[info_label];

--- a/src/project.cpp
+++ b/src/project.cpp
@@ -2602,15 +2602,14 @@ bool Project::readMiscellaneousConstants() {
 bool Project::readEventScriptLabels() {
     this->globalScriptLabels.clear();
 
-    if (porymapConfig.loadAllEventScripts)
-        return true;
+    if (porymapConfig.loadAllEventScripts) {
+        for (const auto &filePath : getEventScriptsFilePaths())
+            this->globalScriptLabels << ParseUtil::getGlobalScriptLabels(filePath);
 
-    for (const auto &filePath : getEventScriptsFilePaths())
-        this->globalScriptLabels << ParseUtil::getGlobalScriptLabels(filePath);
-
-   this->globalScriptLabels.sort(Qt::CaseInsensitive);
-   this->globalScriptLabels.removeDuplicates();
-
+       this->globalScriptLabels.sort(Qt::CaseInsensitive);
+       this->globalScriptLabels.removeDuplicates();
+    }
+    emit eventScriptLabelsRead();
     return true;
 }
 

--- a/src/project.cpp
+++ b/src/project.cpp
@@ -2600,14 +2600,26 @@ bool Project::readMiscellaneousConstants() {
 }
 
 bool Project::readEventScriptLabels() {
-    globalScriptLabels.clear();
-    for (const auto &filePath : getEventScriptsFilePaths())
-        globalScriptLabels << ParseUtil::getGlobalScriptLabels(filePath);
+    this->globalScriptLabels.clear();
 
-    globalScriptLabels.sort(Qt::CaseInsensitive);
-    globalScriptLabels.removeDuplicates();
+    if (porymapConfig.loadAllEventScripts)
+        return true;
+
+    for (const auto &filePath : getEventScriptsFilePaths())
+        this->globalScriptLabels << ParseUtil::getGlobalScriptLabels(filePath);
+
+   this->globalScriptLabels.sort(Qt::CaseInsensitive);
+   this->globalScriptLabels.removeDuplicates();
 
     return true;
+}
+
+void Project::insertGlobalScriptLabels(QStringList &scriptLabels) const {
+    if (this->globalScriptLabels.isEmpty())
+        return;
+    scriptLabels.append(this->globalScriptLabels);
+    scriptLabels.sort();
+    scriptLabels.removeDuplicates();
 }
 
 QString Project::fixPalettePath(QString path) {

--- a/src/ui/draggablepixmapitem.cpp
+++ b/src/ui/draggablepixmapitem.cpp
@@ -27,7 +27,7 @@ void DraggablePixmapItem::emitPositionChanged() {
 }
 
 void DraggablePixmapItem::updatePixmap() {
-    editor->project->setEventPixmap(event, true);
+    editor->project->loadEventPixmap(event, true);
     this->updatePosition();
     editor->redrawEventPixmapItem(this);
     emit spriteChanged(event->getPixmap());

--- a/src/ui/eventframes.cpp
+++ b/src/ui/eventframes.cpp
@@ -173,12 +173,19 @@ void EventFrame::setActive(bool active) {
 }
 
 void EventFrame::populateScriptDropdown(NoScrollComboBox * combo, Project * project) {
-    // The script dropdown is populated with scripts used by the map's events and from its scripts file.
-    if (this->event->getMap())
-        combo->addItems(this->event->getMap()->getScriptLabels(this->event->getEventGroup()));
+    // The script dropdown and autocomplete are populated with scripts used by the map's events and from its scripts file.
+    if (!this->event->getMap())
+        return;
 
-    // The dropdown's autocomplete has all script labels across the full project.
-    auto completer = new QCompleter(project->globalScriptLabels, combo);
+    QStringList scripts = this->event->getMap()->getScriptLabels(this->event->getEventGroup());
+    combo->addItems(scripts);
+
+    // Depending on the settings, the autocomplete may also contain all global scripts.
+    if (porymapConfig.loadAllEventScripts) {
+        project->insertGlobalScriptLabels(scripts);
+    }
+
+    auto completer = new QCompleter(scripts, combo);
     completer->setCaseSensitivity(Qt::CaseInsensitive);
     completer->setModelSorting(QCompleter::CaseInsensitivelySortedModel);
     completer->setFilterMode(Qt::MatchContains);

--- a/src/ui/eventframes.cpp
+++ b/src/ui/eventframes.cpp
@@ -195,6 +195,9 @@ void EventFrame::populateScriptDropdown(NoScrollComboBox * combo, Project * proj
     if (popup) popup->setUniformItemSizes(true);
 
     combo->setCompleter(completer);
+
+    // If the project changes the script labels, update the EventFrame.
+    connect(project, &Project::eventScriptLabelsRead, this, &EventFrame::invalidateValues, Qt::UniqueConnection);
 }
 
 

--- a/src/ui/mapimageexporter.cpp
+++ b/src/ui/mapimageexporter.cpp
@@ -517,7 +517,7 @@ QPixmap MapImageExporter::getFormattedMapPixmap(Map *map, bool ignoreBorder) {
              || (m_settings.showBGs && group == Event::Group::Bg)
              || (m_settings.showTriggers && group == Event::Group::Coord)
              || (m_settings.showHealLocations && group == Event::Group::Heal)) {
-                m_editor->project->setEventPixmap(event);
+                m_editor->project->loadEventPixmap(event);
                 eventPainter.drawImage(QPoint(event->getPixelX() + pixelOffset, event->getPixelY() + pixelOffset), event->getPixmap().toImage());
             }
         }

--- a/src/ui/preferenceeditor.cpp
+++ b/src/ui/preferenceeditor.cpp
@@ -56,6 +56,7 @@ void PreferenceEditor::updateFields() {
     ui->checkBox_OpenRecentProject->setChecked(porymapConfig.reopenOnLaunch);
     ui->checkBox_CheckForUpdates->setChecked(porymapConfig.checkForUpdates);
     ui->checkBox_DisableEventWarning->setChecked(porymapConfig.eventDeleteWarningDisabled);
+    ui->checkBox_AutocompleteAllScripts->setChecked(porymapConfig.loadAllEventScripts);
 }
 
 void PreferenceEditor::saveFields() {
@@ -63,6 +64,11 @@ void PreferenceEditor::saveFields() {
         const auto theme = themeSelector->currentText();
         porymapConfig.theme = theme;
         emit themeChanged(theme);
+    }
+    bool loadAllEventScripts = ui->checkBox_AutocompleteAllScripts->isChecked();
+    if (loadAllEventScripts != porymapConfig.loadAllEventScripts) {
+        porymapConfig.loadAllEventScripts = loadAllEventScripts;
+        emit scriptSettingsChanged(loadAllEventScripts);
     }
     porymapConfig.eventSelectionShapeMode = ui->radioButton_OnSprite->isChecked() ? QGraphicsPixmapItem::MaskShape : QGraphicsPixmapItem::BoundingRectShape;
     porymapConfig.textEditorOpenFolder = ui->lineEdit_TextEditorOpenFolder->text();


### PR DESCRIPTION
A handful of changes to how events are loaded to make Porymap faster (startup specifically is about ~30% faster now)

- The autocomplete for the various `Script` dropdowns on events no longer use every known script. They now only contain the same set of scripts that can be found by manually opening the dropdown (i.e., scripts belonging to the current map). The old behavior is available under `Preferences`, and is off by default.
- The image file for an event's icon is now only read when it's first requested by an event. Previously the image for every possible event icon was read on launch.
- The individual frames sliced from the event icon spritesheets are now cached.

Two additional changes unrelated to speed:
- With the number of settings on the `Preferences` window increasing I opted to divide them into tabs
- When reading `ObjectEventGraphicsInfo` data, Porymap can now use the `width`/`height` fields as a fallback option when determining sprite dimensions.