### PR TITLE
New event button refactor

### DIFF
--- a/include/core/events.h
+++ b/include/core/events.h
@@ -66,7 +66,6 @@ public:
         Trigger, WeatherTrigger,
         Sign, HiddenItem, SecretBase,
         HealLocation,
-        Generic,
         None,
     };
 
@@ -168,7 +167,9 @@ public:
 
     static QString groupToString(Event::Group group);
     static QString typeToString(Event::Type type);
-    static Event::Type typeFromString(QString type);
+    static QString typeToJsonKey(Event::Type type);
+    static Event::Type typeFromJsonKey(QString type);
+    static QList<Event::Type> types();
 
 // protected attributes
 protected:

--- a/include/ui/neweventtoolbutton.h
+++ b/include/ui/neweventtoolbutton.h
@@ -9,31 +9,20 @@ class NewEventToolButton : public QToolButton
     Q_OBJECT
 public:
     explicit NewEventToolButton(QWidget *parent = nullptr);
-    Event::Type getSelectedEventType();
-    QAction *newObjectAction;
-    QAction *newCloneObjectAction;
-    QAction *newWarpAction;
-    QAction *newHealLocationAction;
-    QAction *newTriggerAction;
-    QAction *newWeatherTriggerAction;
-    QAction *newSignAction;
-    QAction *newHiddenItemAction;
-    QAction *newSecretBaseAction;
-public slots:
-    void newObject();
-    void newCloneObject();
-    void newWarp();
-    void newHealLocation();
-    void newTrigger();
-    void newWeatherTrigger();
-    void newSign();
-    void newHiddenItem();
-    void newSecretBase();
+
+    Event::Type getSelectedEventType() const { return this->selectedEventType; }
+    bool selectEventType(Event::Type type);
+    void setEventTypeVisible(Event::Type type, bool visible);
+
 signals:
     void newEventAdded(Event::Type);
+
 private:
+    QMap<Event::Type,QAction*> typeToAction;
     Event::Type selectedEventType;
-    void init();
+    QMenu* menu;
+
+    void addEventType(Event::Type type);
 };
 
 #endif // NEWEVENTTOOLBUTTON_H

--- a/src/core/events.cpp
+++ b/src/core/events.cpp
@@ -112,7 +112,7 @@ QList<Event::Type> Event::types() {
 }
 
 QString Event::typeToString(Event::Type type) {
-    const QMap<Event::Type, QString> typeToStringMap = {
+    static const QMap<Event::Type, QString> typeToStringMap = {
         {Event::Type::Object, "Object"},
         {Event::Type::CloneObject, "Clone Object"},
         {Event::Type::Warp, "Warp"},

--- a/src/core/events.cpp
+++ b/src/core/events.cpp
@@ -73,19 +73,20 @@ void Event::modify() {
     this->map->modify();
 }
 
-const QMap<Event::Group, QString> groupToStringMap = {
-    {Event::Group::Object, "Object"},
-    {Event::Group::Warp, "Warp"},
-    {Event::Group::Coord, "Trigger"},
-    {Event::Group::Bg, "BG"},
-    {Event::Group::Heal, "Heal Location"},
-};
-
 QString Event::groupToString(Event::Group group) {
+    static const QMap<Event::Group, QString> groupToStringMap = {
+        {Event::Group::Object, "Object"},
+        {Event::Group::Warp, "Warp"},
+        {Event::Group::Coord, "Trigger"},
+        {Event::Group::Bg, "BG"},
+        {Event::Group::Heal, "Heal Location"},
+    };
     return groupToStringMap.value(group);
 }
 
-const QMap<Event::Type, QString> typeToStringMap = {
+// These are the expected key names used in the map.json files.
+// We re-use them for key names in the copy/paste JSON data,
+const QMap<Event::Type, QString> typeToJsonKeyMap = {
     {Event::Type::Object, "object"},
     {Event::Type::CloneObject, "clone_object"},
     {Event::Type::Warp, "warp"},
@@ -97,12 +98,32 @@ const QMap<Event::Type, QString> typeToStringMap = {
     {Event::Type::HealLocation, "heal_location"},
 };
 
-QString Event::typeToString(Event::Type type) {
-    return typeToStringMap.value(type);
+QString Event::typeToJsonKey(Event::Type type) {
+    return typeToJsonKeyMap.value(type);
 }
 
-Event::Type Event::typeFromString(QString type) {
-    return typeToStringMap.key(type, Event::Type::None);
+Event::Type Event::typeFromJsonKey(QString type) {
+    return typeToJsonKeyMap.key(type, Event::Type::None);
+}
+
+QList<Event::Type> Event::types() {
+    static QList<Event::Type> typeList = typeToJsonKeyMap.keys();
+    return typeList;
+}
+
+QString Event::typeToString(Event::Type type) {
+    const QMap<Event::Type, QString> typeToStringMap = {
+        {Event::Type::Object, "Object"},
+        {Event::Type::CloneObject, "Clone Object"},
+        {Event::Type::Warp, "Warp"},
+        {Event::Type::Trigger, "Trigger"},
+        {Event::Type::WeatherTrigger, "Weather"},
+        {Event::Type::Sign, "Sign"},
+        {Event::Type::HiddenItem, "Hidden Item"},
+        {Event::Type::SecretBase, "Secret Base"},
+        {Event::Type::HealLocation, "Heal Location"},
+    };
+    return typeToStringMap.value(type);
 }
 
 void Event::loadPixmap(Project *project) {

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -1148,6 +1148,7 @@ void Editor::unsetMap() {
         this->map->pruneEditHistory();
         this->map->disconnect(this);
     }
+    clearMapEvents();
     clearMapConnections();
 
     this->map = nullptr;

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -2109,7 +2109,6 @@ void MainWindow::updateSelectedEvents() {
         ui->tabWidget_EventType->setCurrentWidget(ui->tab_Multiple);
     }
 
-    // (Currently 'events' can't be empty here, but we'll check anyway in case that changes)
     if (!events.isEmpty()) {
         // Set the 'New Event' button to be the type of the most recently-selected event
         ui->newEventToolButton->selectEventType(events.constLast()->getEventType());

--- a/src/project.cpp
+++ b/src/project.cpp
@@ -206,7 +206,7 @@ bool Project::readMapJson(const QString &mapName, QJsonDocument * out) {
 
 bool Project::loadMapEvent(Map *map, const QJsonObject &json, Event::Type defaultType) {
     QString typeString = ParseUtil::jsonToQString(json["type"]);
-    Event::Type type = typeString.isEmpty() ? defaultType : Event::typeFromString(typeString);
+    Event::Type type = typeString.isEmpty() ? defaultType : Event::typeFromJsonKey(typeString);
     Event* event = Event::create(type);
     if (!event) {
         return false;

--- a/src/ui/neweventtoolbutton.cpp
+++ b/src/ui/neweventtoolbutton.cpp
@@ -8,117 +8,53 @@ NewEventToolButton::NewEventToolButton(QWidget *parent) :
 {
     setPopupMode(QToolButton::MenuButtonPopup);
     QObject::connect(this, &NewEventToolButton::triggered, this, &NewEventToolButton::setDefaultAction);
-    this->init();
+
+    this->menu = new QMenu(this);
+    for (const auto &type : Event::types()) {
+        addEventType(type);
+    }
+    setMenu(this->menu);
+    setDefaultAction(this->menu->actions().constFirst());
 }
 
-void NewEventToolButton::init()
-{
-    // Add a context menu to select different types of map events.
-    this->newObjectAction = new QAction("New Object", this);
-    this->newObjectAction->setIcon(QIcon(":/icons/add.ico"));
-    connect(this->newObjectAction, &QAction::triggered, this, &NewEventToolButton::newObject);
+void NewEventToolButton::addEventType(Event::Type type) {
+    if (this->typeToAction.contains(type))
+        return;
 
-    this->newCloneObjectAction = new QAction("New Clone Object", this);
-    this->newCloneObjectAction->setIcon(QIcon(":/icons/add.ico"));
-    connect(this->newCloneObjectAction, &QAction::triggered, this, &NewEventToolButton::newCloneObject);
+    auto action = new QAction(QStringLiteral("New ") + Event::typeToString(type), this);
+    action->setIcon(QIcon(QStringLiteral(":/icons/add.ico")));
+    connect(action, &QAction::triggered, [this, type] {
+        this->selectedEventType = type;
+        emit newEventAdded(this->selectedEventType);
+    });
 
-    this->newWarpAction = new QAction("New Warp", this);
-    this->newWarpAction->setIcon(QIcon(":/icons/add.ico"));
-    connect(this->newWarpAction, &QAction::triggered, this, &NewEventToolButton::newWarp);
-
-    this->newHealLocationAction = new QAction("New Heal Location", this);
-    this->newHealLocationAction->setIcon(QIcon(":/icons/add.ico"));
-    connect(this->newHealLocationAction, &QAction::triggered, this, &NewEventToolButton::newHealLocation);
-
-    this->newTriggerAction = new QAction("New Trigger", this);
-    this->newTriggerAction->setIcon(QIcon(":/icons/add.ico"));
-    connect(this->newTriggerAction, &QAction::triggered, this, &NewEventToolButton::newTrigger);
-
-    this->newWeatherTriggerAction = new QAction("New Weather Trigger", this);
-    this->newWeatherTriggerAction->setIcon(QIcon(":/icons/add.ico"));
-    connect(this->newWeatherTriggerAction, &QAction::triggered, this, &NewEventToolButton::newWeatherTrigger);
-
-    this->newSignAction = new QAction("New Sign", this);
-    this->newSignAction->setIcon(QIcon(":/icons/add.ico"));
-    connect(this->newSignAction, &QAction::triggered, this, &NewEventToolButton::newSign);
-
-    this->newHiddenItemAction = new QAction("New Hidden Item", this);
-    this->newHiddenItemAction->setIcon(QIcon(":/icons/add.ico"));
-    connect(this->newHiddenItemAction, &QAction::triggered, this, &NewEventToolButton::newHiddenItem);
-
-    this->newSecretBaseAction = new QAction("New Secret Base", this);
-    this->newSecretBaseAction->setIcon(QIcon(":/icons/add.ico"));
-    connect(this->newSecretBaseAction, &QAction::triggered, this, &NewEventToolButton::newSecretBase);
-
-    QMenu *alignMenu = new QMenu(this);
-    alignMenu->addAction(this->newObjectAction);
-    alignMenu->addAction(this->newCloneObjectAction);
-    alignMenu->addAction(this->newWarpAction);
-    alignMenu->addAction(this->newHealLocationAction);
-    alignMenu->addAction(this->newTriggerAction);
-    alignMenu->addAction(this->newWeatherTriggerAction);
-    alignMenu->addAction(this->newSignAction);
-    alignMenu->addAction(this->newHiddenItemAction);
-    alignMenu->addAction(this->newSecretBaseAction);
-    this->setMenu(alignMenu);
-    this->setDefaultAction(this->newObjectAction);
+    this->typeToAction.insert(type, action);
+    this->menu->addAction(action);
 }
 
-Event::Type NewEventToolButton::getSelectedEventType()
-{
-    return this->selectedEventType;
+bool NewEventToolButton::selectEventType(Event::Type type) {
+    auto action = this->typeToAction.value(type);
+    if (!action || !action->isVisible())
+        return false;
+
+    this->selectedEventType = type;
+    setDefaultAction(action);
+    return true;
 }
 
-void NewEventToolButton::newObject()
-{
-    this->selectedEventType = Event::Type::Object;
-    emit newEventAdded(this->selectedEventType);
-}
+void NewEventToolButton::setEventTypeVisible(Event::Type type, bool visible) {
+    auto action = this->typeToAction.value(type);
+    if (!action)
+        return;
 
-void NewEventToolButton::newCloneObject()
-{
-    this->selectedEventType = Event::Type::CloneObject;
-    emit newEventAdded(this->selectedEventType);
-}
+    action->setVisible(visible);
 
-void NewEventToolButton::newWarp()
-{
-    this->selectedEventType = Event::Type::Warp;
-    emit newEventAdded(this->selectedEventType);
-}
-
-void NewEventToolButton::newHealLocation()
-{
-    this->selectedEventType = Event::Type::HealLocation;
-    emit newEventAdded(this->selectedEventType);
-}
-
-void NewEventToolButton::newTrigger()
-{
-    this->selectedEventType = Event::Type::Trigger;
-    emit newEventAdded(this->selectedEventType);
-}
-
-void NewEventToolButton::newWeatherTrigger()
-{
-    this->selectedEventType = Event::Type::WeatherTrigger;
-    emit newEventAdded(this->selectedEventType);
-}
-
-void NewEventToolButton::newSign()
-{
-    this->selectedEventType = Event::Type::Sign;
-    emit newEventAdded(this->selectedEventType);
-}
-
-void NewEventToolButton::newHiddenItem()
-{
-    this->selectedEventType = Event::Type::HiddenItem;
-    emit newEventAdded(this->selectedEventType);
-}
-
-void NewEventToolButton::newSecretBase()
-{
-    this->selectedEventType = Event::Type::SecretBase;
-    emit newEventAdded(this->selectedEventType);
+    // If we just hid the currently-selected type we need to pick a new type.
+    if (this->selectedEventType == type) {
+        for (const auto &newType : Event::types()) {
+            if (newType != type && selectEventType(newType)){
+                break;
+            }
+        }
+    }
 }


### PR DESCRIPTION
Generalize the new event tool button to make future support for arbitrary event types a little easier. Also fixes #618 and #695.