### PR TITLE
Read encounter/terrain types from the project

### DIFF
--- a/forms/tileseteditor.ui
+++ b/forms/tileseteditor.ui
@@ -6,12 +6,12 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>727</width>
-    <height>700</height>
+    <width>733</width>
+    <height>784</height>
    </rect>
   </property>
   <property name="focusPolicy">
-   <enum>Qt::ClickFocus</enum>
+   <enum>Qt::FocusPolicy::ClickFocus</enum>
   </property>
   <property name="windowTitle">
    <string>Tileset Editor</string>
@@ -21,7 +21,7 @@
     <item>
      <widget class="QSplitter" name="splitter">
       <property name="orientation">
-       <enum>Qt::Horizontal</enum>
+       <enum>Qt::Orientation::Horizontal</enum>
       </property>
       <property name="childrenCollapsible">
        <bool>false</bool>
@@ -34,10 +34,10 @@
         </sizepolicy>
        </property>
        <property name="frameShape">
-        <enum>QFrame::NoFrame</enum>
+        <enum>QFrame::Shape::NoFrame</enum>
        </property>
        <property name="frameShadow">
-        <enum>QFrame::Plain</enum>
+        <enum>QFrame::Shadow::Plain</enum>
        </property>
        <layout class="QVBoxLayout" name="verticalLayout_3">
         <property name="leftMargin">
@@ -58,15 +58,15 @@
            <bool>true</bool>
           </property>
           <property name="alignment">
-           <set>Qt::AlignHCenter|Qt::AlignTop</set>
+           <set>Qt::AlignmentFlag::AlignHCenter|Qt::AlignmentFlag::AlignTop</set>
           </property>
           <widget class="QWidget" name="scrollAreaWidgetContents_Metatiles">
            <property name="geometry">
             <rect>
              <x>0</x>
              <y>0</y>
-             <width>223</width>
-             <height>593</height>
+             <width>239</width>
+             <height>659</height>
             </rect>
            </property>
            <layout class="QGridLayout" name="gridLayout">
@@ -88,17 +88,17 @@
             <item row="0" column="0">
              <widget class="NoScrollGraphicsView" name="graphicsView_Metatiles">
               <property name="verticalScrollBarPolicy">
-               <enum>Qt::ScrollBarAlwaysOff</enum>
+               <enum>Qt::ScrollBarPolicy::ScrollBarAlwaysOff</enum>
               </property>
               <property name="horizontalScrollBarPolicy">
-               <enum>Qt::ScrollBarAlwaysOff</enum>
+               <enum>Qt::ScrollBarPolicy::ScrollBarAlwaysOff</enum>
               </property>
              </widget>
             </item>
             <item row="1" column="0">
              <spacer name="verticalSpacer">
               <property name="orientation">
-               <enum>Qt::Vertical</enum>
+               <enum>Qt::Orientation::Vertical</enum>
               </property>
               <property name="sizeHint" stdset="0">
                <size>
@@ -121,7 +121,7 @@
            </sizepolicy>
           </property>
           <property name="orientation">
-           <enum>Qt::Horizontal</enum>
+           <enum>Qt::Orientation::Horizontal</enum>
           </property>
          </widget>
         </item>
@@ -129,10 +129,10 @@
       </widget>
       <widget class="QFrame" name="frame_Editing">
        <property name="frameShape">
-        <enum>QFrame::NoFrame</enum>
+        <enum>QFrame::Shape::NoFrame</enum>
        </property>
        <property name="frameShadow">
-        <enum>QFrame::Raised</enum>
+        <enum>QFrame::Shadow::Raised</enum>
        </property>
        <layout class="QVBoxLayout" name="verticalLayout">
         <property name="leftMargin">
@@ -162,14 +162,14 @@
            </size>
           </property>
           <property name="frameShape">
-           <enum>QFrame::NoFrame</enum>
+           <enum>QFrame::Shape::NoFrame</enum>
           </property>
           <property name="frameShadow">
-           <enum>QFrame::Raised</enum>
+           <enum>QFrame::Shadow::Raised</enum>
           </property>
           <layout class="QHBoxLayout" name="horizontalLayout_4">
            <property name="sizeConstraint">
-            <enum>QLayout::SetMinimumSize</enum>
+            <enum>QLayout::SizeConstraint::SetMinimumSize</enum>
            </property>
            <property name="leftMargin">
             <number>0</number>
@@ -195,6 +195,70 @@
               <bool>false</bool>
              </property>
              <layout class="QGridLayout" name="gridLayout_3">
+              <item row="15" column="0" colspan="4">
+               <widget class="QLineEdit" name="lineEdit_metatileLabel">
+                <property name="clearButtonEnabled">
+                 <bool>true</bool>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="2" colspan="3">
+               <widget class="NoScrollComboBox" name="comboBox_layerType">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="minimumSize">
+                 <size>
+                  <width>185</width>
+                  <height>0</height>
+                 </size>
+                </property>
+               </widget>
+              </item>
+              <item row="14" column="0" colspan="5">
+               <widget class="QLabel" name="label_metatileLabel">
+                <property name="text">
+                 <string>Metatile Label (Optional)</string>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="0">
+               <widget class="QLabel" name="label_BottomTop">
+                <property name="text">
+                 <string>Bottom/Top</string>
+                </property>
+               </widget>
+              </item>
+              <item row="10" column="0" colspan="5">
+               <widget class="QLabel" name="label_terrainType">
+                <property name="text">
+                 <string>Terrain Type</string>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="2" colspan="3">
+               <widget class="QLabel" name="label_layerType">
+                <property name="text">
+                 <string>Layer Type</string>
+                </property>
+               </widget>
+              </item>
+              <item row="7" column="0" colspan="5">
+               <widget class="NoScrollComboBox" name="comboBox_metatileBehaviors">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Ignored" vsizetype="Fixed">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="insertPolicy">
+                 <enum>QComboBox::InsertPolicy::NoInsert</enum>
+                </property>
+               </widget>
+              </item>
               <item row="1" column="0">
                <widget class="QGraphicsView" name="graphicsView_metatileLayers">
                 <property name="sizePolicy">
@@ -216,10 +280,10 @@
                  </size>
                 </property>
                 <property name="verticalScrollBarPolicy">
-                 <enum>Qt::ScrollBarAlwaysOff</enum>
+                 <enum>Qt::ScrollBarPolicy::ScrollBarAlwaysOff</enum>
                 </property>
                 <property name="horizontalScrollBarPolicy">
-                 <enum>Qt::ScrollBarAlwaysOff</enum>
+                 <enum>Qt::ScrollBarPolicy::ScrollBarAlwaysOff</enum>
                 </property>
                </widget>
               </item>
@@ -236,15 +300,18 @@
                 </property>
                </widget>
               </item>
-              <item row="14" column="0">
-               <spacer name="verticalSpacer_7">
+              <item row="1" column="1">
+               <spacer name="horizontalSpacer_5">
                 <property name="orientation">
-                 <enum>Qt::Vertical</enum>
+                 <enum>Qt::Orientation::Horizontal</enum>
+                </property>
+                <property name="sizeType">
+                 <enum>QSizePolicy::Policy::Maximum</enum>
                 </property>
                 <property name="sizeHint" stdset="0">
                  <size>
-                  <width>20</width>
-                  <height>1</height>
+                  <width>10</width>
+                  <height>20</height>
                  </size>
                 </property>
                </spacer>
@@ -262,14 +329,28 @@
                 </property>
                </widget>
               </item>
-              <item row="12" column="0" colspan="5">
-               <widget class="QLabel" name="label_metatileLabel">
+              <item row="2" column="0" colspan="5">
+               <widget class="QLabel" name="label_metatileBehavior">
                 <property name="text">
-                 <string>Metatile Label (Optional)</string>
+                 <string>Metatile Behavior</string>
                 </property>
                </widget>
               </item>
-              <item row="13" column="4">
+              <item row="12" column="0" colspan="5">
+               <widget class="QLabel" name="label_rawAttributesValue">
+                <property name="text">
+                 <string>Raw Attributes Value</string>
+                </property>
+               </widget>
+              </item>
+              <item row="8" column="0" colspan="5">
+               <widget class="QLabel" name="label_encounterType">
+                <property name="text">
+                 <string>Encounter Type</string>
+                </property>
+               </widget>
+              </item>
+              <item row="15" column="4">
                <widget class="QToolButton" name="copyButton_metatileLabel">
                 <property name="toolTip">
                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Copies the full metatile label to the clipboard.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
@@ -283,92 +364,21 @@
                 </property>
                </widget>
               </item>
-              <item row="1" column="2" colspan="3">
-               <widget class="NoScrollComboBox" name="comboBox_layerType">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-                <property name="minimumSize">
-                 <size>
-                  <width>185</width>
-                  <height>0</height>
-                 </size>
-                </property>
-               </widget>
-              </item>
-              <item row="7" column="0" colspan="5">
-               <widget class="NoScrollComboBox" name="comboBox_metatileBehaviors">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Ignored" vsizetype="Fixed">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-                <property name="insertPolicy">
-                 <enum>QComboBox::InsertPolicy::NoInsert</enum>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="2" colspan="3">
-               <widget class="QLabel" name="label_layerType">
-                <property name="text">
-                 <string>Layer Type</string>
-                </property>
-               </widget>
-              </item>
-              <item row="13" column="0" colspan="4">
-               <widget class="QLineEdit" name="lineEdit_metatileLabel">
-                <property name="clearButtonEnabled">
-                 <bool>true</bool>
-                </property>
-               </widget>
-              </item>
-              <item row="2" column="0" colspan="5">
-               <widget class="QLabel" name="label_metatileBehavior">
-                <property name="text">
-                 <string>Metatile Behavior</string>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="1">
-               <spacer name="horizontalSpacer_5">
+              <item row="16" column="0">
+               <spacer name="verticalSpacer_7">
                 <property name="orientation">
-                 <enum>Qt::Horizontal</enum>
-                </property>
-                <property name="sizeType">
-                 <enum>QSizePolicy::Maximum</enum>
+                 <enum>Qt::Orientation::Vertical</enum>
                 </property>
                 <property name="sizeHint" stdset="0">
                  <size>
-                  <width>10</width>
-                  <height>20</height>
+                  <width>20</width>
+                  <height>1</height>
                  </size>
                 </property>
                </spacer>
               </item>
-              <item row="8" column="0" colspan="5">
-               <widget class="QLabel" name="label_encounterType">
-                <property name="text">
-                 <string>Encounter Type</string>
-                </property>
-               </widget>
-              </item>
-              <item row="10" column="0" colspan="5">
-               <widget class="QLabel" name="label_terrainType">
-                <property name="text">
-                 <string>Terrain Type</string>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="0">
-               <widget class="QLabel" name="label_BottomTop">
-                <property name="text">
-                 <string>Bottom/Top</string>
-                </property>
-               </widget>
+              <item row="13" column="0" colspan="5">
+               <widget class="UIntHexSpinBox" name="spinBox_rawAttributesValue"/>
               </item>
              </layout>
             </widget>
@@ -408,7 +418,7 @@
               <item row="1" column="1">
                <widget class="QCheckBox" name="checkBox_xFlip">
                 <property name="layoutDirection">
-                 <enum>Qt::LeftToRight</enum>
+                 <enum>Qt::LayoutDirection::LeftToRight</enum>
                 </property>
                 <property name="text">
                  <string/>
@@ -432,10 +442,10 @@
               <item row="3" column="0" colspan="2">
                <spacer name="verticalSpacer_5">
                 <property name="orientation">
-                 <enum>Qt::Vertical</enum>
+                 <enum>Qt::Orientation::Vertical</enum>
                 </property>
                 <property name="sizeType">
-                 <enum>QSizePolicy::Fixed</enum>
+                 <enum>QSizePolicy::Policy::Fixed</enum>
                 </property>
                 <property name="sizeHint" stdset="0">
                  <size>
@@ -460,10 +470,10 @@
                  </size>
                 </property>
                 <property name="frameShape">
-                 <enum>QFrame::NoFrame</enum>
+                 <enum>QFrame::Shape::NoFrame</enum>
                 </property>
                 <property name="frameShadow">
-                 <enum>QFrame::Plain</enum>
+                 <enum>QFrame::Shadow::Plain</enum>
                 </property>
                 <layout class="QVBoxLayout" name="verticalLayout_2">
                  <property name="leftMargin">
@@ -506,13 +516,13 @@
                     </size>
                    </property>
                    <property name="frameShape">
-                    <enum>QFrame::StyledPanel</enum>
+                    <enum>QFrame::Shape::StyledPanel</enum>
                    </property>
                    <property name="verticalScrollBarPolicy">
-                    <enum>Qt::ScrollBarAlwaysOff</enum>
+                    <enum>Qt::ScrollBarPolicy::ScrollBarAlwaysOff</enum>
                    </property>
                    <property name="horizontalScrollBarPolicy">
-                    <enum>Qt::ScrollBarAlwaysOff</enum>
+                    <enum>Qt::ScrollBarPolicy::ScrollBarAlwaysOff</enum>
                    </property>
                   </widget>
                  </item>
@@ -522,7 +532,7 @@
               <item row="6" column="0" colspan="2">
                <spacer name="verticalSpacer_6">
                 <property name="orientation">
-                 <enum>Qt::Vertical</enum>
+                 <enum>Qt::Orientation::Vertical</enum>
                 </property>
                 <property name="sizeHint" stdset="0">
                  <size>
@@ -544,15 +554,15 @@
            <bool>true</bool>
           </property>
           <property name="alignment">
-           <set>Qt::AlignHCenter|Qt::AlignTop</set>
+           <set>Qt::AlignmentFlag::AlignHCenter|Qt::AlignmentFlag::AlignTop</set>
           </property>
           <widget class="QWidget" name="scrollAreaWidgetContents_Tiles">
            <property name="geometry">
             <rect>
              <x>0</x>
              <y>0</y>
-             <width>455</width>
-             <height>232</height>
+             <width>445</width>
+             <height>237</height>
             </rect>
            </property>
            <layout class="QGridLayout" name="gridLayout_2">
@@ -571,17 +581,17 @@
             <item row="0" column="0">
              <widget class="NoScrollGraphicsView" name="graphicsView_Tiles">
               <property name="verticalScrollBarPolicy">
-               <enum>Qt::ScrollBarAlwaysOff</enum>
+               <enum>Qt::ScrollBarPolicy::ScrollBarAlwaysOff</enum>
               </property>
               <property name="horizontalScrollBarPolicy">
-               <enum>Qt::ScrollBarAlwaysOff</enum>
+               <enum>Qt::ScrollBarPolicy::ScrollBarAlwaysOff</enum>
               </property>
              </widget>
             </item>
             <item row="1" column="0">
              <spacer name="verticalSpacer_2">
               <property name="orientation">
-               <enum>Qt::Vertical</enum>
+               <enum>Qt::Orientation::Vertical</enum>
               </property>
               <property name="sizeHint" stdset="0">
                <size>
@@ -598,7 +608,7 @@
         <item>
          <widget class="QSlider" name="horizontalSlider_TilesZoom">
           <property name="orientation">
-           <enum>Qt::Horizontal</enum>
+           <enum>Qt::Orientation::Horizontal</enum>
           </property>
          </widget>
         </item>
@@ -613,8 +623,8 @@
     <rect>
      <x>0</x>
      <y>0</y>
-     <width>727</width>
-     <height>22</height>
+     <width>733</width>
+     <height>37</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuFile">
@@ -657,6 +667,7 @@
     <addaction name="actionLayer_Grid"/>
     <addaction name="actionMetatile_Grid"/>
     <addaction name="actionShow_Tileset_Divider"/>
+    <addaction name="actionShow_Raw_Metatile_Attributes"/>
     <addaction name="separator"/>
     <addaction name="actionShow_Counts"/>
     <addaction name="actionShow_Unused"/>
@@ -817,6 +828,14 @@
     <string>Show Tileset Divider</string>
    </property>
   </action>
+  <action name="actionShow_Raw_Metatile_Attributes">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Show Raw Metatile Attributes</string>
+   </property>
+  </action>
  </widget>
  <customwidgets>
   <customwidget>
@@ -828,6 +847,16 @@
    <class>NoScrollGraphicsView</class>
    <extends>QGraphicsView</extends>
    <header>mapview.h</header>
+  </customwidget>
+  <customwidget>
+   <class>UIntSpinBox</class>
+   <extends>QAbstractSpinBox</extends>
+   <header>uintspinbox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>UIntHexSpinBox</class>
+   <extends>UIntSpinBox</extends>
+   <header location="global">uintspinbox.h</header>
   </customwidget>
  </customwidgets>
  <resources>

--- a/forms/tileseteditor.ui
+++ b/forms/tileseteditor.ui
@@ -231,6 +231,9 @@
                   <verstretch>0</verstretch>
                  </sizepolicy>
                 </property>
+                <property name="insertPolicy">
+                 <enum>QComboBox::InsertPolicy::NoInsert</enum>
+                </property>
                </widget>
               </item>
               <item row="14" column="0">
@@ -253,6 +256,9 @@
                   <horstretch>0</horstretch>
                   <verstretch>0</verstretch>
                  </sizepolicy>
+                </property>
+                <property name="insertPolicy">
+                 <enum>QComboBox::InsertPolicy::NoInsert</enum>
                 </property>
                </widget>
               </item>
@@ -300,6 +306,9 @@
                   <horstretch>0</horstretch>
                   <verstretch>0</verstretch>
                  </sizepolicy>
+                </property>
+                <property name="insertPolicy">
+                 <enum>QComboBox::InsertPolicy::NoInsert</enum>
                 </property>
                </widget>
               </item>

--- a/include/config.h
+++ b/include/config.h
@@ -72,6 +72,7 @@ public:
         this->showTilesetEditorMetatileGrid = false;
         this->showTilesetEditorLayerGrid = true;
         this->showTilesetEditorDivider = false;
+        this->showTilesetEditorRawAttributes = false;
         this->monitorFiles = true;
         this->tilesetCheckerboardFill = true;
         this->newMapHeaderSectionExpanded = false;
@@ -132,6 +133,7 @@ public:
     bool showTilesetEditorMetatileGrid;
     bool showTilesetEditorLayerGrid;
     bool showTilesetEditorDivider;
+    bool showTilesetEditorRawAttributes;
     bool monitorFiles;
     bool tilesetCheckerboardFill;
     bool newMapHeaderSectionExpanded;

--- a/include/config.h
+++ b/include/config.h
@@ -242,6 +242,8 @@ enum ProjectIdentifier {
     regex_sign_facing_directions,
     regex_trainer_types,
     regex_music,
+    regex_encounter_types,
+    regex_terrain_types,
     regex_gbapal,
     regex_bpp,
     pals_output_extension,

--- a/include/core/metatile.h
+++ b/include/core/metatile.h
@@ -11,27 +11,6 @@
 
 class Project;
 
-enum {
-    METATILE_LAYER_MIDDLE_TOP,
-    METATILE_LAYER_BOTTOM_MIDDLE,
-    METATILE_LAYER_BOTTOM_TOP,
-    NUM_METATILE_LAYER_TYPES
-};
-
-enum {
-    ENCOUNTER_NONE,
-    ENCOUNTER_LAND,
-    ENCOUNTER_WATER,
-    NUM_METATILE_ENCOUNTER_TYPES
-};
-
-enum {
-    TERRAIN_NONE,
-    TERRAIN_GRASS,
-    TERRAIN_WATER,
-    TERRAIN_WATERFALL,
-    NUM_METATILE_TERRAIN_TYPES
-};
 
 class Metatile
 {
@@ -40,6 +19,13 @@ public:
     Metatile(const Metatile &other) = default;
     Metatile &operator=(const Metatile &other) = default;
     Metatile(const int numTiles);
+
+    enum LayerType {
+        Normal,
+        Covered,
+        Split,
+        Count
+    };
 
     enum Attr {
         Behavior,

--- a/include/core/parseutil.h
+++ b/include/core/parseutil.h
@@ -45,7 +45,8 @@ public:
     ParseUtil();
     void set_root(const QString &dir);
     static QString readTextFile(const QString &path, QString *error = nullptr);
-    void invalidateTextFile(const QString &path);
+    bool cacheFile(const QString &path, QString *error = nullptr);
+    void clearFileCache() { this->fileCache.clear(); }
     static int textFileLineCount(const QString &path);
     QList<QStringList> parseAsm(const QString &filename);
     QStringList readCArray(const QString &filename, const QString &label);
@@ -87,6 +88,7 @@ private:
     QString text;
     QString file;
     QString curDefine;
+    QHash<QString, QString> fileCache;
     QHash<QString, QStringList> errorMap;
     int evaluateDefine(const QString&, const QString &, QMap<QString, int>*, QMap<QString, QString>*);
     QList<Token> tokenizeExpression(QString, QMap<QString, int>*, QMap<QString, QString>*);
@@ -105,6 +107,8 @@ private:
     QMap<QString, int> evaluateCDefines(const QString &filename, const QSet<QString> &filterList, bool useRegex, QString *error);
     bool defineNameMatchesFilter(const QString &name, const QSet<QString> &filterList) const;
     bool defineNameMatchesFilter(const QString &name, const QSet<QRegularExpression> &filterList) const;
+    QString loadTextFile(const QString &path, QString *error = nullptr);
+    QString pathWithRoot(const QString &path);
 
     static const QRegularExpression re_incScriptLabel;
     static const QRegularExpression re_globalIncScriptLabel;

--- a/include/project.h
+++ b/include/project.h
@@ -279,6 +279,7 @@ private:
 
     void ignoreWatchedFileTemporarily(QString filepath);
     void recordFileChange(const QString &filepath);
+    void resetFileCache();
 
     QString findSpeciesIconPath(const QStringList &names) const;
 

--- a/include/project.h
+++ b/include/project.h
@@ -63,6 +63,8 @@ public:
     QStringList globalScriptLabels;
     QStringList mapSectionIdNamesSaveOrder;
     QStringList mapSectionIdNames;
+    QMap<uint32_t, QString> encounterTypeToName;
+    QMap<uint32_t, QString> terrainTypeToName;
     QMap<QString, MapSectionEntry> regionMapEntries;
     QMap<QString, QMap<QString, uint16_t>> metatileLabelsMap;
     QMap<QString, uint16_t> unusedMetatileLabels;

--- a/include/ui/tileseteditor.h
+++ b/include/ui/tileseteditor.h
@@ -9,6 +9,7 @@
 #include "tileseteditortileselector.h"
 #include "metatilelayersitem.h"
 
+class NoScrollComboBox;
 class Layout;
 
 namespace Ui {
@@ -92,18 +93,11 @@ private slots:
     void on_actionShow_Tileset_Divider_triggered(bool checked);
 
     void on_actionUndo_triggered();
-
     void on_actionRedo_triggered();
-
-    void on_comboBox_metatileBehaviors_currentTextChanged(const QString &arg1);
 
     void on_lineEdit_metatileLabel_editingFinished();
 
     void on_comboBox_layerType_activated(int arg1);
-
-    void on_comboBox_encounterType_activated(int arg1);
-
-    void on_comboBox_terrainType_activated(int arg1);
 
     void on_actionExport_Primary_Tiles_Image_triggered();
     void on_actionExport_Secondary_Tiles_Image_triggered();
@@ -148,6 +142,8 @@ private:
     bool replaceMetatile(uint16_t metatileId, const Metatile * src, QString label);
     void commitMetatileChange(Metatile * prevMetatile);
     void commitMetatileAndLabelChange(Metatile * prevMetatile, QString prevLabel);
+    uint32_t attributeNameToValue(Metatile::Attr attribute, const QString &text, bool *ok);
+    void setAttributeFromComboBox(Metatile::Attr attribute, NoScrollComboBox *combo);
 
     Ui::TilesetEditor *ui;
     History<MetatileHistoryItem*> metatileHistory;

--- a/include/ui/tileseteditor.h
+++ b/include/ui/tileseteditor.h
@@ -97,8 +97,6 @@ private slots:
 
     void on_lineEdit_metatileLabel_editingFinished();
 
-    void on_comboBox_layerType_activated(int arg1);
-
     void on_actionExport_Primary_Tiles_Image_triggered();
     void on_actionExport_Secondary_Tiles_Image_triggered();
     void on_actionExport_Primary_Metatiles_Image_triggered();
@@ -116,7 +114,7 @@ private slots:
     void on_horizontalSlider_TilesZoom_valueChanged(int value);
 
 private:
-    void setAttributesUi();
+    void initAttributesUi();
     void initMetatileSelector();
     void initTileSelector();
     void initSelectedTileItem();
@@ -143,7 +141,14 @@ private:
     void commitMetatileChange(Metatile * prevMetatile);
     void commitMetatileAndLabelChange(Metatile * prevMetatile, QString prevLabel);
     uint32_t attributeNameToValue(Metatile::Attr attribute, const QString &text, bool *ok);
-    void setAttributeFromComboBox(Metatile::Attr attribute, NoScrollComboBox *combo);
+    void commitAttributeFromComboBox(Metatile::Attr attribute, NoScrollComboBox *combo);
+    void onRawAttributesEdited();
+    void refreshMetatileAttributes();
+    void commitMetatileBehavior();
+    void commitEncounterType();
+    void commitTerrainType();
+    void commitLayerType();
+    void setRawAttributesVisible(bool visible);
 
     Ui::TilesetEditor *ui;
     History<MetatileHistoryItem*> metatileHistory;

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -388,6 +388,8 @@ void PorymapConfig::parseConfigKeyValue(QString key, QString value) {
         this->showTilesetEditorLayerGrid = getConfigBool(key, value);
     } else if (key == "show_tileset_editor_divider") {
         this->showTilesetEditorDivider = getConfigBool(key, value);
+    } else if (key == "show_tileset_editor_raw_attributes") {
+        this->showTilesetEditorRawAttributes = getConfigBool(key, value);
     } else if (key == "monitor_files") {
         this->monitorFiles = getConfigBool(key, value);
     } else if (key == "tileset_checkerboard_fill") {
@@ -497,6 +499,7 @@ QMap<QString, QString> PorymapConfig::getKeyValueMap() {
     map.insert("show_tileset_editor_metatile_grid", this->showTilesetEditorMetatileGrid ? "1" : "0");
     map.insert("show_tileset_editor_layer_grid", this->showTilesetEditorLayerGrid ? "1" : "0");
     map.insert("show_tileset_editor_divider", this->showTilesetEditorDivider ? "1" : "0");
+    map.insert("show_tileset_editor_raw_attributes", this->showTilesetEditorRawAttributes ? "1" : "0");
     map.insert("monitor_files", this->monitorFiles ? "1" : "0");
     map.insert("tileset_checkerboard_fill", this->tilesetCheckerboardFill ? "1" : "0");
     map.insert("new_map_header_section_expanded", this->newMapHeaderSectionExpanded ? "1" : "0");

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -125,6 +125,8 @@ const QMap<ProjectIdentifier, QPair<QString, QString>> ProjectConfig::defaultIde
     {ProjectIdentifier::regex_sign_facing_directions,  {"regex_sign_facing_directions",  "\\bBG_EVENT_PLAYER_FACING_"}},
     {ProjectIdentifier::regex_trainer_types,           {"regex_trainer_types",           "\\bTRAINER_TYPE_"}},
     {ProjectIdentifier::regex_music,                   {"regex_music",                   "\\b(SE|MUS)_"}},
+    {ProjectIdentifier::regex_encounter_types,         {"regex_encounter_types",         "\\bTILE_ENCOUNTER_"}},
+    {ProjectIdentifier::regex_terrain_types,           {"regex_terrain_types",           "\\bTILE_TERRAIN_"}},
     {ProjectIdentifier::regex_gbapal,                  {"regex_gbapal",                  "\\.gbapal(\\.[\\w]+)?$"}},
     {ProjectIdentifier::regex_bpp,                     {"regex_bpp",                     "\\.[\\d]+bpp(\\.[\\w]+)?$"}},
     // Other

--- a/src/core/metatile.cpp
+++ b/src/core/metatile.cpp
@@ -128,34 +128,39 @@ void Metatile::setLayout(Project * project) {
     if (behaviorMask && !project->metatileBehaviorMapInverse.isEmpty()) {
         uint32_t maxBehavior = project->metatileBehaviorMapInverse.lastKey();
         if (packer.clamp(maxBehavior) != maxBehavior)
-            logWarn(QString("Metatile Behavior mask '%1' is insufficient to contain all available options.")
-                            .arg(Util::toHexString(behaviorMask)));
+            logWarn(QString("Metatile Behavior mask '%1' is insufficient to contain largest value '%2'.")
+                            .arg(Util::toHexString(behaviorMask))
+                            .arg(Util::toHexString(maxBehavior)));
     }
     attributePackers.insert(Metatile::Attr::Behavior, packer);
 
     // Validate terrain type mask
     packer.setMask(terrainTypeMask);
-    const uint32_t maxTerrainType = NUM_METATILE_TERRAIN_TYPES - 1;
-    if (terrainTypeMask && packer.clamp(maxTerrainType) != maxTerrainType) {
-        logWarn(QString("Metatile Terrain Type mask '%1' is insufficient to contain all %2 available options.")
+    if (terrainTypeMask && !project->terrainTypeToName.isEmpty()) {
+        uint32_t maxTerrainType = project->terrainTypeToName.lastKey();
+        if (packer.clamp(maxTerrainType) != maxTerrainType) {
+            logWarn(QString("Metatile Terrain Type mask '%1' is insufficient to contain largest value '%2'.")
                             .arg(Util::toHexString(terrainTypeMask))
-                            .arg(maxTerrainType + 1));
+                            .arg(Util::toHexString(maxTerrainType)));
+        }
     }
     attributePackers.insert(Metatile::Attr::TerrainType, packer);
 
     // Validate encounter type mask
     packer.setMask(encounterTypeMask);
-    const uint32_t maxEncounterType = NUM_METATILE_ENCOUNTER_TYPES - 1;
-    if (encounterTypeMask && packer.clamp(maxEncounterType) != maxEncounterType) {
-        logWarn(QString("Metatile Encounter Type mask '%1' is insufficient to contain all %2 available options.")
+    if (encounterTypeMask && !project->encounterTypeToName.isEmpty()) {
+        uint32_t maxEncounterType = project->encounterTypeToName.lastKey();
+        if (packer.clamp(maxEncounterType) != maxEncounterType) {
+            logWarn(QString("Metatile Encounter Type mask '%1' is insufficient to contain largest value '%2'.")
                             .arg(Util::toHexString(encounterTypeMask))
-                            .arg(maxEncounterType + 1));
+                            .arg(Util::toHexString(maxEncounterType)));
+        }
     }
     attributePackers.insert(Metatile::Attr::EncounterType, packer);
 
-    // Validate terrain type mask
+    // Validate layer type mask
     packer.setMask(layerTypeMask);
-    const uint32_t maxLayerType = NUM_METATILE_LAYER_TYPES - 1;
+    const uint32_t maxLayerType = Metatile::LayerType::Count - 1;
     if (layerTypeMask && packer.clamp(maxLayerType) != maxLayerType) {
         logWarn(QString("Metatile Layer Type mask '%1' is insufficient to contain all %2 available options.")
                             .arg(Util::toHexString(layerTypeMask))

--- a/src/core/metatile.cpp
+++ b/src/core/metatile.cpp
@@ -10,11 +10,11 @@ static const QMap<Metatile::Attr, BitPacker> attributePackersFRLG = {
     {Metatile::Attr::TerrainType,   BitPacker(0x00003E00) },
     {Metatile::Attr::EncounterType, BitPacker(0x07000000) },
     {Metatile::Attr::LayerType,     BitPacker(0x60000000) },
-  //{Metatile::Attr::Unused,        BitPacker(0x98FFC000) },
+    {Metatile::Attr::Unused,        BitPacker(0x98FFC000) },
 };
 static const QMap<Metatile::Attr, BitPacker> attributePackersRSE = {
     {Metatile::Attr::Behavior,      BitPacker(0x00FF) },
-  //{Metatile::Attr::Unused,        BitPacker(0x0F00) },
+    {Metatile::Attr::Unused,        BitPacker(0x0F00) },
     {Metatile::Attr::LayerType,     BitPacker(0xF000) },
 };
 

--- a/src/core/parseutil.cpp
+++ b/src/core/parseutil.cpp
@@ -98,19 +98,8 @@ QString ParseUtil::loadTextFile(const QString &path, QString *error) {
     auto it = this->fileCache.constFind(path);
     if (it != this->fileCache.constEnd()) {
         // Load text file from cache
-        //logWarn(QString("CACHE HIT ON %1").arg(path));
         return it.value();
     }
-
-/* TODO: Remove
-    static QSet<QString> parsedFiles;
-    if (parsedFiles.contains(path)) {
-        logWarn(QString("CACHE MISS ON %1").arg(path));
-    } else {
-        parsedFiles.insert(path);
-    }
-*/
-
     return readTextFile(pathWithRoot(path), error);
 }
 

--- a/src/core/parseutil.cpp
+++ b/src/core/parseutil.cpp
@@ -37,6 +37,12 @@ void ParseUtil::set_root(const QString &dir) {
     this->root = dir;
 }
 
+QString ParseUtil::pathWithRoot(const QString &path) {
+    if (this->root.isEmpty()) return path;
+    if (path.startsWith(this->root)) return path;
+    return QString("%1/%2").arg(this->root).arg(path);
+}
+
 void ParseUtil::recordError(const QString &message) {
     this->errorMap[this->curDefine].append(message);
 }
@@ -85,6 +91,34 @@ QString ParseUtil::readTextFile(const QString &path, QString *error) {
     return text;
 }
 
+// Load the specified text file, either from the cache or by reading the file.
+// Note that this doesn't insert any parsed files into the file cache, and we don't
+// want it to (we read a lot of files only once, storing them all is a waste of memory).
+QString ParseUtil::loadTextFile(const QString &path, QString *error) {
+    auto it = this->fileCache.constFind(path);
+    if (it != this->fileCache.constEnd()) {
+        // Load text file from cache
+        //logWarn(QString("CACHE HIT ON %1").arg(path));
+        return it.value();
+    }
+
+/* TODO: Remove
+    static QSet<QString> parsedFiles;
+    if (parsedFiles.contains(path)) {
+        logWarn(QString("CACHE MISS ON %1").arg(path));
+    } else {
+        parsedFiles.insert(path);
+    }
+*/
+
+    return readTextFile(pathWithRoot(path), error);
+}
+
+bool ParseUtil::cacheFile(const QString &path, QString *error) {
+    this->fileCache.insert(path, readTextFile(pathWithRoot(path), error));
+    return !error || error->isEmpty();
+}
+
 int ParseUtil::textFileLineCount(const QString &path) {
     const QString text = readTextFile(path);
     return text.split('\n').count() + 1;
@@ -93,7 +127,7 @@ int ParseUtil::textFileLineCount(const QString &path) {
 QList<QStringList> ParseUtil::parseAsm(const QString &filename) {
     QList<QStringList> parsed;
 
-    this->text = readTextFile(this->root + '/' + filename);
+    this->text = loadTextFile(filename);
     const QStringList lines = removeLineComments(this->text, "@").split('\n');
     for (const auto &line : lines) {
         const QString trimmedLine = line.trimmed();
@@ -295,7 +329,7 @@ QString ParseUtil::readCIncbin(const QString &filename, const QString &label) {
         return path;
     }
 
-    this->text = readTextFile(this->root + "/" + filename);
+    this->text = loadTextFile(filename);
 
     QRegularExpression re(QString(
         "\\b%1\\b"
@@ -316,7 +350,7 @@ QMap<QString, QString> ParseUtil::readCIncbinMulti(const QString &filepath) {
     QMap<QString, QString> incbinMap;
 
     this->file = filepath;
-    this->text = readTextFile(this->root + "/" + filepath);
+    this->text = loadTextFile(filepath);
 
     static const QRegularExpression regex("(?<label>[A-Za-z0-9_]+)\\s*\\[?\\s*\\]?\\s*=\\s*INCBIN_[US][0-9][0-9]?\\(\\s*\\\"(?<path>[^\\\\\"]*)\\\"\\s*\\)");
 
@@ -338,7 +372,7 @@ QStringList ParseUtil::readCIncbinArray(const QString &filename, const QString &
         return paths;
     }
 
-    this->text = readTextFile(this->root + "/" + filename);
+    this->text = loadTextFile(filename);
 
     bool found = false;
     QString arrayText;
@@ -388,8 +422,7 @@ ParseUtil::ParsedDefines ParseUtil::readCDefines(const QString &filename, const 
         return result;
     }
 
-    QString filepath = this->root + "/" + this->file;
-    this->text = readTextFile(filepath, error);
+    this->text = loadTextFile(filename, error);
     if (this->text.isNull())
         return result;
 
@@ -507,7 +540,7 @@ QStringList ParseUtil::readCArray(const QString &filename, const QString &label)
     }
 
     this->file = filename;
-    this->text = readTextFile(this->root + "/" + filename);
+    this->text = loadTextFile(filename);
 
     QRegularExpression re(QString(R"(\b%1\b\s*(\[?[^\]]*\])?\s*=\s*\{([^\}]*)\})").arg(label));
     QRegularExpressionMatch match = re.match(this->text);
@@ -530,7 +563,7 @@ QMap<QString, QStringList> ParseUtil::readCArrayMulti(const QString &filename) {
     QMap<QString, QStringList> map;
 
     this->file = filename;
-    this->text = readTextFile(this->root + "/" + filename);
+    this->text = loadTextFile(filename);
 
     static const QRegularExpression regex(R"((?<label>\b[A-Za-z0-9_]+\b)\s*(\[[^\]]*\])?\s*=\s*\{(?<body>[^\}]*)\})");
 
@@ -556,7 +589,7 @@ QMap<QString, QStringList> ParseUtil::readCArrayMulti(const QString &filename) {
 }
 
 QMap<QString, QString> ParseUtil::readNamedIndexCArray(const QString &filename, const QString &label, QString *error) {
-    this->text = readTextFile(this->root + "/" + filename, error);
+    this->text = loadTextFile(filename, error);
     QMap<QString, QString> map;
 
     QRegularExpression re_text(QString(R"(\b%1\b\s*(\[?[^\]]*\])?\s*=\s*\{([^\}]*)\})").arg(label));
@@ -589,7 +622,7 @@ bool ParseUtil::gameStringToBool(const QString &gameString, bool * ok) {
 }
 
 tsl::ordered_map<QString, QHash<QString, QString>> ParseUtil::readCStructs(const QString &filename, const QString &label, const QHash<int, QString> &memberMap) {
-    QString filePath = this->root + "/" + filename;
+    QString filePath = pathWithRoot(filename);
     auto cParser = fex::Parser();
     auto tokens = fex::Lexer().LexFile(filePath);
     auto topLevelObjects = cParser.ParseTopLevelObjects(tokens);
@@ -657,7 +690,7 @@ QStringList ParseUtil::getLabelValues(const QList<QStringList> &list, const QStr
 }
 
 bool ParseUtil::tryParseJsonFile(QJsonDocument *out, const QString &filepath, QString *error) {
-    QFile file(filepath);
+    QFile file(pathWithRoot(filepath));
     if (!file.open(QIODevice::ReadOnly)) {
         if (error) *error = file.errorString();
         return false;
@@ -678,7 +711,7 @@ bool ParseUtil::tryParseJsonFile(QJsonDocument *out, const QString &filepath, QS
 
 bool ParseUtil::tryParseOrderedJsonFile(poryjson::Json::object *out, const QString &filepath, QString *error) {
     QString err;
-    QString jsonTxt = readTextFile(filepath, error);
+    QString jsonTxt = loadTextFile(filepath, error);
     if (error && !error->isEmpty()) {
         return false;
     }

--- a/src/ui/imageproviders.cpp
+++ b/src/ui/imageproviders.cpp
@@ -72,19 +72,19 @@ QImage getMetatileImage(
             switch (layerType)
             {
             default:
-            case METATILE_LAYER_MIDDLE_TOP:
+            case Metatile::LayerType::Normal:
                 if (l == 0)
                     tile = Tile(projectConfig.unusedTileNormal);
                 else // Tiles are on layers 1 and 2
                     tile = metatile->tiles.value(tileOffset + ((l - 1) * 4));
                 break;
-            case METATILE_LAYER_BOTTOM_MIDDLE:
+            case Metatile::LayerType::Covered:
                 if (l == 2)
                     tile = Tile(projectConfig.unusedTileCovered);
                 else // Tiles are on layers 0 and 1
                     tile = metatile->tiles.value(tileOffset + (l * 4));
                 break;
-            case METATILE_LAYER_BOTTOM_TOP:
+            case Metatile::LayerType::Split:
                 if (l == 1)
                     tile = Tile(projectConfig.unusedTileSplit);
                 else // Tiles are on layers 0 and 2

--- a/src/ui/tileseteditor.cpp
+++ b/src/ui/tileseteditor.cpp
@@ -129,10 +129,10 @@ void TilesetEditor::initAttributesUi() {
     connect(ui->comboBox_encounterType->lineEdit(), &QLineEdit::editingFinished, this, &TilesetEditor::commitEncounterType);
     connect(ui->comboBox_terrainType->lineEdit(), &QLineEdit::editingFinished, this, &TilesetEditor::commitTerrainType);
     connect(ui->comboBox_layerType->lineEdit(), &QLineEdit::editingFinished, this, &TilesetEditor::commitLayerType);
-    connect(ui->comboBox_metatileBehaviors, &QComboBox::activated, this, &TilesetEditor::commitMetatileBehavior);
-    connect(ui->comboBox_encounterType, &QComboBox::activated, this, &TilesetEditor::commitEncounterType);
-    connect(ui->comboBox_terrainType, &QComboBox::activated, this, &TilesetEditor::commitTerrainType);
-    connect(ui->comboBox_layerType, &QComboBox::activated, this, &TilesetEditor::commitLayerType);
+    connect(ui->comboBox_metatileBehaviors, QOverload<int>::of(&QComboBox::activated), this, &TilesetEditor::commitMetatileBehavior);
+    connect(ui->comboBox_encounterType,  QOverload<int>::of(&QComboBox::activated), this, &TilesetEditor::commitEncounterType);
+    connect(ui->comboBox_terrainType, QOverload<int>::of(&QComboBox::activated), this, &TilesetEditor::commitTerrainType);
+    connect(ui->comboBox_layerType, QOverload<int>::of(&QComboBox::activated), this, &TilesetEditor::commitLayerType);
 
     // Behavior
     if (projectConfig.metatileBehaviorMask) {

--- a/src/ui/tileseteditor.cpp
+++ b/src/ui/tileseteditor.cpp
@@ -134,10 +134,9 @@ void TilesetEditor::setAttributesUi() {
 
     // Terrain Type
     if (projectConfig.metatileTerrainTypeMask) {
-        this->ui->comboBox_terrainType->addItem("Normal", TERRAIN_NONE);
-        this->ui->comboBox_terrainType->addItem("Grass", TERRAIN_GRASS);
-        this->ui->comboBox_terrainType->addItem("Water", TERRAIN_WATER);
-        this->ui->comboBox_terrainType->addItem("Waterfall", TERRAIN_WATERFALL);
+        for (auto i = project->terrainTypeToName.constBegin(); i != project->terrainTypeToName.constEnd(); i++) {
+            this->ui->comboBox_terrainType->addItem(i.value(), i.key());
+        }
         this->ui->comboBox_terrainType->setEditable(false);
         this->ui->comboBox_terrainType->setMinimumContentsLength(0);
     } else {
@@ -147,9 +146,9 @@ void TilesetEditor::setAttributesUi() {
 
     // Encounter Type
     if (projectConfig.metatileEncounterTypeMask) {
-        this->ui->comboBox_encounterType->addItem("None", ENCOUNTER_NONE);
-        this->ui->comboBox_encounterType->addItem("Land", ENCOUNTER_LAND);
-        this->ui->comboBox_encounterType->addItem("Water", ENCOUNTER_WATER);
+        for (auto i = project->encounterTypeToName.constBegin(); i != project->encounterTypeToName.constEnd(); i++) {
+            this->ui->comboBox_encounterType->addItem(i.value(), i.key());
+        }
         this->ui->comboBox_encounterType->setEditable(false);
         this->ui->comboBox_encounterType->setMinimumContentsLength(0);
     } else {
@@ -159,9 +158,9 @@ void TilesetEditor::setAttributesUi() {
 
     // Layer Type
     if (!projectConfig.tripleLayerMetatilesEnabled) {
-        this->ui->comboBox_layerType->addItem("Normal - Middle/Top", METATILE_LAYER_MIDDLE_TOP);
-        this->ui->comboBox_layerType->addItem("Covered - Bottom/Middle", METATILE_LAYER_BOTTOM_MIDDLE);
-        this->ui->comboBox_layerType->addItem("Split - Bottom/Top", METATILE_LAYER_BOTTOM_TOP);
+        this->ui->comboBox_layerType->addItem("Normal - Middle/Top",     Metatile::LayerType::Normal);
+        this->ui->comboBox_layerType->addItem("Covered - Bottom/Middle", Metatile::LayerType::Covered);
+        this->ui->comboBox_layerType->addItem("Split - Bottom/Top",      Metatile::LayerType::Split);
         this->ui->comboBox_layerType->setEditable(false);
         this->ui->comboBox_layerType->setMinimumContentsLength(0);
         if (!projectConfig.metatileLayerTypeMask) {
@@ -607,6 +606,7 @@ void TilesetEditor::on_comboBox_layerType_activated(int layerType)
     }
 }
 
+// TODO: Needs to read data from item, not index of item.
 void TilesetEditor::on_comboBox_encounterType_activated(int encounterType)
 {
     if (this->metatile) {
@@ -616,6 +616,7 @@ void TilesetEditor::on_comboBox_encounterType_activated(int encounterType)
     }
 }
 
+// TODO: Needs to read data from item, not index of item.
 void TilesetEditor::on_comboBox_terrainType_activated(int terrainType)
 {
     if (this->metatile) {


### PR DESCRIPTION
Currently the Tileset Editor hard codes the options for Encounter Type and Terrain Type. After this change it reads the options from the projects. The metatile attribute dropdowns are now all editable and will update automatically to remove invalid values.

This also adds a file cache to `ParseUtil`. The motivation was because Porymap was parsing `global.fieldmap.h` multiple times to filter for different sets of defines. I also applied this cache to the tileset data files (when we first load a tileset we were parsing up to 5 files per tileset that we had already parsed). This should make the`Count Tile/Metatile Usage` features much faster on platforms with slow file I/O, because it used to involve opening the same tileset files hundreds of times.

Updated to add a toggleable input field that lets users edit the raw metatile attributes value directly. This input field is hidden by default.