### PR TITLE
Update map image exporter

### DIFF
--- a/forms/mapimageexporter.ui
+++ b/forms/mapimageexporter.ui
@@ -25,6 +25,9 @@
        <verstretch>0</verstretch>
       </sizepolicy>
      </property>
+     <property name="focusPolicy">
+      <enum>Qt::FocusPolicy::ClickFocus</enum>
+     </property>
      <layout class="QVBoxLayout" name="verticalLayout_Options">
       <item>
        <layout class="QFormLayout" name="formLayout">
@@ -166,7 +169,7 @@
             </widget>
            </item>
            <item row="1" column="0">
-            <widget class="QCheckBox" name="checkBox_Elevation">
+            <widget class="QCheckBox" name="checkBox_Collision">
              <property name="text">
               <string>Collision</string>
              </property>
@@ -191,7 +194,10 @@
         </property>
         <layout class="QGridLayout" name="gridLayout_7">
          <item row="2" column="1">
-          <widget class="QSpinBox" name="spinBox_TimelapseDelay">
+          <widget class="NoScrollSpinBox" name="spinBox_TimelapseDelay">
+           <property name="focusPolicy">
+            <enum>Qt::FocusPolicy::StrongFocus</enum>
+           </property>
            <property name="specialValueText">
             <string/>
            </property>
@@ -217,7 +223,10 @@
           </widget>
          </item>
          <item row="3" column="1">
-          <widget class="QSpinBox" name="spinBox_FrameSkip">
+          <widget class="NoScrollSpinBox" name="spinBox_FrameSkip">
+           <property name="focusPolicy">
+            <enum>Qt::FocusPolicy::StrongFocus</enum>
+           </property>
            <property name="suffix">
             <string/>
            </property>
@@ -253,9 +262,22 @@
        </spacer>
       </item>
       <item>
-       <widget class="QCheckBox" name="checkBox_ActualSize">
+       <widget class="QCheckBox" name="checkBox_DisablePreviewUpdates">
+        <property name="toolTip">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If checked, the image in the preview window will not be recreated when the settings are changed.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
         <property name="text">
-         <string>Preview actual size</string>
+         <string>Disable preview updates</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="checkBox_DisablePreviewScaling">
+        <property name="toolTip">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If checked, the image shown in the preview window will not scale to fit into the available space. The aspect ratio of the image will never change.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+        <property name="text">
+         <string>Disable preview scaling</string>
         </property>
        </widget>
       </item>
@@ -265,6 +287,9 @@
          <widget class="QPushButton" name="pushButton_Reset">
           <property name="text">
            <string>Reset</string>
+          </property>
+          <property name="autoDefault">
+           <bool>false</bool>
           </property>
          </widget>
         </item>
@@ -286,12 +311,18 @@
           <property name="text">
            <string>Cancel</string>
           </property>
+          <property name="autoDefault">
+           <bool>false</bool>
+          </property>
          </widget>
         </item>
         <item>
          <widget class="QPushButton" name="pushButton_Save">
           <property name="text">
            <string>Save</string>
+          </property>
+          <property name="autoDefault">
+           <bool>false</bool>
           </property>
          </widget>
         </item>
@@ -406,6 +437,11 @@
    <class>NoScrollComboBox</class>
    <extends>QComboBox</extends>
    <header>noscrollcombobox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>NoScrollSpinBox</class>
+   <extends>QSpinBox</extends>
+   <header>noscrollspinbox.h</header>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/forms/mapimageexporter.ui
+++ b/forms/mapimageexporter.ui
@@ -374,9 +374,6 @@
             <property name="sizeAdjustPolicy">
              <enum>QAbstractScrollArea::SizeAdjustPolicy::AdjustIgnored</enum>
             </property>
-            <property name="renderHints">
-             <set>QPainter::RenderHint::LosslessImageRendering|QPainter::RenderHint::TextAntialiasing</set>
-            </property>
             <property name="dragMode">
              <enum>QGraphicsView::DragMode::NoDrag</enum>
             </property>

--- a/forms/mapimageexporter.ui
+++ b/forms/mapimageexporter.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>817</width>
-    <height>535</height>
+    <height>556</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -37,11 +37,11 @@
         </item>
         <item row="0" column="1">
          <widget class="NoScrollComboBox" name="comboBox_MapSelection">
-          <property name="sizeAdjustPolicy">
-           <enum>QComboBox::SizeAdjustPolicy::AdjustToContents</enum>
-          </property>
           <property name="insertPolicy">
            <enum>QComboBox::InsertPolicy::NoInsert</enum>
+          </property>
+          <property name="sizeAdjustPolicy">
+           <enum>QComboBox::SizeAdjustPolicy::AdjustToContents</enum>
           </property>
          </widget>
         </item>
@@ -326,8 +326,14 @@
       </property>
       <item row="0" column="0">
        <widget class="QScrollArea" name="scrollArea_Preview">
+        <property name="sizeAdjustPolicy">
+         <enum>QAbstractScrollArea::SizeAdjustPolicy::AdjustToContents</enum>
+        </property>
         <property name="widgetResizable">
          <bool>true</bool>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignmentFlag::AlignCenter</set>
         </property>
         <widget class="QWidget" name="scrollAreaWidgetContents">
          <property name="geometry">
@@ -335,7 +341,7 @@
            <x>0</x>
            <y>0</y>
            <width>469</width>
-           <height>464</height>
+           <height>485</height>
           </rect>
          </property>
          <layout class="QGridLayout" name="gridLayout">
@@ -367,6 +373,9 @@
             </property>
             <property name="sizeAdjustPolicy">
              <enum>QAbstractScrollArea::SizeAdjustPolicy::AdjustIgnored</enum>
+            </property>
+            <property name="renderHints">
+             <set>QPainter::RenderHint::LosslessImageRendering|QPainter::RenderHint::TextAntialiasing</set>
             </property>
             <property name="dragMode">
              <enum>QGraphicsView::DragMode::NoDrag</enum>

--- a/forms/mapimageexporter.ui
+++ b/forms/mapimageexporter.ui
@@ -40,6 +40,9 @@
           <property name="sizeAdjustPolicy">
            <enum>QComboBox::SizeAdjustPolicy::AdjustToContents</enum>
           </property>
+          <property name="insertPolicy">
+           <enum>QComboBox::InsertPolicy::NoInsert</enum>
+          </property>
          </widget>
         </item>
        </layout>

--- a/include/core/editcommands.h
+++ b/include/core/editcommands.h
@@ -47,6 +47,13 @@ enum CommandId {
 #define IDMask_EventType_Trigger (1 << 11)
 #define IDMask_EventType_Heal    (1 << 12)
 
+#define IDMask_ConnectionDirection_Up     (1 << 8)
+#define IDMask_ConnectionDirection_Down   (1 << 9)
+#define IDMask_ConnectionDirection_Left   (1 << 10)
+#define IDMask_ConnectionDirection_Right  (1 << 11)
+#define IDMask_ConnectionDirection_Dive   (1 << 12)
+#define IDMask_ConnectionDirection_Emerge (1 << 13)
+
 /// Implements a command to commit metatile paint actions
 /// onto the map using the pencil tool.
 class PaintMetatile : public QUndoCommand {
@@ -400,7 +407,7 @@ public:
     void redo() override;
 
     bool mergeWith(const QUndoCommand *command) override;
-    int id() const override { return CommandId::ID_MapConnectionMove; }
+    int id() const override;
 
 private:
     MapConnection *connection;
@@ -421,7 +428,7 @@ public:
     void undo() override;
     void redo() override;
 
-    int id() const override { return CommandId::ID_MapConnectionChangeDirection; }
+    int id() const override;
 
 private:
     QPointer<MapConnection> connection;
@@ -443,7 +450,7 @@ public:
     void undo() override;
     void redo() override;
 
-    int id() const override { return CommandId::ID_MapConnectionChangeMap; }
+    int id() const override;
 
 private:
     QPointer<MapConnection> connection;
@@ -465,7 +472,7 @@ public:
     void undo() override;
     void redo() override;
 
-    int id() const override { return CommandId::ID_MapConnectionAdd; }
+    int id() const override;
 
 private:
     Map *map = nullptr;
@@ -485,7 +492,7 @@ public:
     void undo() override;
     void redo() override;
 
-    int id() const override { return CommandId::ID_MapConnectionRemove; }
+    int id() const override;
 
 private:
     Map *map = nullptr;

--- a/include/core/events.h
+++ b/include/core/events.h
@@ -615,6 +615,10 @@ private:
 };
 
 
+inline uint qHash(const Event::Group &key, uint seed = 0) {
+    return qHash(static_cast<int>(key), seed);
+}
+
 
 ///
 /// Keeps track of scripts

--- a/include/core/events.h
+++ b/include/core/events.h
@@ -170,6 +170,7 @@ public:
     static QString typeToJsonKey(Event::Type type);
     static Event::Type typeFromJsonKey(QString type);
     static QList<Event::Type> types();
+    static QList<Event::Group> groups();
 
 // protected attributes
 protected:

--- a/include/core/map.h
+++ b/include/core/map.h
@@ -89,7 +89,7 @@ public:
     bool hasEvent(Event *) const;
 
     void deleteConnections();
-    QList<MapConnection*> getConnections() const;
+    QList<MapConnection*> getConnections() const { return m_connections; }
     void removeConnection(MapConnection *);
     void addConnection(MapConnection *);
     void loadConnection(MapConnection *);

--- a/include/core/mapconnection.h
+++ b/include/core/mapconnection.h
@@ -26,13 +26,19 @@ public:
     QString direction() const { return m_direction; }
     void setDirection(const QString &direction, bool mirror = true);
 
+    bool isCardinal() const { return isCardinal(m_direction); }
+    bool isHorizontal() const { return isHorizontal(m_direction); }
+    bool isVertical() const { return isVertical(m_direction); }
+    bool isDiving() const { return isDiving(m_direction); }
+
     int offset() const { return m_offset; }
     void setOffset(int offset, bool mirror = true);
 
     MapConnection* findMirror();
     MapConnection* createMirror();
 
-    QPixmap getPixmap();
+    QPixmap render() const;
+    QPoint relativePos(bool clipped = false) const;
 
     static QPointer<Project> project;
     static const QMap<QString, QString> oppositeDirections;

--- a/include/core/maplayout.h
+++ b/include/core/maplayout.h
@@ -95,6 +95,8 @@ public:
     int getHeight() const { return height; }
     int getBorderWidth() const { return border_width; }
     int getBorderHeight() const { return border_height; }
+    int getBorderDrawWidth() const;
+    int getBorderDrawHeight() const;
 
     bool isWithinBounds(int x, int y);
     bool isWithinBorderBounds(int x, int y);
@@ -139,6 +141,8 @@ public:
 private:
     void setNewDimensionsBlockdata(int newWidth, int newHeight);
     void setNewBorderDimensionsBlockdata(int newWidth, int newHeight);
+
+    static int getBorderDrawDistance(int dimension, qreal minimum);
 
 signals:
     void layoutChanged(Layout *layout);

--- a/include/core/maplayout.h
+++ b/include/core/maplayout.h
@@ -98,8 +98,9 @@ public:
     int getBorderDrawWidth() const;
     int getBorderDrawHeight() const;
 
-    bool isWithinBounds(int x, int y);
-    bool isWithinBorderBounds(int x, int y);
+    bool isWithinBounds(int x, int y) const;
+    bool isWithinBounds(const QRect &rect) const;
+    bool isWithinBorderBounds(int x, int y) const;
 
     bool getBlock(int x, int y, Block *out);
     void setBlock(int x, int y, Block block, bool enableScriptCallback = false);

--- a/include/editor.h
+++ b/include/editor.h
@@ -175,8 +175,6 @@ public:
 
     void eventsView_onMousePress(QMouseEvent *event);
 
-    int getBorderDrawDistance(int dimension);
-
     bool selectingEvent = false;
 
     void deleteSelectedEvents();

--- a/include/mainwindow.h
+++ b/include/mainwindow.h
@@ -301,6 +301,10 @@ public:
     Ui::MainWindow *ui;
     QPointer<Editor> editor = nullptr;
 
+signals:
+    void mapOpened(Map*);
+    void layoutOpened(Layout*);
+
 private:
     QLabel *label_MapRulerStatus = nullptr;
     QPointer<TilesetEditor> tilesetEditor = nullptr;

--- a/include/ui/mapimageexporter.h
+++ b/include/ui/mapimageexporter.h
@@ -24,6 +24,7 @@ struct ImageExporterSettings {
     bool previewActualSize = false;
     int timelapseSkipAmount = 1;
     int timelapseDelayMs = 200;
+    QColor fillColor = Qt::transparent; // Not exposed as a setting in the UI atm.
 };
 
 class MapImageExporter : public QDialog
@@ -50,13 +51,14 @@ private:
     Map *m_map = nullptr;
     Layout *m_layout = nullptr;
     QGraphicsScene *m_scene = nullptr;
-    QGifImage *m_timelapseImage = nullptr;
+    QGifImage *m_timelapseGifImage = nullptr;
     QBuffer *m_timelapseBuffer = nullptr;
     QMovie *m_timelapseMovie = nullptr;
     QGraphicsPixmapItem *m_preview = nullptr;
 
     ImageExporterSettings m_settings;
     ImageExporterMode m_mode = ImageExporterMode::Normal;
+    ImageExporterMode m_originalMode;
 
     void setModeSpecificUi();
     void setSelectionText(const QString &text);
@@ -70,19 +72,17 @@ private:
     bool connectionsEnabled();
     void setConnectionDirectionEnabled(const QString &dir, bool enable);
     void saveImage();
-    QGifImage* createTimelapseImage();
+    QGifImage* createTimelapseGifImage(QProgressDialog *progress);
     QPixmap getStitchedImage(QProgressDialog *progress);
     QPixmap getFormattedMapPixmap();
-    QPixmap getFormattedMapPixmap(Map *map);
-    QPixmap getFormattedLayoutPixmap(Layout *layout);
     void paintBorder(QPainter *painter, Layout *layout);
     void paintCollision(QPainter *painter, Layout *layout);
     void paintConnections(QPainter *painter, const Map *map);
     void paintEvents(QPainter *painter, const Map *map);
     void paintGrid(QPainter *painter, const Layout *layout = nullptr);
-    QPixmap getResizedPixmap(const QPixmap &pixmap, const QMargins &margins);
-    QMargins getMargins(const Map *map = nullptr);
-    bool historyItemAppliesToFrame(const QUndoCommand *command);
+    QMargins getMargins(const Map *map);
+    QPixmap getExpandedPixmap(const QPixmap &pixmap, const QSize &minSize, const QColor &fillColor);
+    bool currentHistoryAppliesToFrame(QUndoStack *historyStack);
 
 protected:
     virtual void showEvent(QShowEvent *) override;

--- a/include/ui/mapimageexporter.h
+++ b/include/ui/mapimageexporter.h
@@ -14,15 +14,8 @@ enum ImageExporterMode {
 };
 
 struct ImageExporterSettings {
-    bool showObjects = false;
-    bool showWarps = false;
-    bool showBGs = false;
-    bool showTriggers = false;
-    bool showHealLocations = false;
-    bool showUpConnections = false;
-    bool showDownConnections = false;
-    bool showLeftConnections = false;
-    bool showRightConnections = false;
+    QSet<Event::Group> showEvents;
+    QSet<QString> showConnections;
     bool showGrid = false;
     bool showBorder = false;
     bool showCollision = false;
@@ -62,13 +55,18 @@ private:
     QString getDescription(ImageExporterMode mode);
     void updatePreview();
     void scalePreview();
+    bool eventsEnabled();
+    void setEventGroupEnabled(Event::Group group, bool enable);
+    bool connectionsEnabled();
+    void setConnectionDirectionEnabled(const QString &dir, bool enable);
     void updateShowBorderState();
     void saveImage();
-    QPixmap getStitchedImage(QProgressDialog *progress, bool includeBorder);
+    QPixmap getStitchedImage(QProgressDialog *progress);
     QPixmap getFormattedMapPixmap();
-    QPixmap getFormattedMapPixmap(Map *map, bool ignoreBorder = false);
-    QPixmap getFormattedLayoutPixmap(Layout *layout, bool ignoreBorder = false, bool ignoreGrid = false);
-    void paintGrid(QPixmap *pixmap, bool ignoreBorder = false);
+    QPixmap getFormattedMapPixmap(Map *map);
+    QPixmap getFormattedLayoutPixmap(Layout *layout);
+    void paintEvents(QPixmap *pixmap, const Map *map, const QPoint &pixelOffset);
+    void paintGrid(QPixmap *pixmap);
     bool historyItemAppliesToFrame(const QUndoCommand *command);
     void updateMapSelection(const QString &text);
 

--- a/include/ui/mapimageexporter.h
+++ b/include/ui/mapimageexporter.h
@@ -3,6 +3,8 @@
 
 #include "project.h"
 
+class QGifImage;
+
 namespace Ui {
 class MapImageExporter;
 }
@@ -48,8 +50,11 @@ private:
     Map *m_map = nullptr;
     Layout *m_layout = nullptr;
     QGraphicsScene *m_scene = nullptr;
+    QGifImage *m_timelapseImage = nullptr;
+    QBuffer *m_timelapseBuffer = nullptr;
+    QMovie *m_timelapseMovie = nullptr;
+    QGraphicsPixmapItem *m_preview = nullptr;
 
-    QPixmap m_preview;
 
     ImageExporterSettings m_settings;
     ImageExporterMode m_mode = ImageExporterMode::Normal;
@@ -65,6 +70,7 @@ private:
     bool connectionsEnabled();
     void setConnectionDirectionEnabled(const QString &dir, bool enable);
     void saveImage();
+    QGifImage* createTimelapseImage();
     QPixmap getStitchedImage(QProgressDialog *progress);
     QPixmap getFormattedMapPixmap();
     QPixmap getFormattedMapPixmap(Map *map);

--- a/include/ui/mapimageexporter.h
+++ b/include/ui/mapimageexporter.h
@@ -1,10 +1,7 @@
 #ifndef MAPIMAGEEXPORTER_H
 #define MAPIMAGEEXPORTER_H
 
-#include "map.h"
-#include "editor.h"
-
-#include <QDialog>
+#include "project.h"
 
 namespace Ui {
 class MapImageExporter;
@@ -39,15 +36,21 @@ class MapImageExporter : public QDialog
     Q_OBJECT
 
 public:
-    explicit MapImageExporter(QWidget *parent, Editor *editor, ImageExporterMode mode);
+    explicit MapImageExporter(QWidget *parent, Project *project, Layout *layout, ImageExporterMode mode = ImageExporterMode::Normal)
+                        : MapImageExporter(parent, project, nullptr, layout, mode) {};
+    explicit MapImageExporter(QWidget *parent, Project *project, Map *map, ImageExporterMode mode = ImageExporterMode::Normal)
+                        : MapImageExporter(parent, project, map, map->layout(), mode) {};
     ~MapImageExporter();
 
-private:
-    Ui::MapImageExporter *ui;
+    ImageExporterMode mode() const { return m_mode; }
 
-    Layout *m_layout = nullptr;
+private:
+    explicit MapImageExporter(QWidget *parent, Project *project, Map *map, Layout *layout, ImageExporterMode mode);
+
+    Ui::MapImageExporter *ui;
+    Project *m_project = nullptr;
     Map *m_map = nullptr;
-    Editor *m_editor = nullptr;
+    Layout *m_layout = nullptr;
     QGraphicsScene *m_scene = nullptr;
 
     QPixmap m_preview;
@@ -55,6 +58,8 @@ private:
     ImageExporterSettings m_settings;
     ImageExporterMode m_mode = ImageExporterMode::Normal;
 
+    QString getTitle(ImageExporterMode mode);
+    QString getDescription(ImageExporterMode mode);
     void updatePreview();
     void scalePreview();
     void updateShowBorderState();
@@ -65,6 +70,7 @@ private:
     QPixmap getFormattedLayoutPixmap(Layout *layout, bool ignoreBorder = false, bool ignoreGrid = false);
     void paintGrid(QPixmap *pixmap, bool ignoreBorder = false);
     bool historyItemAppliesToFrame(const QUndoCommand *command);
+    void updateMapSelection(const QString &text);
 
 protected:
     virtual void showEvent(QShowEvent *) override;

--- a/include/ui/mapimageexporter.h
+++ b/include/ui/mapimageexporter.h
@@ -59,12 +59,14 @@ private:
     void setEventGroupEnabled(Event::Group group, bool enable);
     bool connectionsEnabled();
     void setConnectionDirectionEnabled(const QString &dir, bool enable);
-    void updateShowBorderState();
     void saveImage();
     QPixmap getStitchedImage(QProgressDialog *progress);
     QPixmap getFormattedMapPixmap();
     QPixmap getFormattedMapPixmap(Map *map);
-    QPixmap getFormattedLayoutPixmap(Layout *layout);
+    QPixmap getFormattedLayoutPixmap(Layout *layout, bool ignoreGrid = false);
+    void paintBorder(QPixmap *pixmap, Layout *layout);
+    void paintCollision(QPixmap *pixmap, Layout *layout);
+    void paintConnections(QPixmap *pixmap, const Map *map);
     void paintEvents(QPixmap *pixmap, const Map *map, const QPoint &pixelOffset);
     void paintGrid(QPixmap *pixmap);
     bool historyItemAppliesToFrame(const QUndoCommand *command);

--- a/include/ui/mapimageexporter.h
+++ b/include/ui/mapimageexporter.h
@@ -55,11 +55,11 @@ private:
     QMovie *m_timelapseMovie = nullptr;
     QGraphicsPixmapItem *m_preview = nullptr;
 
-
     ImageExporterSettings m_settings;
     ImageExporterMode m_mode = ImageExporterMode::Normal;
 
     void setModeSpecificUi();
+    void setSelectionText(const QString &text);
     void updateMapSelection();
     QString getTitle(ImageExporterMode mode);
     QString getDescription(ImageExporterMode mode);
@@ -74,12 +74,14 @@ private:
     QPixmap getStitchedImage(QProgressDialog *progress);
     QPixmap getFormattedMapPixmap();
     QPixmap getFormattedMapPixmap(Map *map);
-    QPixmap getFormattedLayoutPixmap(Layout *layout, bool ignoreGrid = false);
-    void paintBorder(QPixmap *pixmap, Layout *layout);
-    void paintCollision(QPixmap *pixmap, Layout *layout);
-    void paintConnections(QPixmap *pixmap, const Map *map);
-    void paintEvents(QPixmap *pixmap, const Map *map, const QPoint &pixelOffset);
-    void paintGrid(QPixmap *pixmap);
+    QPixmap getFormattedLayoutPixmap(Layout *layout);
+    void paintBorder(QPainter *painter, Layout *layout);
+    void paintCollision(QPainter *painter, Layout *layout);
+    void paintConnections(QPainter *painter, const Map *map);
+    void paintEvents(QPainter *painter, const Map *map);
+    void paintGrid(QPainter *painter, const Layout *layout = nullptr);
+    QPixmap getResizedPixmap(const QPixmap &pixmap, const QMargins &margins);
+    QMargins getMargins(const Map *map = nullptr);
     bool historyItemAppliesToFrame(const QUndoCommand *command);
 
 protected:

--- a/include/ui/mapimageexporter.h
+++ b/include/ui/mapimageexporter.h
@@ -21,10 +21,12 @@ struct ImageExporterSettings {
     bool showGrid = false;
     bool showBorder = false;
     bool showCollision = false;
-    bool previewActualSize = false;
+    bool disablePreviewScaling = false;
+    bool disablePreviewUpdates = false;
     int timelapseSkipAmount = 1;
     int timelapseDelayMs = 200;
-    QColor fillColor = Qt::transparent; // Not exposed as a setting in the UI atm.
+    // Not exposed as a setting in the UI atm (our color input widget has no alpha channel).
+    QColor fillColor = Qt::transparent;
 };
 
 class MapImageExporter : public QDialog
@@ -63,9 +65,10 @@ private:
     void setModeSpecificUi();
     void setSelectionText(const QString &text);
     void updateMapSelection();
+    void resetSettings();
     QString getTitle(ImageExporterMode mode);
     QString getDescription(ImageExporterMode mode);
-    void updatePreview();
+    void updatePreview(bool forceUpdate = false);
     void scalePreview();
     bool eventsEnabled();
     void setEventGroupEnabled(Event::Group group, bool enable);
@@ -81,7 +84,7 @@ private:
     void paintEvents(QPainter *painter, const Map *map);
     void paintGrid(QPainter *painter, const Layout *layout = nullptr);
     QMargins getMargins(const Map *map);
-    QPixmap getExpandedPixmap(const QPixmap &pixmap, const QSize &minSize, const QColor &fillColor);
+    QPixmap getExpandedPixmap(const QPixmap &pixmap, const QSize &targetSize, const QColor &fillColor);
     bool currentHistoryAppliesToFrame(QUndoStack *historyStack);
 
 protected:
@@ -102,15 +105,16 @@ private slots:
     void on_checkBox_ConnectionRight_stateChanged(int state);
     void on_checkBox_AllConnections_stateChanged(int state);
 
-    void on_checkBox_Elevation_stateChanged(int state);
+    void on_checkBox_Collision_stateChanged(int state);
     void on_checkBox_Grid_stateChanged(int state);
     void on_checkBox_Border_stateChanged(int state);
 
     void on_pushButton_Reset_pressed();
-    void on_spinBox_TimelapseDelay_valueChanged(int delayMs);
-    void on_spinBox_FrameSkip_valueChanged(int skip);
+    void on_spinBox_TimelapseDelay_editingFinished();
+    void on_spinBox_FrameSkip_editingFinished();
 
-    void on_checkBox_ActualSize_stateChanged(int state);
+    void on_checkBox_DisablePreviewScaling_stateChanged(int state);
+    void on_checkBox_DisablePreviewUpdates_stateChanged(int state);
 };
 
 #endif // MAPIMAGEEXPORTER_H

--- a/include/ui/mapimageexporter.h
+++ b/include/ui/mapimageexporter.h
@@ -29,13 +29,16 @@ class MapImageExporter : public QDialog
     Q_OBJECT
 
 public:
-    explicit MapImageExporter(QWidget *parent, Project *project, Layout *layout, ImageExporterMode mode = ImageExporterMode::Normal)
-                        : MapImageExporter(parent, project, nullptr, layout, mode) {};
     explicit MapImageExporter(QWidget *parent, Project *project, Map *map, ImageExporterMode mode = ImageExporterMode::Normal)
                         : MapImageExporter(parent, project, map, map->layout(), mode) {};
+    explicit MapImageExporter(QWidget *parent, Project *project, Layout *layout, ImageExporterMode mode = ImageExporterMode::Normal)
+                        : MapImageExporter(parent, project, nullptr, layout, mode) {};
     ~MapImageExporter();
 
     ImageExporterMode mode() const { return m_mode; }
+
+    void setMap(Map *map);
+    void setLayout(Layout *layout);
 
 private:
     explicit MapImageExporter(QWidget *parent, Project *project, Map *map, Layout *layout, ImageExporterMode mode);
@@ -51,6 +54,8 @@ private:
     ImageExporterSettings m_settings;
     ImageExporterMode m_mode = ImageExporterMode::Normal;
 
+    void setModeSpecificUi();
+    void updateMapSelection();
     QString getTitle(ImageExporterMode mode);
     QString getDescription(ImageExporterMode mode);
     void updatePreview();
@@ -70,7 +75,6 @@ private:
     void paintEvents(QPixmap *pixmap, const Map *map, const QPoint &pixelOffset);
     void paintGrid(QPixmap *pixmap);
     bool historyItemAppliesToFrame(const QUndoCommand *command);
-    void updateMapSelection(const QString &text);
 
 protected:
     virtual void showEvent(QShowEvent *) override;

--- a/src/core/editcommands.cpp
+++ b/src/core/editcommands.cpp
@@ -5,7 +5,7 @@
 
 #include <QDebug>
 
-int getEventTypeMask(QList<Event *> events) {
+int getEventTypeMask(const QList<Event *> &events) {
     int eventTypeMask = 0;
     for (auto event : events) {
         Event::Group groupType = event->getEventGroup();
@@ -22,6 +22,26 @@ int getEventTypeMask(QList<Event *> events) {
         }
     }
     return eventTypeMask;
+}
+
+int getConnectionDirectionMask(const QList<QString> &directions) {
+    int mask = 0;
+    for (auto direction : directions) {
+        if (direction == "up") {
+            mask |= IDMask_ConnectionDirection_Up;
+        } else if (direction == "down") {
+            mask |= IDMask_ConnectionDirection_Down;
+        } else if (direction == "left") {
+            mask |= IDMask_ConnectionDirection_Left;
+        } else if (direction == "right") {
+            mask |= IDMask_ConnectionDirection_Right;
+        } else if (direction == "dive") {
+            mask |= IDMask_ConnectionDirection_Dive;
+        } else if (direction == "emerge") {
+            mask |= IDMask_ConnectionDirection_Emerge;
+        }
+    }
+    return mask;
 }
 
 void renderBlocks(Layout *layout, bool ignoreCache = false) {
@@ -587,6 +607,10 @@ bool MapConnectionMove::mergeWith(const QUndoCommand *command) {
     return true;
 }
 
+int MapConnectionMove::id() const {
+    return CommandId::ID_MapConnectionMove | getConnectionDirectionMask({this->connection->direction()});
+}
+
 /******************************************************************************
     ************************************************************************
  ******************************************************************************/
@@ -629,6 +653,10 @@ void MapConnectionChangeDirection::undo() {
     QUndoCommand::undo();
 }
 
+int MapConnectionChangeDirection::id() const {
+    return CommandId::ID_MapConnectionChangeDirection | getConnectionDirectionMask({this->oldDirection, this->newDirection});
+}
+
 /******************************************************************************
     ************************************************************************
  ******************************************************************************/
@@ -662,6 +690,10 @@ void MapConnectionChangeMap::undo() {
         this->connection->setOffset(this->oldOffset, this->mirrored);
     }
     QUndoCommand::undo();
+}
+
+int MapConnectionChangeMap::id() const {
+    return CommandId::ID_MapConnectionChangeMap | getConnectionDirectionMask({this->connection->direction()});
 }
 
 /******************************************************************************
@@ -708,6 +740,10 @@ void MapConnectionAdd::undo() {
     QUndoCommand::undo();
 }
 
+int MapConnectionAdd::id() const {
+    return CommandId::ID_MapConnectionAdd | getConnectionDirectionMask({this->connection->direction()});
+}
+
 /******************************************************************************
     ************************************************************************
  ******************************************************************************/
@@ -744,4 +780,8 @@ void MapConnectionRemove::undo() {
         this->mirrorMap->addConnection(this->mirror);
 
     QUndoCommand::undo();
+}
+
+int MapConnectionRemove::id() const {
+    return CommandId::ID_MapConnectionRemove | getConnectionDirectionMask({this->connection->direction()});
 }

--- a/src/core/events.cpp
+++ b/src/core/events.cpp
@@ -73,15 +73,21 @@ void Event::modify() {
     this->map->modify();
 }
 
+const QMap<Event::Group, QString> groupToStringMap = {
+    {Event::Group::Object, "Object"},
+    {Event::Group::Warp, "Warp"},
+    {Event::Group::Coord, "Trigger"},
+    {Event::Group::Bg, "BG"},
+    {Event::Group::Heal, "Heal Location"},
+};
+
 QString Event::groupToString(Event::Group group) {
-    static const QMap<Event::Group, QString> groupToStringMap = {
-        {Event::Group::Object, "Object"},
-        {Event::Group::Warp, "Warp"},
-        {Event::Group::Coord, "Trigger"},
-        {Event::Group::Bg, "BG"},
-        {Event::Group::Heal, "Heal Location"},
-    };
     return groupToStringMap.value(group);
+}
+
+QList<Event::Group> Event::groups() {
+    static QList<Event::Group> groupList = groupToStringMap.keys();
+    return groupList;
 }
 
 // These are the expected key names used in the map.json files.

--- a/src/core/map.cpp
+++ b/src/core/map.cpp
@@ -233,10 +233,6 @@ void Map::deleteConnections() {
     m_connections.clear();
 }
 
-QList<MapConnection*> Map::getConnections() const {
-    return m_connections;
-}
-
 void Map::addConnection(MapConnection *connection) {
     if (!connection || m_connections.contains(connection))
         return;
@@ -244,7 +240,7 @@ void Map::addConnection(MapConnection *connection) {
     // Maps should only have one Dive/Emerge connection at a time.
     // (Users can technically have more by editing their data manually, but we will only display one at a time)
     // Any additional connections being added (this can happen via mirroring) are tracked for deleting but otherwise ignored.
-    if (MapConnection::isDiving(connection->direction())) {
+    if (connection->isDiving()) {
         for (const auto &i : m_connections) {
             if (i->direction() == connection->direction()) {
                 trackConnection(connection);

--- a/src/core/maplayout.cpp
+++ b/src/core/maplayout.cpp
@@ -58,6 +58,25 @@ bool Layout::isWithinBorderBounds(int x, int y) {
     return (x >= 0 && x < this->getBorderWidth() && y >= 0 && y < this->getBorderHeight());
 }
 
+int Layout::getBorderDrawWidth() const {
+    return getBorderDrawDistance(border_width, BORDER_DISTANCE);
+}
+
+int Layout::getBorderDrawHeight() const {
+    return getBorderDrawDistance(border_height, BORDER_DISTANCE);
+}
+
+// We need to draw sufficient border blocks to fill the area that gets loaded around the player in-game (BORDER_DISTANCE).
+// Note that this is not the same as the player's view distance.
+// The result will be some multiple of the input dimension, because we only draw the border in increments of its full width/height.
+int Layout::getBorderDrawDistance(int dimension, qreal minimum) {
+    if (dimension >= minimum)
+        return dimension;
+
+    // Get first multiple of dimension >= the minimum
+    return dimension * qCeil(minimum / qMax(dimension, 1));
+}
+
 bool Layout::getBlock(int x, int y, Block *out) {
     if (isWithinBounds(x, y)) {
         int i = y * getWidth() + x;

--- a/src/core/maplayout.cpp
+++ b/src/core/maplayout.cpp
@@ -50,11 +50,15 @@ Layout::Settings Layout::settings() const {
     return settings;
 }
 
-bool Layout::isWithinBounds(int x, int y) {
+bool Layout::isWithinBounds(int x, int y) const {
     return (x >= 0 && x < this->getWidth() && y >= 0 && y < this->getHeight());
 }
 
-bool Layout::isWithinBorderBounds(int x, int y) {
+bool Layout::isWithinBounds(const QRect &rect) const {
+    return rect.left() >= 0 && rect.right() < this->getWidth() && rect.top() >= 0 && rect.bottom() < this->getHeight();
+}
+
+bool Layout::isWithinBorderBounds(int x, int y) const {
     return (x >= 0 && x < this->getBorderWidth() && y >= 0 && y < this->getBorderHeight());
 }
 

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -761,7 +761,7 @@ void Editor::displayConnection(MapConnection *connection) {
     if (!connection)
         return;
 
-    if (MapConnection::isDiving(connection->direction())) {
+    if (connection->isDiving()) {
         displayDivingConnection(connection);
         return;
     }
@@ -826,7 +826,7 @@ void Editor::removeConnectionPixmap(MapConnection *connection) {
     if (!connection)
         return;
 
-    if (MapConnection::isDiving(connection->direction())) {
+    if (connection->isDiving()) {
         removeDivingMapPixmap(connection);
         return;
     }
@@ -1790,8 +1790,8 @@ void Editor::displayMapBorder() {
 
     int borderWidth = this->layout->getBorderWidth();
     int borderHeight = this->layout->getBorderHeight();
-    int borderHorzDist = getBorderDrawDistance(borderWidth);
-    int borderVertDist = getBorderDrawDistance(borderHeight);
+    int borderHorzDist = this->layout->getBorderDrawWidth();
+    int borderVertDist = this->layout->getBorderDrawHeight();
     QPixmap pixmap = this->layout->renderBorder();
     for (int y = -borderVertDist; y < this->layout->getHeight() + borderVertDist; y += borderHeight)
     for (int x = -borderHorzDist; x < this->layout->getWidth() + borderHorzDist; x += borderWidth) {
@@ -1814,17 +1814,6 @@ void Editor::updateMapBorder() {
 void Editor::updateMapConnections() {
     for (auto item : connection_items)
         item->render(true);
-}
-
-int Editor::getBorderDrawDistance(int dimension) {
-    // Draw sufficient border blocks to fill the player's view (BORDER_DISTANCE)
-    if (dimension >= BORDER_DISTANCE) {
-        return dimension;
-    } else if (dimension) {
-        return dimension * (BORDER_DISTANCE / dimension + (BORDER_DISTANCE % dimension ? 1 : 0));
-    } else {
-        return BORDER_DISTANCE;
-    }
 }
 
 void Editor::toggleGrid(bool checked) {

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -2492,12 +2492,19 @@ void MainWindow::on_actionImport_Map_from_Advance_Map_1_92_triggered() {
 void MainWindow::showExportMapImageWindow(ImageExporterMode mode) {
     if (!editor->project) return;
 
-    // If the user is requesting this window again we assume it's for a new
-    // window (the map/mode may have changed), so delete the old window.
-    if (this->mapImageExporter)
+    // If the user is requesting this window again with a different mode
+    // then we'll recreate the window with the new mode.
+    if (this->mapImageExporter && this->mapImageExporter->mode() != mode)
         delete this->mapImageExporter;
 
-    this->mapImageExporter = new MapImageExporter(this, this->editor, mode);
+    if (!this->mapImageExporter) {
+        // Open new image export window
+        if (this->editor->map){
+            this->mapImageExporter = new MapImageExporter(this, this->editor->project, this->editor->map, mode);
+        } else if (this->editor->layout) {
+            this->mapImageExporter = new MapImageExporter(this, this->editor->project, this->editor->layout, mode);
+        }
+    }
 
     openSubWindow(this->mapImageExporter);
 }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -2506,9 +2506,11 @@ void MainWindow::showExportMapImageWindow(ImageExporterMode mode) {
         // Open new image export window
         if (this->editor->map){
             this->mapImageExporter = new MapImageExporter(this, this->editor->project, this->editor->map, mode);
-            connect(this, &MainWindow::mapOpened, this->mapImageExporter, &MapImageExporter::setMap);
         } else if (this->editor->layout) {
             this->mapImageExporter = new MapImageExporter(this, this->editor->project, this->editor->layout, mode);
+        }
+        if (this->mapImageExporter) {
+            connect(this, &MainWindow::mapOpened, this->mapImageExporter, &MapImageExporter::setMap);
             connect(this, &MainWindow::layoutOpened, this->mapImageExporter, &MapImageExporter::setLayout);
         }
     }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -934,6 +934,9 @@ bool MainWindow::setMap(QString map_name) {
     Scripting::cb_MapOpened(map_name);
     prefab.updatePrefabUi(editor->layout);
     updateTilesetEditor();
+
+    emit mapOpened(editor->map);
+
     return true;
 }
 
@@ -987,6 +990,8 @@ bool MainWindow::setLayout(QString layoutId) {
     updateTilesetEditor();
 
     userConfig.recentMapOrLayout = layoutId;
+
+    emit layoutOpened(editor->layout);
 
     return true;
 }
@@ -2501,8 +2506,10 @@ void MainWindow::showExportMapImageWindow(ImageExporterMode mode) {
         // Open new image export window
         if (this->editor->map){
             this->mapImageExporter = new MapImageExporter(this, this->editor->project, this->editor->map, mode);
+            connect(this, &MainWindow::mapOpened, this->mapImageExporter, &MapImageExporter::setMap);
         } else if (this->editor->layout) {
             this->mapImageExporter = new MapImageExporter(this, this->editor->project, this->editor->layout, mode);
+            connect(this, &MainWindow::layoutOpened, this->mapImageExporter, &MapImageExporter::setLayout);
         }
     }
 

--- a/src/ui/divingmappixmapitem.cpp
+++ b/src/ui/divingmappixmapitem.cpp
@@ -25,7 +25,7 @@ QPixmap DivingMapPixmapItem::getBasePixmap(MapConnection* connection) {
         return QPixmap(); // Save some rendering time if it won't be displayed
     if (connection->targetMapName() == connection->parentMapName())
         return QPixmap(); // If the map is connected to itself then rendering is pointless.
-    return connection->getPixmap();
+    return connection->render();
 }
 
 void DivingMapPixmapItem::updatePixmap() {

--- a/src/ui/mapimageexporter.cpp
+++ b/src/ui/mapimageexporter.cpp
@@ -57,7 +57,7 @@ MapImageExporter::MapImageExporter(QWidget *parent, Project *project, Map *map, 
 
     // Update the map selector when the text changes.
     // We don't use QComboBox::currentTextChanged to avoid unnecessary re-rendering.
-    connect(ui->comboBox_MapSelection, &QComboBox::currentIndexChanged, this, &MapImageExporter::updateMapSelection);
+    connect(ui->comboBox_MapSelection, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &MapImageExporter::updateMapSelection);
     connect(ui->comboBox_MapSelection->lineEdit(), &QLineEdit::editingFinished, this, &MapImageExporter::updateMapSelection);
 
     ui->graphicsView_Preview->setFocus();

--- a/src/ui/mapimageexporter.cpp
+++ b/src/ui/mapimageexporter.cpp
@@ -437,7 +437,6 @@ QGifImage* MapImageExporter::createTimelapseImage() {
                 historyStack->redo();
             }
             progress.setValue(progress.maximum() - i);
-            // TODO: Painting events is doing something funky to the quality of the timelapse image
             QPixmap pixmap = getFormattedMapPixmap();
             if (pixmap.width() < maxWidth || pixmap.height() < maxHeight) {
                 QPixmap resizedPixmap = QPixmap(maxWidth, maxHeight);
@@ -654,7 +653,10 @@ void MapImageExporter::paintEvents(QPixmap *pixmap, const Map *map, const QPoint
             continue;
         for (const auto &event : map->getEvents(group)) {
             m_project->loadEventPixmap(event);
-            painter.setOpacity(event->getUsesDefaultPixmap() ? 0.7 : 1.0);
+            if (m_mode != ImageExporterMode::Timelapse) {
+                // GIF format doesn't support partial transparency, so we can't do this in Timelapse mode.
+                painter.setOpacity(event->getUsesDefaultPixmap() ? 0.7 : 1.0);
+            }
             painter.drawImage(QPoint(event->getPixelX(), event->getPixelY()), event->getPixmap().toImage());
         }
     }

--- a/src/ui/mapimageexporter.cpp
+++ b/src/ui/mapimageexporter.cpp
@@ -8,8 +8,6 @@
 #include <QPainter>
 #include <QPoint>
 
-#define STITCH_MODE_BORDER_DISTANCE 2
-
 QString MapImageExporter::getTitle(ImageExporterMode mode) {
     switch (mode)
     {
@@ -167,8 +165,8 @@ void MapImageExporter::saveImage() {
                     int maxWidth = m_layout->getWidth() * 16;
                     int maxHeight = m_layout->getHeight() * 16;
                     if (m_settings.showBorder) {
-                        maxWidth += 2 * STITCH_MODE_BORDER_DISTANCE * 16;
-                        maxHeight += 2 * STITCH_MODE_BORDER_DISTANCE * 16;
+                        maxWidth += 2 * BORDER_DISTANCE * 16;
+                        maxHeight += 2 * BORDER_DISTANCE * 16;
                     }
                     // Rewind to the specified start of the map edit history.
                     int i = 0;
@@ -178,8 +176,8 @@ void MapImageExporter::saveImage() {
                         int width = m_layout->getWidth() * 16;
                         int height = m_layout->getHeight() * 16;
                         if (m_settings.showBorder) {
-                            width += 2 * STITCH_MODE_BORDER_DISTANCE * 16;
-                            height += 2 * STITCH_MODE_BORDER_DISTANCE * 16;
+                            width += 2 * BORDER_DISTANCE * 16;
+                            height += 2 * BORDER_DISTANCE * 16;
                         }
                         if (width > maxWidth) {
                             maxWidth = width;
@@ -346,10 +344,10 @@ QPixmap MapImageExporter::getStitchedImage(QProgressDialog *progress) {
     }
 
     if (m_settings.showBorder) {
-        minX -= STITCH_MODE_BORDER_DISTANCE;
-        maxX += STITCH_MODE_BORDER_DISTANCE;
-        minY -= STITCH_MODE_BORDER_DISTANCE;
-        maxY += STITCH_MODE_BORDER_DISTANCE;
+        minX -= BORDER_DISTANCE;
+        maxX += BORDER_DISTANCE;
+        minY -= BORDER_DISTANCE;
+        maxY += BORDER_DISTANCE;
     }
 
     // Draw the maps on the full canvas, while taking
@@ -379,8 +377,8 @@ QPixmap MapImageExporter::getStitchedImage(QProgressDialog *progress) {
         int pixelX = (map.x - minX) * 16;
         int pixelY = (map.y - minY) * 16;
         if (m_settings.showBorder) {
-            pixelX -= STITCH_MODE_BORDER_DISTANCE * 16;
-            pixelY -= STITCH_MODE_BORDER_DISTANCE * 16;
+            pixelX -= BORDER_DISTANCE * 16;
+            pixelY -= BORDER_DISTANCE * 16;
         }
         QPixmap pixmap = getFormattedMapPixmap(map.map);
         painter.drawPixmap(pixelX, pixelY, pixmap);
@@ -490,16 +488,15 @@ QPixmap MapImageExporter::getFormattedLayoutPixmap(Layout *layout) {
     // draw map border
     int borderHeight = 0, borderWidth = 0;
     if (m_settings.showBorder) {
-        int borderDistance = m_mode ? STITCH_MODE_BORDER_DISTANCE : BORDER_DISTANCE;
         layout->renderBorder();
         int borderHorzDist = layout->getBorderDrawWidth();
         int borderVertDist = layout->getBorderDrawHeight();
-        borderWidth = borderDistance * 16;
-        borderHeight = borderDistance * 16;
+        borderWidth = BORDER_DISTANCE * 16;
+        borderHeight = BORDER_DISTANCE * 16;
         QPixmap newPixmap = QPixmap(layout->pixmap.width() + borderWidth * 2, layout->pixmap.height() + borderHeight * 2);
         QPainter borderPainter(&newPixmap);
-        for (int y = borderDistance - borderVertDist; y < layout->getHeight() + borderVertDist * 2; y += layout->getBorderHeight()) {
-            for (int x = borderDistance - borderHorzDist; x < layout->getWidth() + borderHorzDist * 2; x += layout->getBorderWidth()) {
+        for (int y = BORDER_DISTANCE - borderVertDist; y < layout->getHeight() + borderVertDist * 2; y += layout->getBorderHeight()) {
+            for (int x = BORDER_DISTANCE - borderHorzDist; x < layout->getWidth() + borderHorzDist * 2; x += layout->getBorderWidth()) {
                 borderPainter.drawPixmap(x * 16, y * 16, layout->border_pixmap);
             }
         }
@@ -527,21 +524,18 @@ QPixmap MapImageExporter::getFormattedMapPixmap(Map *map) {
     if (m_settings.showBorder && connectionsEnabled()) {
         QPainter connectionPainter(&pixmap);
         
-        int borderDistance = m_mode ? STITCH_MODE_BORDER_DISTANCE : BORDER_DISTANCE;
         for (const auto &connection : m_map->getConnections()) {
             if (!m_settings.showConnections.contains(connection->direction()))
                 continue;
             QPoint pos = connection->relativePos(true);
-            connectionPainter.drawImage((pos.x() + borderDistance) * 16, (pos.y() + borderDistance) * 16, connection->render().toImage());
+            connectionPainter.drawImage((pos.x() + BORDER_DISTANCE) * 16, (pos.y() + BORDER_DISTANCE) * 16, connection->render().toImage());
         }
         connectionPainter.end();
     }
 
-    int eventPixelOffset = 0;
-    if (m_settings.showBorder) {
-        eventPixelOffset = (m_mode == ImageExporterMode::Normal) ? BORDER_DISTANCE * 16 : STITCH_MODE_BORDER_DISTANCE * 16;
-    }
+    int eventPixelOffset = m_settings.showBorder ? BORDER_DISTANCE * 16 : 0;
     paintEvents(&pixmap, map, QPoint(eventPixelOffset, eventPixelOffset));
+
     paintGrid(&pixmap);
 
     return pixmap;

--- a/src/ui/mapimageexporter.cpp
+++ b/src/ui/mapimageexporter.cpp
@@ -244,11 +244,12 @@ bool MapImageExporter::currentHistoryAppliesToFrame(QUndoStack *historyStack) {
         case CommandId::ID_MapConnectionRemove: {
             if (!connectionsEnabled())
                 return false;
-            if (command->id() & IDMask_ConnectionDirection_Up)    return m_settings.showConnections.contains("up");
-            if (command->id() & IDMask_ConnectionDirection_Down)  return m_settings.showConnections.contains("down");
-            if (command->id() & IDMask_ConnectionDirection_Left)  return m_settings.showConnections.contains("left");
-            if (command->id() & IDMask_ConnectionDirection_Right) return m_settings.showConnections.contains("right");
-            return false;
+            uint32_t flags = 0;
+            if (m_settings.showConnections.contains("up"))    flags |= IDMask_ConnectionDirection_Up;
+            if (m_settings.showConnections.contains("down"))  flags |= IDMask_ConnectionDirection_Down;
+            if (m_settings.showConnections.contains("left"))  flags |= IDMask_ConnectionDirection_Left;
+            if (m_settings.showConnections.contains("right")) flags |= IDMask_ConnectionDirection_Right;
+            return (command->id() & flags) != 0;
         }
         case CommandId::ID_EventMove:
         case CommandId::ID_EventShift:
@@ -256,12 +257,15 @@ bool MapImageExporter::currentHistoryAppliesToFrame(QUndoStack *historyStack) {
         case CommandId::ID_EventPaste:
         case CommandId::ID_EventDelete:
         case CommandId::ID_EventDuplicate: {
-            if (command->id() & IDMask_EventType_Object)  return m_settings.showEvents.contains(Event::Group::Object);
-            if (command->id() & IDMask_EventType_Warp)    return m_settings.showEvents.contains(Event::Group::Warp);
-            if (command->id() & IDMask_EventType_BG)      return m_settings.showEvents.contains(Event::Group::Bg);
-            if (command->id() & IDMask_EventType_Trigger) return m_settings.showEvents.contains(Event::Group::Coord);
-            if (command->id() & IDMask_EventType_Heal)    return m_settings.showEvents.contains(Event::Group::Heal);
-            return false;
+            if (!eventsEnabled())
+                return false;
+            uint32_t flags = 0;
+            if (m_settings.showEvents.contains(Event::Group::Object)) flags |= IDMask_EventType_Object;
+            if (m_settings.showEvents.contains(Event::Group::Warp))   flags |= IDMask_EventType_Warp;
+            if (m_settings.showEvents.contains(Event::Group::Bg))     flags |= IDMask_EventType_BG;
+            if (m_settings.showEvents.contains(Event::Group::Coord))  flags |= IDMask_EventType_Trigger;
+            if (m_settings.showEvents.contains(Event::Group::Heal))   flags |= IDMask_EventType_Heal;
+            return (command->id() & flags) != 0;
         }
         default:
             return false;

--- a/src/vendor/QtGifImage/gifimage/qgifimage.cpp
+++ b/src/vendor/QtGifImage/gifimage/qgifimage.cpp
@@ -357,6 +357,15 @@ QVector<QRgb> QGifImage::globalColorTable() const
 }
 
 /*!
+    Return canvas size.
+ */
+QSize QGifImage::getCanvasSize() const
+{
+    Q_D(const QGifImage);
+    return d->getCanvasSize();
+}
+
+/*!
     Return background color of the gif canvas. It only makes sense when
     global color table is not empty.
  */

--- a/src/vendor/QtGifImage/gifimage/qgifimage.h
+++ b/src/vendor/QtGifImage/gifimage/qgifimage.h
@@ -52,6 +52,8 @@ public:
     int loopCount() const;
     void setLoopCount(int loop);
 
+    QSize getCanvasSize() const;
+
     int frameCount() const;
     QImage frame(int index) const;
 


### PR DESCRIPTION
Fixes a handful of bugs and incomplete features for the export map image / stitch image / timelapse windows.

Additions/changes:
- Add a live preview of the gif when exporting a timelapse. Each mode now has a preview that accurately reflects the export.
- The amount of time it takes to create a map stitch image was reduced by 80% (removed a bunch of redundant rendering).
- Enable the dropdown to change which map to export / start the map stitch from. Add a similar dropdown for layouts.
- Render the full border, as displayed in the editor (previously, enabling the border only rendered 2 additional rows/columns)
- Allow map connections to be rendered without the border.
- Render events with the same opacity they render with on the Events tab.
- Limit the grid setting to the map area, rather than drawing the grid on the entire image.
- Add a setting to disable updates to the preview (mostly useful when working with long timelapses).

Fixes:
- Fix events being occluded by neighboring maps when rendering stitch images.
- Fix the rendered map connections coming from the map currently open in the editor, rather than the map shown in the export window.
- Fix crash when exporting a stitch image if a map fails to load.
- Fix crash when exporting a timelapse that has edit history for events after switching maps in the editor.
- Fix exported timelapses sometimes excluding map size changes.
- Fix exported timelapses excluding pasted events.
- Fix exporting a timelapse sometimes altering the state of the current map's edit history.

Note: The timelapse is still tied to the editor, there are a bunch of assumptions in `editcommands.cpp` that the map referred to by the edit history is the map currently displayed in the editor. As a workaround for now, if you change the map/layout in the editor the map/layout in the export window will update accordingly, and the map/layout selector on the timelapse window remains disabled.