### PR TITLE
More fixes from layout split

### DIFF
--- a/docsrc/manual/scripting-capabilities.rst
+++ b/docsrc/manual/scripting-capabilities.rst
@@ -153,10 +153,17 @@ Callbacks
 
 .. js:function:: onMapOpened(mapName)
 
-   Called when a map or layout is opened.
+   Called when a map is opened.
 
-   :param mapName: the name of the opened map or layout
+   :param mapName: the name of the opened map
    :type mapName: string
+
+.. js:function:: onLayoutOpened(layoutName)
+
+   Called when a layout is opened, either by selecting a new map/layout in the map list or swapping the layout for the current map.
+
+   :param layoutName: the name of the opened layout
+   :type layoutName: string
 
 .. js:function:: onBlockChanged(x, y, prevBlock, newBlock)
 

--- a/include/config.h
+++ b/include/config.h
@@ -52,6 +52,8 @@ public:
         this->projectManuallyClosed = false;
         this->reopenOnLaunch = true;
         this->mapListTab = 0;
+        this->mapListEditGroupsEnabled = false;
+        this->mapListHideEmptyEnabled.clear();
         this->prettyCursors = true;
         this->mirrorConnectingMaps = true;
         this->showDiveEmergeMaps = false;
@@ -110,6 +112,8 @@ public:
     bool reopenOnLaunch;
     bool projectManuallyClosed;
     int mapListTab;
+    bool mapListEditGroupsEnabled;
+    QMap<int, bool> mapListHideEmptyEnabled;
     bool prettyCursors;
     bool mirrorConnectingMaps;
     bool showDiveEmergeMaps;

--- a/include/core/map.h
+++ b/include/core/map.h
@@ -48,11 +48,8 @@ public:
     static QString mapConstantFromName(const QString &name);
     QString expectedConstantName() const { return Map::mapConstantFromName(m_name); }
 
-    void setLayout(Layout *layout);
+    void setLayout(Layout *layout) { m_layout = layout; }
     Layout* layout() const { return m_layout; }
-
-    void setLayoutId(const QString &layoutId) { m_layoutId = layoutId; }
-    QString layoutId() const { return m_layoutId; }
 
     int getWidth() const;
     int getHeight() const;
@@ -71,10 +68,12 @@ public:
     void setNeedsHealLocation(bool needsHealLocation) { m_needsHealLocation = needsHealLocation; }
     void setIsPersistedToFile(bool persistedToFile) { m_isPersistedToFile = persistedToFile; }
     void setHasUnsavedDataChanges(bool unsavedDataChanges) { m_hasUnsavedDataChanges = unsavedDataChanges; }
+    void setLoaded(bool loaded) { m_loaded = loaded; }
 
     bool needsHealLocation() const { return m_needsHealLocation; }
     bool isPersistedToFile() const { return m_isPersistedToFile; }
     bool hasUnsavedDataChanges() const { return m_hasUnsavedDataChanges; }
+    bool loaded() const { return m_loaded; }
 
     void resetEvents();
     QList<Event *> getEvents(Event::Group group = Event::Group::None) const;
@@ -109,7 +108,6 @@ public:
 private:
     QString m_name;
     QString m_constantName;
-    QString m_layoutId;
     QString m_sharedEventsMap = "";
     QString m_sharedScriptsMap = "";
 
@@ -123,6 +121,7 @@ private:
     bool m_hasUnsavedDataChanges = false;
     bool m_needsHealLocation = false;
     bool m_scriptsLoaded = false;
+    bool m_loaded = false;
 
     QMap<Event::Group, QList<Event *>> m_events;
     QSet<Event *> m_ownedEvents; // for memory management

--- a/include/core/map.h
+++ b/include/core/map.h
@@ -48,7 +48,7 @@ public:
     static QString mapConstantFromName(const QString &name);
     QString expectedConstantName() const { return Map::mapConstantFromName(m_name); }
 
-    void setLayout(Layout *layout) { m_layout = layout; }
+    void setLayout(Layout *layout);
     Layout* layout() const { return m_layout; }
 
     int getWidth() const;
@@ -143,6 +143,7 @@ signals:
     void openScriptRequested(QString label);
     void connectionAdded(MapConnection*);
     void connectionRemoved(MapConnection*);
+    void layoutChanged();
 };
 
 #endif // MAP_H

--- a/include/core/map.h
+++ b/include/core/map.h
@@ -68,12 +68,10 @@ public:
     void setNeedsHealLocation(bool needsHealLocation) { m_needsHealLocation = needsHealLocation; }
     void setIsPersistedToFile(bool persistedToFile) { m_isPersistedToFile = persistedToFile; }
     void setHasUnsavedDataChanges(bool unsavedDataChanges) { m_hasUnsavedDataChanges = unsavedDataChanges; }
-    void setLoaded(bool loaded) { m_loaded = loaded; }
 
     bool needsHealLocation() const { return m_needsHealLocation; }
     bool isPersistedToFile() const { return m_isPersistedToFile; }
     bool hasUnsavedDataChanges() const { return m_hasUnsavedDataChanges; }
-    bool loaded() const { return m_loaded; }
 
     void resetEvents();
     QList<Event *> getEvents(Event::Group group = Event::Group::None) const;
@@ -121,7 +119,6 @@ private:
     bool m_hasUnsavedDataChanges = false;
     bool m_needsHealLocation = false;
     bool m_scriptsLoaded = false;
-    bool m_loaded = false;
 
     QMap<Event::Group, QList<Event *>> m_events;
     QSet<Event *> m_ownedEvents; // for memory management

--- a/include/core/maplayout.h
+++ b/include/core/maplayout.h
@@ -22,7 +22,6 @@ public:
 
     static QString layoutConstantFromName(const QString &name);
 
-    bool loaded = false;
     bool hasUnsavedDataChanges = false;
 
     QString id;

--- a/include/core/maplayout.h
+++ b/include/core/maplayout.h
@@ -141,9 +141,7 @@ private:
     void setNewBorderDimensionsBlockdata(int newWidth, int newHeight);
 
 signals:
-    void layoutChanged(Layout *layout);
-    //void modified();
-    void layoutDimensionsChanged(const QSize &size);
+    void dimensionsChanged(const QSize &size);
     void needsRedrawing();
 };
 

--- a/include/core/validator.h
+++ b/include/core/validator.h
@@ -34,7 +34,7 @@ public:
     QString prefix() const { return m_prefix; }
     void setPrefix(const QString &prefix);
 
-    bool isValid(QString &input) const;
+    bool isValid(const QString &input) const;
 
 private:
     QString m_prefix;

--- a/include/mainwindow.h
+++ b/include/mainwindow.h
@@ -423,6 +423,7 @@ private:
     double getMetatilesZoomScale();
     void redrawMetatileSelection();
     void scrollMetatileSelectorToSelection();
+    MapListToolBar* getMapListToolBar(int tab);
     MapListToolBar* getCurrentMapListToolBar();
     MapTree* getCurrentMapList();
     void setLocationComboBoxes(const QStringList &locations);

--- a/include/mainwindow.h
+++ b/include/mainwindow.h
@@ -186,7 +186,6 @@ private slots:
     void copy();
     void paste();
 
-    void onLayoutChanged(Layout *layout);
     void onOpenConnectedMap(MapConnection*);
     void onTilesetsSaved(QString, QString);
     void onNewMapCreated(Map *newMap, const QString &groupName);
@@ -383,6 +382,8 @@ private:
 
     void refreshRecentProjectsMenu();
 
+    void rebuildMapList_Locations();
+    void rebuildMapList_Layouts();
     void updateMapList();
     void openMapListItem(const QModelIndex &index);
     void onMapListTabChanged(int index);

--- a/include/mainwindow.h
+++ b/include/mainwindow.h
@@ -204,6 +204,7 @@ private slots:
     void on_actionNew_Tileset_triggered();
     void on_action_Save_triggered();
     void on_action_Exit_triggered();
+    void onLayoutSelectorEditingFinished();
     void on_comboBox_LayoutSelector_currentTextChanged(const QString &text);
     void on_actionShortcuts_triggered();
 

--- a/include/project.h
+++ b/include/project.h
@@ -131,7 +131,7 @@ public:
     Layout *createNewLayout(const Layout::Settings &layoutSettings, const Layout* toDuplicate = nullptr);
     Tileset *createNewTileset(QString name, bool secondary, bool checkerboardFill);
     bool isIdentifierUnique(const QString &identifier) const;
-    bool isValidNewIdentifier(QString identifier) const;
+    bool isValidNewIdentifier(const QString &identifier) const;
     QString toUniqueIdentifier(const QString &identifier) const;
     QString getProjectTitle() const;
     QString getNewHealLocationName(const Map* map) const;
@@ -147,7 +147,7 @@ public:
     QString getDefaultSpeciesIconPath(const QString &species);
     QPixmap getSpeciesIcon(const QString &species);
 
-    void addNewMapsec(const QString &idName);
+    bool addNewMapsec(const QString &idName, const QString &displayName = QString());
     void removeMapsec(const QString &idName);
     QString getMapsecDisplayName(const QString &idName) const { return this->mapSectionDisplayNames.value(idName); }
     void setMapsecDisplayName(const QString &idName, const QString &displayName);

--- a/include/project.h
+++ b/include/project.h
@@ -92,6 +92,11 @@ public:
     // Note: This does not guarantee the map is loaded.
     Map* getMap(const QString &mapName) { return this->maps.value(mapName); }
 
+    bool isMapLoaded(const Map *map) const { return map && isMapLoaded(map->name()); }
+    bool isMapLoaded(const QString &mapName) const { return this->loadedMapNames.contains(mapName); }
+    bool isLayoutLoaded(const Layout *layout) const { return layout && isLayoutLoaded(layout->id); }
+    bool isLayoutLoaded(const QString &layoutId) const { return this->loadedLayoutIds.contains(layoutId); }
+
     QMap<QString, Tileset*> tilesetCache;
     Tileset* loadTileset(QString, Tileset *tileset = nullptr);
     Tileset* getTileset(QString, bool forceLoad = false);
@@ -259,6 +264,15 @@ private:
     QMap<QString, QString> facingDirections;
     QHash<QString, QString> speciesToIconPath;
     QHash<QString, Map*> maps;
+
+    // Maps/layouts represented in these sets have been fully loaded from the project.
+    // If a valid map name / layout id is not in these sets, a Map / Layout object exists
+    // for it in Project::maps / Project::mapLayouts, but it has been minimally populated
+    // (i.e. for a map layout it only has the data read from layouts.json, none of its assets
+    // have been loaded, and for a map it only has the data needed to identify it in the map
+    // list, none of the rest of its data in map.json).
+    QSet<QString> loadedMapNames;
+    QSet<QString> loadedLayoutIds;
 
     const QRegularExpression re_gbapalExtension;
     const QRegularExpression re_bppExtension;

--- a/include/project.h
+++ b/include/project.h
@@ -37,9 +37,6 @@ public:
     QStringList healLocationSaveOrder;
     QMap<QString, QList<HealLocationEvent*>> healLocations;
     QMap<QString, QString> mapConstantsToMapNames;
-    QMap<QString, QString> mapNamesToMapConstants;
-    QMap<QString, QString> mapNameToLayoutId;
-    QMap<QString, QString> mapNameToMapSectionName;
     QString layoutsLabel;
     QStringList layoutIds;
     QStringList layoutIdsMaster;
@@ -81,7 +78,7 @@ public:
 
     void set_root(QString);
 
-    void clearMapCache();
+    void clearMaps();
     void clearTilesetCache();
     void clearMapLayouts();
     void clearEventGraphics();
@@ -90,9 +87,10 @@ public:
     bool sanityCheck();
     bool load();
 
-    QMap<QString, Map*> mapCache;
-    Map* loadMap(QString);
-    Map* getMap(QString);
+    Map* loadMap(const QString &mapName);
+
+    // Note: This does not guarantee the map is loaded.
+    Map* getMap(const QString &mapName) { return this->maps.value(mapName); }
 
     QMap<QString, Tileset*> tilesetCache;
     Tileset* loadTileset(QString, Tileset *tileset = nullptr);
@@ -111,7 +109,10 @@ public:
 
     bool readMapGroups();
     void addNewMapGroup(const QString &groupName);
-    QString mapNameToMapGroup(const QString &mapName);
+    QString mapNameToMapGroup(const QString &mapName) const;
+    QString getMapConstant(const QString &mapName, const QString &defaultValue = QString()) const;
+    QString getMapLayoutId(const QString &mapName, const QString &defaultValue = QString()) const;
+    QString getMapLocation(const QString &mapName, const QString &defaultValue = QString()) const;
 
     struct NewMapSettings {
         QString name;
@@ -253,10 +254,11 @@ public:
     static QString getMapGroupPrefix();
 
 private:
-    QMap<QString, QString> mapSectionDisplayNames;
+    QHash<QString, QString> mapSectionDisplayNames;
     QMap<QString, qint64> modifiedFileTimestamps;
     QMap<QString, QString> facingDirections;
-    QMap<QString, QString> speciesToIconPath;
+    QHash<QString, QString> speciesToIconPath;
+    QHash<QString, Map*> maps;
 
     const QRegularExpression re_gbapalExtension;
     const QRegularExpression re_bppExtension;

--- a/include/scripting.h
+++ b/include/scripting.h
@@ -9,6 +9,8 @@
 #include <QStringList>
 #include <QJSEngine>
 
+// !! New callback functions or changes to existing callback function names/arguments
+//    should be synced to resources/text/script_template.txt and docsrc/manual/scripting-capabilities.rst
 enum CallbackType {
     OnProjectOpened,
     OnProjectClosed,
@@ -17,6 +19,7 @@ enum CallbackType {
     OnBlockHoverChanged,
     OnBlockHoverCleared,
     OnMapOpened,
+    OnLayoutOpened,
     OnMapResized,
     OnBorderResized,
     OnMapShifted,
@@ -43,6 +46,7 @@ public:
     static void cb_BlockHoverChanged(int x, int y);
     static void cb_BlockHoverCleared();
     static void cb_MapOpened(QString mapName);
+    static void cb_LayoutOpened(QString layoutName);
     static void cb_MapResized(int oldWidth, int oldHeight, int newWidth, int newHeight);
     static void cb_BorderResized(int oldWidth, int oldHeight, int newWidth, int newHeight);
     static void cb_MapShifted(int xDelta, int yDelta);

--- a/include/ui/maplisttoolbar.h
+++ b/include/ui/maplisttoolbar.h
@@ -42,6 +42,8 @@ public:
 signals:
     void filterCleared(MapTree*);
     void addFolderClicked();
+    void editsAllowedChanged(bool allowed);
+    void emptyFoldersVisibleChanged(bool visible);
 
 private:
     Ui::MapListToolBar *ui;

--- a/include/ui/mapview.h
+++ b/include/ui/mapview.h
@@ -70,11 +70,13 @@ public:
     Q_INVOKABLE void addTileImage(int x, int y, QJSValue tileObj, bool setTransparency = false, int layer = 0);
     Q_INVOKABLE void addMetatileImage(int x, int y, int metatileId, bool setTransparency = false, int layer = 0);
 
-private:
-    QMap<int, Overlay*> overlayMap;
 protected:
     virtual void drawForeground(QPainter *painter, const QRectF &rect) override;
     virtual void keyPressEvent(QKeyEvent*) override;
+private:
+    QMap<int, Overlay*> overlayMap;
+
+    void updateScene();
 };
 
 #endif // GRAPHICSVIEW_H

--- a/porymap.pro
+++ b/porymap.pro
@@ -30,7 +30,7 @@ win32 {
 
 DEFINES += PORYMAP_LATEST_COMMIT=\\\"$$LATEST_COMMIT\\\"
 
-VERSION = 5.4.1
+VERSION = 6.0.0
 DEFINES += PORYMAP_VERSION=\\\"$$VERSION\\\"
 
 SOURCES += src/core/advancemapparser.cpp \

--- a/resources/text/script_template.txt
+++ b/resources/text/script_template.txt
@@ -13,6 +13,11 @@ export function onMapOpened(mapName) {
 
 }
 
+// Called when a layout is opened, either by selecting a new map/layout in the map list or swapping the layout for the current map.
+export function onLayoutOpened(layoutName) {
+
+}
+
 // Called when a block is changed on the map. For example, this is called when a user paints a new tile or changes the collision property of a block.
 export function onBlockChanged(x, y, prevBlock, newBlock) {
 

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -304,6 +304,16 @@ void PorymapConfig::parseConfigKeyValue(QString key, QString value) {
         this->prettyCursors = getConfigBool(key, value);
     } else if (key == "map_list_tab") {
         this->mapListTab = getConfigInteger(key, value, 0, 2, 0);
+    } else if (key == "map_list_edit_groups_enabled") {
+        this->mapListEditGroupsEnabled = getConfigBool(key, value);
+    } else if (key.startsWith("map_list_hide_empty_enabled/")) {
+        bool ok;
+        int tab = key.mid(QStringLiteral("map_list_hide_empty_enabled/").length()).toInt(&ok, 0);
+        if (!ok) {
+            logWarn(QString("Invalid config key found in config file %1: '%2'").arg(this->getConfigFilepath()).arg(key));
+            return;
+        }
+        this->mapListHideEmptyEnabled.insert(tab, getConfigBool(key, value));
     } else if (key == "main_window_geometry") {
         this->mainWindowGeometry = bytesFromString(value);
     } else if (key == "main_window_state") {
@@ -445,6 +455,10 @@ QMap<QString, QString> PorymapConfig::getKeyValueMap() {
     map.insert("reopen_on_launch", this->reopenOnLaunch ? "1" : "0");
     map.insert("pretty_cursors", this->prettyCursors ? "1" : "0");
     map.insert("map_list_tab", QString::number(this->mapListTab));
+    map.insert("map_list_edit_groups_enabled", this->mapListEditGroupsEnabled ? "1" : "0");
+    for (auto i = this->mapListHideEmptyEnabled.constBegin(); i != this->mapListHideEmptyEnabled.constEnd(); i++) {
+        map.insert(QStringLiteral("map_list_hide_empty_enabled/") + QString::number(i.key()), i.value() ? "1" : "0");
+    }
     map.insert("main_window_geometry", stringFromByteArray(this->mainWindowGeometry));
     map.insert("main_window_state", stringFromByteArray(this->mainWindowState));
     map.insert("map_splitter_state", stringFromByteArray(this->mapSplitterState));
@@ -769,14 +783,14 @@ void ProjectConfig::parseConfigKeyValue(QString key, QString value) {
         userConfig.parseCustomScripts(value);
 #endif
     } else if (key.startsWith("path/")) {
-        auto k = reverseDefaultPaths(key.mid(5));
+        auto k = reverseDefaultPaths(key.mid(QStringLiteral("path/").length()));
         if (k != static_cast<ProjectFilePath>(-1)) {
             this->setFilePath(k, value);
         } else {
             logWarn(QString("Invalid config key found in config file %1: '%2'").arg(this->getConfigFilepath()).arg(key));
         }
     } else if (key.startsWith("ident/")) {
-        auto identifierId = reverseDefaultIdentifier(key.mid(6));
+        auto identifierId = reverseDefaultIdentifier(key.mid(QStringLiteral("ident/").length()));
         if (identifierId != static_cast<ProjectIdentifier>(-1)) {
             this->setIdentifier(identifierId, value);
         } else {
@@ -803,7 +817,7 @@ void ProjectConfig::parseConfigKeyValue(QString key, QString value) {
     } else if (key == "event_icon_path_heal") {
         this->eventIconPaths[Event::Group::Heal] = value;
     } else if (key.startsWith("pokemon_icon_path/")) {
-        this->pokemonIconPaths.insert(key.mid(18).toUpper(), value);
+        this->pokemonIconPaths.insert(key.mid(QStringLiteral("pokemon_icon_path/").length()).toUpper(), value);
     } else if (key == "collision_sheet_path") {
         this->collisionSheetPath = value;
     } else if (key == "collision_sheet_width") {

--- a/src/core/events.cpp
+++ b/src/core/events.cpp
@@ -285,7 +285,7 @@ OrderedJson::object CloneObjectEvent::buildEventJson(Project *project) {
     cloneJson["y"] = this->getY();
     cloneJson["target_local_id"] = this->getTargetID();
     const QString mapName = this->getTargetMap();
-    cloneJson["target_map"] = project->mapNamesToMapConstants.value(mapName, mapName);
+    cloneJson["target_map"] = project->getMapConstant(mapName, mapName);
     this->addCustomAttributesTo(&cloneJson);
 
     return cloneJson;
@@ -333,7 +333,7 @@ QSet<QString> CloneObjectEvent::getExpectedFields() {
 void CloneObjectEvent::loadPixmap(Project *project) {
     // Try to get the targeted object to clone
     int eventIndex = this->targetID - 1;
-    Map *clonedMap = project->getMap(this->targetMap);
+    Map *clonedMap = project->loadMap(this->targetMap);
     Event *clonedEvent = clonedMap ? clonedMap->getEvent(Event::Group::Object, eventIndex) : nullptr;
 
     if (clonedEvent && clonedEvent->getEventType() == Event::Type::Object) {
@@ -380,7 +380,7 @@ OrderedJson::object WarpEvent::buildEventJson(Project *project) {
     warpJson["y"] = this->getY();
     warpJson["elevation"] = this->getElevation();
     const QString mapName = this->getDestinationMap();
-    warpJson["dest_map"] = project->mapNamesToMapConstants.value(mapName, mapName);
+    warpJson["dest_map"] = project->getMapConstant(mapName, mapName);
     warpJson["dest_warp_id"] = this->getDestinationWarpID();
 
     this->addCustomAttributesTo(&warpJson);
@@ -839,7 +839,7 @@ OrderedJson::object HealLocationEvent::buildEventJson(Project *project) {
     healLocationJson["y"] = this->getY();
     if (projectConfig.healLocationRespawnDataEnabled) {
         const QString mapName = this->getRespawnMapName();
-        healLocationJson["respawn_map"] = project->mapNamesToMapConstants.value(mapName, mapName);
+        healLocationJson["respawn_map"] = project->getMapConstant(mapName, mapName);
         healLocationJson["respawn_npc"] = this->getRespawnNPC();
     }
 

--- a/src/core/map.cpp
+++ b/src/core/map.cpp
@@ -47,6 +47,14 @@ Map::~Map() {
     deleteConnections();
 }
 
+// Note: Map does not take ownership of layout
+void Map::setLayout(Layout *layout) {
+    if (layout == m_layout)
+        return;
+    m_layout = layout;
+    emit layoutChanged();
+}
+
 // We don't enforce this for existing maps, but for creating new maps we need to formulaically generate a new MAP_NAME ID.
 QString Map::mapConstantFromName(const QString &name) {
     return projectConfig.getIdentifier(ProjectIdentifier::define_map_prefix) + Util::toDefineCase(name);

--- a/src/core/map.cpp
+++ b/src/core/map.cpp
@@ -23,7 +23,6 @@ Map::Map(QObject *parent) : QObject(parent)
 Map::Map(const Map &other, QObject *parent) : Map(parent) {
     m_name = other.m_name;
     m_constantName = other.m_constantName;
-    m_layoutId = other.m_layoutId;
     m_sharedEventsMap = other.m_sharedEventsMap;
     m_sharedScriptsMap = other.m_sharedScriptsMap;
     m_customAttributes = other.m_customAttributes;
@@ -46,14 +45,6 @@ Map::~Map() {
     qDeleteAll(m_ownedEvents);
     m_ownedEvents.clear();
     deleteConnections();
-}
-
-// Note: Map does not take ownership of layout
-void Map::setLayout(Layout *layout) {
-    m_layout = layout;
-    if (layout) {
-        m_layoutId = layout->id;
-    }
 }
 
 // We don't enforce this for existing maps, but for creating new maps we need to formulaically generate a new MAP_NAME ID.

--- a/src/core/mapconnection.cpp
+++ b/src/core/mapconnection.cpp
@@ -53,7 +53,7 @@ void MapConnection::markMapEdited() {
 }
 
 Map* MapConnection::getMap(const QString& mapName) const {
-    return project ? project->getMap(mapName) : nullptr;
+    return project ? project->loadMap(mapName) : nullptr;
 }
 
 Map* MapConnection::targetMap() const {

--- a/src/core/maplayout.cpp
+++ b/src/core/maplayout.cpp
@@ -168,8 +168,7 @@ void Layout::setDimensions(int newWidth, int newHeight, bool setNewBlockdata, bo
         Scripting::cb_MapResized(oldWidth, oldHeight, newWidth, newHeight);
     }
 
-    emit layoutChanged(this);
-    emit layoutDimensionsChanged(QSize(getWidth(), getHeight()));
+    emit dimensionsChanged(QSize(getWidth(), getHeight()));
 }
 
 void Layout::adjustDimensions(QMargins margins, bool setNewBlockdata) {
@@ -194,8 +193,7 @@ void Layout::adjustDimensions(QMargins margins, bool setNewBlockdata) {
     this->width = newWidth;
     this->height = newHeight;
 
-    emit layoutChanged(this);
-    emit layoutDimensionsChanged(QSize(getWidth(), getHeight()));
+    emit dimensionsChanged(QSize(getWidth(), getHeight()));
 }
 
 void Layout::setBorderDimensions(int newWidth, int newHeight, bool setNewBlockdata, bool enableScriptCallback) {
@@ -211,8 +209,6 @@ void Layout::setBorderDimensions(int newWidth, int newHeight, bool setNewBlockda
     if (enableScriptCallback && (oldWidth != newWidth || oldHeight != newHeight)) {
         Scripting::cb_BorderResized(oldWidth, oldHeight, newWidth, newHeight);
     }
-
-    emit layoutChanged(this);
 }
 
 void Layout::setNewDimensionsBlockdata(int newWidth, int newHeight) {

--- a/src/core/validator.cpp
+++ b/src/core/validator.cpp
@@ -35,7 +35,8 @@ void PrefixValidator::fixup(QString &input) const {
         input.prepend(m_prefix);
 }
 
-bool PrefixValidator::isValid(QString &input) const {
+bool PrefixValidator::isValid(const QString &input) const {
     int pos = 0;
-    return validate(input, pos) == QValidator::Acceptable;
+    QString s(input);
+    return validate(s, pos) == QValidator::Acceptable;
 }

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -1191,6 +1191,9 @@ bool Editor::setLayout(QString layoutId) {
         return false;
     }
 
+    QString prevLayoutName;
+    if (this->layout) prevLayoutName = this->layout->name;
+
     Layout *loadedLayout = this->project->loadLayout(layoutId);
     if (!loadedLayout) {
         return false;
@@ -1217,6 +1220,9 @@ bool Editor::setLayout(QString layoutId) {
     int index = this->ui->comboBox_LayoutSelector->findText(layoutId);
     if (index < 0) index = 0;
     this->ui->comboBox_LayoutSelector->setCurrentIndex(index);
+
+    if (this->layout->name != prevLayoutName)
+        Scripting::cb_LayoutOpened(this->layout->name);
 
     return true;
 }

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -1204,7 +1204,7 @@ bool Editor::setLayout(QString layoutId) {
     editGroup.addStack(&this->layout->editHistory);
 
     map_ruler->setMapDimensions(QSize(this->layout->getWidth(), this->layout->getHeight()));
-    connect(this->layout, &Layout::layoutDimensionsChanged, map_ruler, &MapRuler::setMapDimensions);
+    connect(this->layout, &Layout::dimensionsChanged, map_ruler, &MapRuler::setMapDimensions);
 
     ui->comboBox_PrimaryTileset->blockSignals(true);
     ui->comboBox_SecondaryTileset->blockSignals(true);

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -988,7 +988,6 @@ bool MainWindow::setLayout(QString layoutId) {
 
     connect(editor->layout, &Layout::needsRedrawing, this, &MainWindow::redrawMapScene, Qt::UniqueConnection);
 
-    Scripting::cb_MapOpened(layout->name);
     updateTilesetEditor();
 
     userConfig.recentMapOrLayout = layoutId;
@@ -2848,13 +2847,10 @@ void MainWindow::reloadScriptEngine() {
     // Lying to the scripts here, simulating a project reload
     Scripting::cb_ProjectOpened(projectConfig.projectDir);
     if (this->editor) {
-        QString curName;
+        if (this->editor->layout)
+            Scripting::cb_LayoutOpened(this->editor->layout->name);
         if (this->editor->map)
-            curName = this->editor->map->name();
-        else if (editor->layout)
-            curName = this->editor->layout->name;
-
-        Scripting::cb_MapOpened(curName);
+            Scripting::cb_MapOpened(this->editor->map->name());
     }
 }
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1384,7 +1384,7 @@ void MainWindow::openNewMapDialog() {
 }
 
 void MainWindow::openDuplicateMapDialog(const QString &mapName) {
-    const Map *map = this->editor->project->getMap(mapName);
+    const Map *map = this->editor->project->loadMap(mapName);
     if (map) {
         auto dialog = new NewMapDialog(this->editor->project, map, this);
         dialog->open();

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -298,6 +298,7 @@ void MainWindow::initExtraSignals() {
     connect(ui->action_NewMap, &QAction::triggered, this, &MainWindow::openNewMapDialog);
     connect(ui->action_NewLayout, &QAction::triggered, this, &MainWindow::openNewLayoutDialog);
     connect(ui->actionDuplicate_Current_Map_Layout, &QAction::triggered, this, &MainWindow::openDuplicateMapOrLayoutDialog);
+    connect(ui->comboBox_LayoutSelector->lineEdit(), &QLineEdit::editingFinished, this, &MainWindow::onLayoutSelectorEditingFinished);
 }
 
 void MainWindow::on_actionCheck_for_Updates_triggered() {
@@ -1088,6 +1089,18 @@ void MainWindow::on_comboBox_LayoutSelector_currentTextChanged(const QString &te
     this->editor->map->setLayout(layout);
     setMap(this->editor->map->name());
     markMapEdited();
+}
+
+void MainWindow::onLayoutSelectorEditingFinished() {
+    if (!this->editor || !this->editor->project || !this->editor->layout)
+        return;
+
+    // If the user left the layout selector in an invalid state, restore it so that it displays the current layout.
+    const QString text = ui->comboBox_LayoutSelector->currentText();
+    if (!this->editor->project->mapLayouts.contains(text)) {
+        const QSignalBlocker b(ui->comboBox_LayoutSelector);
+        ui->comboBox_LayoutSelector->setCurrentText(this->editor->layout->id);
+    }
 }
 
 // Update the UI using information we've read from the user's project files.

--- a/src/project.cpp
+++ b/src/project.cpp
@@ -2357,7 +2357,7 @@ bool Project::addNewMapsec(const QString &idName, const QString &displayName) {
         return false;
     }
 
-    if (this->mapSectionIdNamesSaveOrder.last() == getEmptyMapsecName()) {
+    if (!this->mapSectionIdNamesSaveOrder.isEmpty() && this->mapSectionIdNamesSaveOrder.last() == getEmptyMapsecName()) {
         // If the default map section name (MAPSEC_NONE) is last in the list we'll keep it last in the list.
         this->mapSectionIdNamesSaveOrder.insert(this->mapSectionIdNames.length() - 1, idName);
     } else {

--- a/src/scriptapi/apioverlay.cpp
+++ b/src/scriptapi/apioverlay.cpp
@@ -2,15 +2,21 @@
 #include "scripting.h"
 #include "imageproviders.h"
 
+void MapView::updateScene() {
+    if (this->scene()) {
+        this->scene()->update();
+    }
+}
+
 void MapView::clear(int layer) {
     this->getOverlay(layer)->clearItems();
-    this->scene()->update();
+    this->updateScene();
 }
 
 // Overload. No layer provided, clear all layers
 void MapView::clear() {
     this->clearOverlayMap();
-    this->scene()->update();
+    this->updateScene();
 }
 
 void MapView::hide(int layer) {
@@ -37,14 +43,14 @@ bool MapView::getVisibility(int layer) {
 
 void MapView::setVisibility(bool visible, int layer) {
     this->getOverlay(layer)->setHidden(!visible);
-    this->scene()->update();
+    this->updateScene();
 }
 
 // Overload. No layer provided, set visibility of all layers
 void MapView::setVisibility(bool visible) {
     foreach (Overlay * layer, this->overlayMap)
         layer->setHidden(!visible);
-    this->scene()->update();
+    this->updateScene();
 }
 
 int MapView::getX(int layer) {
@@ -57,49 +63,49 @@ int MapView::getY(int layer) {
 
 void MapView::setX(int x, int layer) {
     this->getOverlay(layer)->setX(x);
-    this->scene()->update();
+    this->updateScene();
 }
 
 // Overload. No layer provided, set x of all layers
 void MapView::setX(int x) {
     foreach (Overlay * layer, this->overlayMap)
         layer->setX(x);
-    this->scene()->update();
+    this->updateScene();
 }
 
 void MapView::setY(int y, int layer) {
     this->getOverlay(layer)->setY(y);
-    this->scene()->update();
+    this->updateScene();
 }
 
 // Overload. No layer provided, set y of all layers
 void MapView::setY(int y) {
     foreach (Overlay * layer, this->overlayMap)
         layer->setY(y);
-    this->scene()->update();
+    this->updateScene();
 }
 
 void MapView::setClippingRect(int x, int y, int width, int height, int layer) {
     this->getOverlay(layer)->setClippingRect(QRectF(x, y, width, height));
-    this->scene()->update();
+    this->updateScene();
 }
 
 void MapView::setClippingRect(int x, int y, int width, int height) {
     QRectF rect = QRectF(x, y, width, height);
     foreach (Overlay * layer, this->overlayMap)
         layer->setClippingRect(rect);
-    this->scene()->update();
+    this->updateScene();
 }
 
 void MapView::clearClippingRect(int layer) {
     this->getOverlay(layer)->clearClippingRect();
-    this->scene()->update();
+    this->updateScene();
 }
 
 void MapView::clearClippingRect() {
     foreach (Overlay * layer, this->overlayMap)
         layer->clearClippingRect();
-    this->scene()->update();
+    this->updateScene();
 }
 
 QJSValue MapView::getPosition(int layer) {
@@ -109,26 +115,26 @@ QJSValue MapView::getPosition(int layer) {
 
 void MapView::setPosition(int x, int y, int layer) {
     this->getOverlay(layer)->setPosition(x, y);
-    this->scene()->update();
+    this->updateScene();
 }
 
 // Overload. No layer provided, set position of all layers
 void MapView::setPosition(int x, int y) {
     foreach (Overlay * layer, this->overlayMap)
         layer->setPosition(x, y);
-    this->scene()->update();
+    this->updateScene();
 }
 
 void MapView::move(int deltaX, int deltaY, int layer) {
     this->getOverlay(layer)->move(deltaX, deltaY);
-    this->scene()->update();
+    this->updateScene();
 }
 
 // Overload. No layer provided, move all layers
 void MapView::move(int deltaX, int deltaY) {
     foreach (Overlay * layer, this->overlayMap)
         layer->move(deltaX, deltaY);
-    this->scene()->update();
+    this->updateScene();
 }
 
 int MapView::getOpacity(int layer) {
@@ -137,14 +143,14 @@ int MapView::getOpacity(int layer) {
 
 void MapView::setOpacity(int opacity, int layer) {
     this->getOverlay(layer)->setOpacity(opacity);
-    this->scene()->update();
+    this->updateScene();
 }
 
 // Overload. No layer provided, set opacity of all layers
 void MapView::setOpacity(int opacity) {
     foreach (Overlay * layer, this->overlayMap)
         layer->setOpacity(opacity);
-    this->scene()->update();
+    this->updateScene();
 }
 
 qreal MapView::getHorizontalScale(int layer) {
@@ -157,38 +163,38 @@ qreal MapView::getVerticalScale(int layer) {
 
 void MapView::setHorizontalScale(qreal scale, int layer) {
     this->getOverlay(layer)->setHScale(scale);
-    this->scene()->update();
+    this->updateScene();
 }
 
 // Overload. No layer provided, set horizontal scale of all layers
 void MapView::setHorizontalScale(qreal scale) {
     foreach (Overlay * layer, this->overlayMap)
         layer->setHScale(scale);
-    this->scene()->update();
+    this->updateScene();
 }
 
 void MapView::setVerticalScale(qreal scale, int layer) {
     this->getOverlay(layer)->setVScale(scale);
-    this->scene()->update();
+    this->updateScene();
 }
 
 // Overload. No layer provided, set vertical scale of all layers
 void MapView::setVerticalScale(qreal scale) {
     foreach (Overlay * layer, this->overlayMap)
         layer->setVScale(scale);
-    this->scene()->update();
+    this->updateScene();
 }
 
 void MapView::setScale(qreal hScale, qreal vScale, int layer) {
     this->getOverlay(layer)->setScale(hScale, vScale);
-    this->scene()->update();
+    this->updateScene();
 }
 
 // Overload. No layer provided, set scale of all layers
 void MapView::setScale(qreal hScale, qreal vScale) {
     foreach (Overlay * layer, this->overlayMap)
         layer->setScale(hScale, vScale);
-    this->scene()->update();
+    this->updateScene();
 }
 
 int MapView::getRotation(int layer) {
@@ -197,41 +203,41 @@ int MapView::getRotation(int layer) {
 
 void MapView::setRotation(int angle, int layer) {
     this->getOverlay(layer)->setRotation(angle);
-    this->scene()->update();
+    this->updateScene();
 }
 
 // Overload. No layer provided, set rotation of all layers
 void MapView::setRotation(int angle) {
     foreach (Overlay * layer, this->overlayMap)
         layer->setRotation(angle);
-    this->scene()->update();
+    this->updateScene();
 }
 
 void MapView::rotate(int degrees, int layer) {
     this->getOverlay(layer)->rotate(degrees);
-    this->scene()->update();
+    this->updateScene();
 }
 
 // Overload. No layer provided, rotate all layers
 void MapView::rotate(int degrees) {
     foreach (Overlay * layer, this->overlayMap)
         layer->rotate(degrees);
-    this->scene()->update();
+    this->updateScene();
 }
 
 void MapView::addText(QString text, int x, int y, QString color, int fontSize, int layer) {
     this->getOverlay(layer)->addText(text, x, y, color, fontSize);
-    this->scene()->update();
+    this->updateScene();
 }
 
 void MapView::addRect(int x, int y, int width, int height, QString borderColor, QString fillColor, int rounding, int layer) {
     if (this->getOverlay(layer)->addRect(x, y, width, height, borderColor, fillColor, rounding))
-        this->scene()->update();
+        this->updateScene();
 }
 
 void MapView::addPath(QList<int> xCoords, QList<int> yCoords, QString borderColor, QString fillColor, int layer) {
     if (this->getOverlay(layer)->addPath(xCoords, yCoords, borderColor, fillColor))
-        this->scene()->update();
+        this->updateScene();
 }
 
 void MapView::addPath(QList<QList<int>> coords, QString borderColor, QString fillColor, int layer) {
@@ -250,7 +256,7 @@ void MapView::addPath(QList<QList<int>> coords, QString borderColor, QString fil
 
 void MapView::addImage(int x, int y, QString filepath, int layer, bool useCache) {
     if (this->getOverlay(layer)->addImage(x, y, filepath, useCache))
-        this->scene()->update();
+        this->updateScene();
 }
 
 void MapView::createImage(int x, int y, QString filepath, int width, int height, int xOffset, int yOffset, qreal hScale, qreal vScale, int paletteId, bool setTransparency, int layer, bool useCache) {
@@ -260,7 +266,7 @@ void MapView::createImage(int x, int y, QString filepath, int width, int height,
     if (paletteId != -1)
         palette = Tileset::getPalette(paletteId, this->editor->layout->tileset_primary, this->editor->layout->tileset_secondary);
     if (this->getOverlay(layer)->addImage(x, y, filepath, useCache, width, height, xOffset, yOffset, hScale, vScale, palette, setTransparency))
-        this->scene()->update();
+        this->updateScene();
 }
 
 void MapView::addTileImage(int x, int y, int tileId, bool xflip, bool yflip, int paletteId, bool setTransparency, int layer) {
@@ -274,7 +280,7 @@ void MapView::addTileImage(int x, int y, int tileId, bool xflip, bool yflip, int
     if (setTransparency)
         image.setColor(0, qRgba(0, 0, 0, 0));
     if (this->getOverlay(layer)->addImage(x, y, image))
-        this->scene()->update();
+        this->updateScene();
 }
 
 void MapView::addTileImage(int x, int y, QJSValue tileObj, bool setTransparency, int layer) {
@@ -293,5 +299,5 @@ void MapView::addMetatileImage(int x, int y, int metatileId, bool setTransparenc
     if (setTransparency)
         image.setColor(0, qRgba(0, 0, 0, 0));
     if (this->getOverlay(layer)->addImage(x, y, image))
-        this->scene()->update();
+        this->updateScene();
 }

--- a/src/scriptapi/scripting.cpp
+++ b/src/scriptapi/scripting.cpp
@@ -12,6 +12,7 @@ const QMap<CallbackType, QString> callbackFunctions = {
     {OnBlockHoverChanged, "onBlockHoverChanged"},
     {OnBlockHoverCleared, "onBlockHoverCleared"},
     {OnMapOpened, "onMapOpened"},
+    {OnLayoutOpened, "onLayoutOpened"},
     {OnMapResized, "onMapResized"},
     {OnBorderResized, "onBorderResized"},
     {OnMapShifted, "onMapShifted"},
@@ -256,6 +257,15 @@ void Scripting::cb_MapOpened(QString mapName) {
         mapName,
     };
     instance->invokeCallback(OnMapOpened, args);
+}
+
+void Scripting::cb_LayoutOpened(QString layoutName) {
+    if (!instance) return;
+
+    QJSValueList args {
+        layoutName,
+    };
+    instance->invokeCallback(OnLayoutOpened, args);
 }
 
 void Scripting::cb_MapResized(int oldWidth, int oldHeight, int newWidth, int newHeight) {

--- a/src/ui/maplistmodels.cpp
+++ b/src/ui/maplistmodels.cpp
@@ -104,7 +104,7 @@ QStandardItem *MapListModel::createMapItem(const QString &mapName, QStandardItem
     map->setData(mapName, MapListUserRoles::NameRole);
     map->setData("map_name", MapListUserRoles::TypeRole);
     map->setFlags(Qt::ItemIsSelectable | Qt::ItemIsEnabled | Qt::ItemIsDragEnabled | Qt::ItemNeverHasChildren);
-    map->setToolTip(this->project->mapNamesToMapConstants.value(mapName));
+    map->setToolTip(this->project->getMapConstant(mapName));
     this->mapItems.insert(mapName, map);
     return map;
 }
@@ -164,10 +164,10 @@ QVariant MapListModel::data(const QModelIndex &index, int role) const {
             if (name == this->activeItemName)
                 return this->mapOpenedIcon;
 
-            const Map* map = this->project->mapCache.value(name);
-            if (!map)
+            const Map* map = this->project->getMap(name);
+            if (!map || !map->loaded())
                 return this->mapGrayIcon;
-            return map->hasUnsavedChanges() ? this->mapEditedIcon : this->mapIcon; 
+            return map->hasUnsavedChanges() ? this->mapEditedIcon : this->mapIcon;
         } else if (type == this->folderTypeName) {
             // Decorating map folder in the map list
             return item->hasChildren() ? this->mapFolderIcon : this->emptyMapFolderIcon;
@@ -446,7 +446,7 @@ MapLocationModel::MapLocationModel(Project *project, QObject *parent) : MapListM
         insertMapFolderItem(idName);
     }
     for (const auto &mapName : this->project->mapNames) {
-        insertMapItem(mapName, this->project->mapNameToMapSectionName.value(mapName));
+        insertMapItem(mapName, this->project->getMapLocation(mapName));
     }
 }
 
@@ -470,7 +470,7 @@ LayoutTreeModel::LayoutTreeModel(Project *project, QObject *parent) : MapListMod
         insertMapFolderItem(layoutId);
     }
     for (const auto &mapName : this->project->mapNames) {
-        insertMapItem(mapName, this->project->mapNameToLayoutId.value(mapName));
+        insertMapItem(mapName, this->project->getMapLayoutId(mapName));
     }
 }
 

--- a/src/ui/maplistmodels.cpp
+++ b/src/ui/maplistmodels.cpp
@@ -165,7 +165,7 @@ QVariant MapListModel::data(const QModelIndex &index, int role) const {
                 return this->mapOpenedIcon;
 
             const Map* map = this->project->getMap(name);
-            if (!map || !map->loaded())
+            if (!this->project->isMapLoaded(map))
                 return this->mapGrayIcon;
             return map->hasUnsavedChanges() ? this->mapEditedIcon : this->mapIcon;
         } else if (type == this->folderTypeName) {
@@ -510,7 +510,7 @@ QVariant LayoutTreeModel::data(const QModelIndex &index, int role) const {
                 return this->mapOpenedIcon;
 
             const Layout* layout = this->project->mapLayouts.value(name);
-            if (!layout || !layout->loaded)
+            if (!this->project->isLayoutLoaded(layout))
                 return this->mapGrayIcon;
             return layout->hasUnsavedChanges() ? this->mapEditedIcon : this->mapIcon;
         }

--- a/src/ui/newlocationdialog.cpp
+++ b/src/ui/newlocationdialog.cpp
@@ -69,11 +69,7 @@ void NewLocationDialog::accept() {
     if (!validateIdName())
         return;
 
-    const QString idName = ui->lineEdit_IdName->text();
-    const QString displayName = ui->lineEdit_DisplayName->text();
-
-    this->project->addNewMapsec(idName);
-    this->project->setMapsecDisplayName(idName, displayName);
+    this->project->addNewMapsec(ui->lineEdit_IdName->text(), ui->lineEdit_DisplayName->text());
 
     QDialog::accept();
 }


### PR DESCRIPTION
- Update the map list if the `Layout` or `Location` for a map is changed.
- Fix crash if a layout selected via the layout combo box fails to load
- Disallow invalid layout IDs remaining in the layout combo box (they'll be ignored later anyway)
- Fix crash when creating a `MAPSEC` if there are no pre-existing `MAPSEC` values.
- Fix missing check for `MAPSEC` prefix when creating a new map
- Automatically add `MAPSEC` values when saving maps if a new one was specified on the `Header` tab.
- Allow projects with no maps or map groups to be opened (only >=1 map layout is required)
- Save map list settings in the config
- Add `onLayoutOpened` to scripting API

- Internally, maps are now stored in memory more similarly to map layouts. We need some data always loaded for each map in order to display them in the map lists. We were tracking this data with separate arrays, even though once the map is loaded we also track this data on the `Map` object. Now each map always has a `Map` object with this list data set, and the project tracks which of these objects have been fully loaded with the rest of their data.
- Preemptively bump the version number to 6.0.0 (makes it easier to test some version differences in the scripting API with `constants.version`)

Closes #638 