### PR TITLE
Stop unnecessary full redraws of metatile selectors

### DIFF
--- a/include/ui/metatileselector.h
+++ b/include/ui/metatileselector.h
@@ -42,8 +42,10 @@ public:
         this->cellPos = QPoint(-1, -1);
         setAcceptHoverEvents(true);
     }
-    QPoint getSelectionDimensions();
-    void draw();
+
+    QPoint getSelectionDimensions() override;
+    void draw() override;
+
     bool select(uint16_t metatile);
     void selectFromMap(uint16_t metatileId, uint16_t collision, uint16_t elevation);
     void setTilesets(Tileset*, Tileset*);
@@ -53,15 +55,18 @@ public:
     QPoint getMetatileIdCoordsOnWidget(uint16_t);
     void setLayout(Layout *layout);
     bool isInternalSelection() const { return (!this->externalSelection && !this->prefabSelection); }
+
     Tileset *primaryTileset;
     Tileset *secondaryTileset;
 protected:
-    void mousePressEvent(QGraphicsSceneMouseEvent*);
-    void mouseMoveEvent(QGraphicsSceneMouseEvent*);
-    void mouseReleaseEvent(QGraphicsSceneMouseEvent*);
-    void hoverMoveEvent(QGraphicsSceneHoverEvent*);
-    void hoverLeaveEvent(QGraphicsSceneHoverEvent*);
+    void mousePressEvent(QGraphicsSceneMouseEvent*) override;
+    void mouseMoveEvent(QGraphicsSceneMouseEvent*) override;
+    void mouseReleaseEvent(QGraphicsSceneMouseEvent*) override;
+    void hoverMoveEvent(QGraphicsSceneHoverEvent*) override;
+    void hoverLeaveEvent(QGraphicsSceneHoverEvent*) override;
+    void drawSelection() override;
 private:
+    QPixmap basePixmap;
     bool externalSelection;
     bool prefabSelection;
     int numMetatilesWide;
@@ -72,6 +77,7 @@ private:
     MetatileSelection selection;
     QPoint cellPos;
 
+    void updateBasePixmap();
     void updateSelectedMetatiles();
     void updateExternalSelectedMetatiles();
     uint16_t getMetatileId(int x, int y) const;

--- a/include/ui/selectablepixmapitem.h
+++ b/include/ui/selectablepixmapitem.h
@@ -31,9 +31,9 @@ protected:
     void select(int, int, int, int);
     void updateSelection(int, int);
     QPoint getCellPos(QPointF);
-    void mousePressEvent(QGraphicsSceneMouseEvent*);
-    void mouseMoveEvent(QGraphicsSceneMouseEvent*);
-    void mouseReleaseEvent(QGraphicsSceneMouseEvent*);
+    virtual void mousePressEvent(QGraphicsSceneMouseEvent*) override;
+    virtual void mouseMoveEvent(QGraphicsSceneMouseEvent*) override;
+    virtual void mouseReleaseEvent(QGraphicsSceneMouseEvent*) override;
     virtual void drawSelection();
 
 signals:

--- a/include/ui/tileseteditormetatileselector.h
+++ b/include/ui/tileseteditormetatileselector.h
@@ -11,9 +11,13 @@ class TilesetEditorMetatileSelector: public SelectablePixmapItem {
 public:
     TilesetEditorMetatileSelector(Tileset *primaryTileset, Tileset *secondaryTileset, Layout *layout);
     Layout *layout = nullptr;
-    void draw();
+
+    void draw() override;
+    void drawMetatile(uint16_t metatileId);
+    void drawSelectedMetatile();
+
     bool select(uint16_t metatileId);
-    void setTilesets(Tileset*, Tileset*, bool draw = true);
+    void setTilesets(Tileset*, Tileset*);
     uint16_t getSelectedMetatileId();
     void updateSelectedMetatile();
     QPoint getMetatileIdCoordsOnWidget(uint16_t metatileId);
@@ -27,18 +31,21 @@ public:
     bool showDivider = false;
 
 protected:
-    void mousePressEvent(QGraphicsSceneMouseEvent*);
-    void mouseMoveEvent(QGraphicsSceneMouseEvent*);
-    void mouseReleaseEvent(QGraphicsSceneMouseEvent*);
-    void hoverMoveEvent(QGraphicsSceneHoverEvent*);
-    void hoverLeaveEvent(QGraphicsSceneHoverEvent*);
+    void mousePressEvent(QGraphicsSceneMouseEvent*) override;
+    void mouseMoveEvent(QGraphicsSceneMouseEvent*) override;
+    void mouseReleaseEvent(QGraphicsSceneMouseEvent*) override;
+    void hoverMoveEvent(QGraphicsSceneHoverEvent*) override;
+    void hoverLeaveEvent(QGraphicsSceneHoverEvent*) override;
 
 private:
+    QImage baseImage;
+    QPixmap basePixmap;
     Tileset *primaryTileset = nullptr;
     Tileset *secondaryTileset = nullptr;
-    uint16_t selectedMetatile;
+    uint16_t selectedMetatileId;
     int numMetatilesWide;
     int numMetatilesHigh;
+    void updateBasePixmap();
     uint16_t getMetatileId(int x, int y);
     QPoint getMetatileIdCoords(uint16_t);
     bool shouldAcceptEvent(QGraphicsSceneMouseEvent*);

--- a/src/ui/metatileselector.cpp
+++ b/src/ui/metatileselector.cpp
@@ -14,11 +14,7 @@ int MetatileSelector::numPrimaryMetatilesRounded() const {
     return ceil((double)this->primaryTileset->numMetatiles() / this->numMetatilesWide) * this->numMetatilesWide;
 }
 
-void MetatileSelector::draw() {
-    if (!this->primaryTileset || !this->secondaryTileset) {
-        this->setPixmap(QPixmap());
-    }
-
+void MetatileSelector::updateBasePixmap() {
     int primaryLength = this->numPrimaryMetatilesRounded();
     int length_ = primaryLength + this->secondaryTileset->numMetatiles();
     int height_ = length_ / this->numMetatilesWide;
@@ -39,12 +35,20 @@ void MetatileSelector::draw() {
         QPoint metatile_origin = QPoint(map_x * 16, map_y * 16);
         painter.drawImage(metatile_origin, metatile_image);
     }
-
     painter.end();
-    this->setPixmap(QPixmap::fromImage(image));
+    this->basePixmap = QPixmap::fromImage(image);
+}
 
+void MetatileSelector::draw() {
+    if (this->basePixmap.isNull())
+        updateBasePixmap();
+    setPixmap(this->basePixmap);
+    drawSelection();
+}
+
+void MetatileSelector::drawSelection() {
     if (!this->prefabSelection && (!this->externalSelection || (this->externalSelectionWidth == 1 && this->externalSelectionHeight == 1))) {
-        this->drawSelection();
+        SelectablePixmapItem::drawSelection();
     }
 }
 
@@ -76,7 +80,9 @@ void MetatileSelector::setTilesets(Tileset *primaryTileset, Tileset *secondaryTi
         this->updateExternalSelectedMetatiles();
     else
         this->updateSelectedMetatiles();
-    this->draw();
+
+    updateBasePixmap();
+    draw();
 }
 
 MetatileSelection MetatileSelector::getMetatileSelection() {

--- a/src/ui/tileseteditor.cpp
+++ b/src/ui/tileseteditor.cpp
@@ -473,7 +473,7 @@ void TilesetEditor::onMetatileLayerTileChanged(int x, int y) {
         }
     }
 
-    this->metatileSelector->draw();
+    this->metatileSelector->drawSelectedMetatile();
     this->metatileLayersItem->draw();
     this->tileSelector->draw();
     this->commitMetatileChange(prevMetatile);
@@ -601,7 +601,7 @@ void TilesetEditor::on_comboBox_layerType_activated(int layerType)
         Metatile *prevMetatile = new Metatile(*this->metatile);
         this->metatile->setLayerType(layerType);
         this->commitMetatileChange(prevMetatile);
-        this->metatileSelector->draw(); // Changing the layer type can affect how fully transparent metatiles appear
+        this->metatileSelector->drawSelectedMetatile(); // Changing the layer type can affect how fully transparent metatiles appear
     }
 }
 
@@ -858,7 +858,7 @@ bool TilesetEditor::replaceMetatile(uint16_t metatileId, const Metatile * src, Q
     this->metatile = dest;
     *this->metatile = *src;
     this->metatileSelector->select(metatileId);
-    this->metatileSelector->draw();
+    this->metatileSelector->drawMetatile(metatileId);
     this->metatileLayersItem->draw();
     this->metatileLayersItem->clearLastModifiedCoords();
     this->metatileLayersItem->clearLastHoveredCoords();


### PR DESCRIPTION
The metatile selectors on the `Map` tab and in the Tileset Editor were both recreating and repainting all their metatile images whenever the selection changed. Now they'll only do this then the underlying tilesets are changed.

This was never slow enough to create GUI lag for me, but I'm assuming this was the root problem for #641. The "current metatile selection" pixmap is doing something similar, which I did not update in this PR.