### PR TITLE
Fix some clazy warnings

### DIFF
--- a/src/core/editcommands.cpp
+++ b/src/core/editcommands.cpp
@@ -220,7 +220,7 @@ void ResizeLayout::redo() {
     layout->lastCommitBlocks.layoutDimensions = QSize(layout->getWidth(), layout->getHeight());
     layout->lastCommitBlocks.borderDimensions = QSize(layout->getBorderWidth(), layout->getBorderHeight());
 
-    layout->needsRedrawing();
+    emit layout->needsRedrawing();
 }
 
 void ResizeLayout::undo() {
@@ -237,7 +237,7 @@ void ResizeLayout::undo() {
     layout->lastCommitBlocks.layoutDimensions = QSize(layout->getWidth(), layout->getHeight());
     layout->lastCommitBlocks.borderDimensions = QSize(layout->getBorderWidth(), layout->getBorderHeight());
 
-    layout->needsRedrawing();
+    emit layout->needsRedrawing();
 
     QUndoCommand::undo();
 }

--- a/src/core/events.cpp
+++ b/src/core/events.cpp
@@ -206,7 +206,7 @@ bool ObjectEvent::loadFromJson(const QJsonObject &json, Project *) {
 }
 
 void ObjectEvent::setDefaultValues(Project *project) {
-    this->setGfx(project->gfxDefines.keys().value(0, "0"));
+    this->setGfx(project->gfxDefines.key(0, "0"));
     this->setMovement(project->movementTypes.value(0, "0"));
     this->setScript("NULL");
     this->setTrainerType(project->trainerTypes.value(0, "0"));
@@ -310,7 +310,7 @@ bool CloneObjectEvent::loadFromJson(const QJsonObject &json, Project *project) {
 }
 
 void CloneObjectEvent::setDefaultValues(Project *project) {
-    this->setGfx(project->gfxDefines.keys().value(0, "0"));
+    this->setGfx(project->gfxDefines.key(0, "0"));
     this->setTargetID(1);
     if (this->getMap()) this->setTargetMap(this->getMap()->name());
 }

--- a/src/core/parseutil.cpp
+++ b/src/core/parseutil.cpp
@@ -677,7 +677,6 @@ bool ParseUtil::tryParseJsonFile(QJsonDocument *out, const QString &filepath, QS
 }
 
 bool ParseUtil::tryParseOrderedJsonFile(poryjson::Json::object *out, const QString &filepath, QString *error) {
-    QString err;
     QString jsonTxt = readTextFile(filepath, error);
     if (error && !error->isEmpty()) {
         return false;

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -865,7 +865,7 @@ void Editor::displayDivingConnection(MapConnection *connection) {
 }
 
 void Editor::renderDivingConnections() {
-    for (auto item : diving_map_items.values())
+    for (auto &item : diving_map_items)
         item->updatePixmap();
 }
 
@@ -1696,7 +1696,7 @@ void Editor::removeEventPixmapItem(Event *event) {
 }
 
 void Editor::clearMapConnections() {
-    for (auto item : connection_items) {
+    for (auto &item : connection_items) {
         if (item->scene())
             item->scene()->removeItem(item);
         delete item;
@@ -1708,7 +1708,7 @@ void Editor::clearMapConnections() {
     ui->comboBox_DiveMap->setCurrentText("");
     ui->comboBox_EmergeMap->setCurrentText("");
 
-    for (auto item : diving_map_items.values()) {
+    for (auto &item : diving_map_items) {
         if (item->scene())
             item->scene()->removeItem(item);
         delete item;

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1546,9 +1546,9 @@ void MainWindow::updateMapList() {
     this->mapLocationModel->setActiveItem(activeItemName);
     this->layoutTreeModel->setActiveItem(activeItemName);
 
-    this->groupListProxyModel->layoutChanged();
-    this->locationListProxyModel->layoutChanged();
-    this->layoutListProxyModel->layoutChanged();
+    emit this->groupListProxyModel->layoutChanged();
+    emit this->locationListProxyModel->layoutChanged();
+    emit this->layoutListProxyModel->layoutChanged();
 }
 
 void MainWindow::on_action_Save_Project_triggered() {

--- a/src/ui/resizelayoutpopup.cpp
+++ b/src/ui/resizelayoutpopup.cpp
@@ -172,7 +172,7 @@ void ResizeLayoutPopup::setupLayoutView() {
     scene->addItem(outline);
 
     layoutPixmap->setBoundary(outline);
-    this->outline->rectUpdated(outline->rect().toAlignedRect());
+    emit this->outline->rectUpdated(outline->rect().toAlignedRect());
 
     // TODO: is this an ideal size for all maps, or should this adjust based on starting dimensions?
     this->ui->graphicsView->setTransform(QTransform::fromScale(0.5, 0.5));

--- a/src/ui/tileseteditor.cpp
+++ b/src/ui/tileseteditor.cpp
@@ -123,8 +123,8 @@ void TilesetEditor::setTilesets(QString primaryTilesetLabel, QString secondaryTi
 void TilesetEditor::setAttributesUi() {
     // Behavior
     if (projectConfig.metatileBehaviorMask) {
-        for (int num : project->metatileBehaviorMapInverse.keys()) {
-            this->ui->comboBox_metatileBehaviors->addItem(project->metatileBehaviorMapInverse[num], num);
+        for (auto i = project->metatileBehaviorMapInverse.constBegin(); i != project->metatileBehaviorMapInverse.constEnd(); i++) {
+            this->ui->comboBox_metatileBehaviors->addItem(i.value(), i.key());
         }
         this->ui->comboBox_metatileBehaviors->setMinimumContentsLength(0);
     } else {
@@ -1123,7 +1123,7 @@ void TilesetEditor::countTileUsage() {
     QSet<Tileset*> primaryTilesets;
     QSet<Tileset*> secondaryTilesets;
 
-    for (auto layout : this->project->mapLayouts.values()) {
+    for (auto &layout : this->project->mapLayouts) {
         this->project->loadLayoutTilesets(layout);
         if (layout->tileset_primary_label == this->primaryTileset->name
          || layout->tileset_secondary_label == this->secondaryTileset->name) {


### PR DESCRIPTION
Fix clazy warnings for [container-anti-pattern](https://github.com/KDE/clazy/blob/master/docs/checks/README-container-anti-pattern.md), [incorrect-emit](https://github.com/KDE/clazy/blob/master/docs/checks/README-incorrect-emit.md), and [unused-non-trivial-variable](https://github.com/KDE/clazy/blob/master/docs/checks/README-unused-non-trivial-variable.md)