### PR TITLE
Preserve custom JSON data

### DIFF
--- a/forms/projectsettingseditor.ui
+++ b/forms/projectsettingseditor.ui
@@ -39,7 +39,7 @@
              <x>0</x>
              <y>0</y>
              <width>559</width>
-             <height>568</height>
+             <height>589</height>
             </rect>
            </property>
            <layout class="QVBoxLayout" name="verticalLayout_7">
@@ -63,6 +63,16 @@
                 <widget class="QCheckBox" name="checkBox_ShowWildEncounterTables">
                  <property name="text">
                   <string>Show Wild Encounter Tables</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QCheckBox" name="checkBox_PreserveMatchingOnlyData">
+                 <property name="toolTip">
+                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If enabled, Porymap will not discard data like &amp;quot;connections_include_order&amp;quot; or &amp;quot;name_clone&amp;quot;, which serve no purpose other than recreating the original game.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                 </property>
+                 <property name="text">
+                  <string>Preserve data only needed to match the original game</string>
                  </property>
                 </widget>
                </item>
@@ -1084,7 +1094,7 @@
              <x>0</x>
              <y>0</y>
              <width>559</width>
-             <height>788</height>
+             <height>840</height>
             </rect>
            </property>
            <layout class="QVBoxLayout" name="verticalLayout_8">

--- a/include/config.h
+++ b/include/config.h
@@ -323,6 +323,7 @@ public:
         this->tilesetsHaveCallback = true;
         this->tilesetsHaveIsCompressed = true;
         this->setTransparentPixelsBlack = true;
+        this->preserveMatchingOnlyData = false;
         this->filePaths.clear();
         this->eventIconPaths.clear();
         this->pokemonIconPaths.clear();
@@ -389,6 +390,7 @@ public:
     bool tilesetsHaveCallback;
     bool tilesetsHaveIsCompressed;
     bool setTransparentPixelsBlack;
+    bool preserveMatchingOnlyData;
     int metatileAttributesSize;
     uint32_t metatileBehaviorMask;
     uint32_t metatileTerrainTypeMask;

--- a/include/core/events.h
+++ b/include/core/events.h
@@ -10,6 +10,7 @@
 #include <QPointer>
 
 #include "orderedjson.h"
+#include "parseutil.h"
 
 
 class Project;
@@ -139,15 +140,14 @@ public:
     Event::Type getEventType() const { return this->eventType; }
 
     virtual OrderedJson::object buildEventJson(Project *project) = 0;
-    virtual bool loadFromJson(const QJsonObject &json, Project *project) = 0;
+    virtual bool loadFromJson(QJsonObject json, Project *project) = 0;
 
     virtual void setDefaultValues(Project *project);
 
     virtual QSet<QString> getExpectedFields() = 0;
-    void readCustomAttributes(const QJsonObject &json);
-    void addCustomAttributesTo(OrderedJson::object *obj) const;
-    const QMap<QString, QJsonValue> getCustomAttributes() const { return this->customAttributes; }
-    void setCustomAttributes(const QMap<QString, QJsonValue> newCustomAttributes) { this->customAttributes = newCustomAttributes; }
+
+    QJsonObject getCustomAttributes() const { return this->customAttributes; }
+    void setCustomAttributes(const QJsonObject &newCustomAttributes) { this->customAttributes = newCustomAttributes; }
 
     virtual void loadPixmap(Project *project);
 
@@ -190,12 +190,16 @@ protected:
     // When deleting events like this we want to warn the user that the #define may also be deleted.
     QString idName;
 
-    QMap<QString, QJsonValue> customAttributes;
+    QJsonObject customAttributes;
 
     QPixmap pixmap;
     DraggablePixmapItem *pixmapItem = nullptr;
 
     QPointer<EventFrame> eventFrame;
+
+    static QString readString(QJsonObject *object, const QString &key) { return ParseUtil::jsonToQString(object->take(key)); }
+    static int readInt(QJsonObject *object, const QString &key) { return ParseUtil::jsonToInt(object->take(key)); }
+    static bool readBool(QJsonObject *object, const QString &key) { return ParseUtil::jsonToBool(object->take(key)); }
 };
 
 
@@ -218,7 +222,7 @@ public:
     virtual EventFrame *createEventFrame() override;
 
     virtual OrderedJson::object buildEventJson(Project *project) override;
-    virtual bool loadFromJson(const QJsonObject &json, Project *project) override;
+    virtual bool loadFromJson(QJsonObject json, Project *project) override;
 
     virtual void setDefaultValues(Project *project) override;
 
@@ -285,7 +289,7 @@ public:
     virtual EventFrame *createEventFrame() override;
 
     virtual OrderedJson::object buildEventJson(Project *project) override;
-    virtual bool loadFromJson(const QJsonObject &json, Project *project) override;
+    virtual bool loadFromJson(QJsonObject json, Project *project) override;
 
     virtual void setDefaultValues(Project *project) override;
 
@@ -323,7 +327,7 @@ public:
     virtual EventFrame *createEventFrame() override;
 
     virtual OrderedJson::object buildEventJson(Project *project) override;
-    virtual bool loadFromJson(const QJsonObject &json, Project *project) override;
+    virtual bool loadFromJson(QJsonObject json, Project *project) override;
 
     virtual void setDefaultValues(Project *project) override;
 
@@ -358,7 +362,7 @@ public:
     virtual EventFrame *createEventFrame() override = 0;
 
     virtual OrderedJson::object buildEventJson(Project *project) override = 0;
-    virtual bool loadFromJson(const QJsonObject &json, Project *project) override = 0;
+    virtual bool loadFromJson(QJsonObject json, Project *project) override = 0;
 
     virtual void setDefaultValues(Project *project) override = 0;
 
@@ -386,7 +390,7 @@ public:
     virtual EventFrame *createEventFrame() override;
 
     virtual OrderedJson::object buildEventJson(Project *project) override;
-    virtual bool loadFromJson(const QJsonObject &json, Project *project) override;
+    virtual bool loadFromJson(QJsonObject json, Project *project) override;
 
     virtual void setDefaultValues(Project *project) override;
 
@@ -426,7 +430,7 @@ public:
     virtual EventFrame *createEventFrame() override;
 
     virtual OrderedJson::object buildEventJson(Project *project) override;
-    virtual bool loadFromJson(const QJsonObject &json, Project *project) override;
+    virtual bool loadFromJson(QJsonObject json, Project *project) override;
 
     virtual void setDefaultValues(Project *project) override;
 
@@ -457,7 +461,7 @@ public:
     virtual EventFrame *createEventFrame() override = 0;
 
     virtual OrderedJson::object buildEventJson(Project *project) override = 0;
-    virtual bool loadFromJson(const QJsonObject &json, Project *project) override = 0;
+    virtual bool loadFromJson(QJsonObject json, Project *project) override = 0;
 
     virtual void setDefaultValues(Project *project) override = 0;
 
@@ -484,7 +488,7 @@ public:
     virtual EventFrame *createEventFrame() override;
 
     virtual OrderedJson::object buildEventJson(Project *project) override;
-    virtual bool loadFromJson(const QJsonObject &json, Project *project) override;
+    virtual bool loadFromJson(QJsonObject json, Project *project) override;
 
     virtual void setDefaultValues(Project *project) override;
 
@@ -519,7 +523,7 @@ public:
     virtual EventFrame *createEventFrame() override;
 
     virtual OrderedJson::object buildEventJson(Project *project) override;
-    virtual bool loadFromJson(const QJsonObject &json, Project *project) override;
+    virtual bool loadFromJson(QJsonObject json, Project *project) override;
 
     virtual void setDefaultValues(Project *project) override;
 
@@ -564,7 +568,7 @@ public:
     virtual EventFrame *createEventFrame() override;
 
     virtual OrderedJson::object buildEventJson(Project *project) override;
-    virtual bool loadFromJson(const QJsonObject &json, Project *project) override;
+    virtual bool loadFromJson(QJsonObject json, Project *project) override;
 
     virtual void setDefaultValues(Project *project) override;
 
@@ -596,11 +600,14 @@ public:
     virtual EventFrame *createEventFrame() override;
 
     virtual OrderedJson::object buildEventJson(Project *project) override;
-    virtual bool loadFromJson(const QJsonObject &, Project *) override;
+    virtual bool loadFromJson(QJsonObject json, Project *project) override;
 
     virtual void setDefaultValues(Project *project) override;
 
     virtual QSet<QString> getExpectedFields() override;
+
+    void setHostMapName(QString newHostMapName) { this->hostMapName = newHostMapName; }
+    QString getHostMapName() const;
 
     void setRespawnMapName(QString newRespawnMapName) { this->respawnMapName = newRespawnMapName; }
     QString getRespawnMapName() const { return this->respawnMapName; }
@@ -611,6 +618,7 @@ public:
 private:
     QString respawnMapName;
     QString respawnNPC;
+    QString hostMapName; // Only needed if the host map fails to load.
 };
 
 

--- a/include/core/map.h
+++ b/include/core/map.h
@@ -100,8 +100,8 @@ public:
     bool hasUnsavedChanges() const;
     void pruneEditHistory();
 
-    void setCustomAttributes(const QMap<QString, QJsonValue> &attributes) { m_customAttributes = attributes; }
-    QMap<QString, QJsonValue> customAttributes() const { return m_customAttributes; }
+    void setCustomAttributes(const QJsonObject &attributes) { m_customAttributes = attributes; }
+    QJsonObject customAttributes() const { return m_customAttributes; }
 
 private:
     QString m_name;
@@ -110,7 +110,7 @@ private:
     QString m_sharedScriptsMap = "";
 
     QStringList m_scriptsFileLabels;
-    QMap<QString, QJsonValue> m_customAttributes;
+    QJsonObject m_customAttributes;
 
     MapHeader *m_header = nullptr;
     Layout *m_layout = nullptr;

--- a/include/core/mapconnection.h
+++ b/include/core/mapconnection.h
@@ -5,6 +5,7 @@
 #include <QString>
 #include <QObject>
 #include <QMap>
+#include <QJsonObject>
 
 class Project;
 class Map;
@@ -29,6 +30,9 @@ public:
     int offset() const { return m_offset; }
     void setOffset(int offset, bool mirror = true);
 
+    QJsonObject customData() const { return m_customData; }
+    void setCustomData(const QJsonObject &customData) { m_customData = customData; }
+
     MapConnection* findMirror();
     MapConnection* createMirror();
 
@@ -49,6 +53,7 @@ private:
     QString m_targetMapName;
     QString m_direction;
     int m_offset;
+    QJsonObject m_customData;
 
     void markMapEdited();
     Map* getMap(const QString& mapName) const;

--- a/include/core/maplayout.h
+++ b/include/core/maplayout.h
@@ -42,6 +42,8 @@ public:
     Tileset *tileset_primary = nullptr;
     Tileset *tileset_secondary = nullptr;
 
+    QJsonObject customData;
+
     Blockdata blockdata;
 
     QImage image;

--- a/include/core/parseutil.h
+++ b/include/core/parseutil.h
@@ -58,7 +58,7 @@ public:
     QMap<QString, int> readCDefinesByRegex(const QString &filename, const QSet<QString> &regexList, QString *error = nullptr);
     QMap<QString, int> readCDefinesByName(const QString &filename, const QSet<QString> &names, QString *error = nullptr);
     QStringList readCDefineNames(const QString &filename, const QSet<QString> &regexList, QString *error = nullptr);
-    tsl::ordered_map<QString, QHash<QString, QString>> readCStructs(const QString &, const QString & = "", const QHash<int, QString>& = {});
+    OrderedMap<QString, QHash<QString, QString>> readCStructs(const QString &, const QString & = "", const QHash<int, QString>& = {});
     QList<QStringList> getLabelMacros(const QList<QStringList>&, const QString&);
     QStringList getLabelValues(const QList<QStringList>&, const QString&);
     bool tryParseJsonFile(QJsonDocument *out, const QString &filepath, QString *error = nullptr);

--- a/include/core/regionmap.h
+++ b/include/core/regionmap.h
@@ -56,8 +56,8 @@ public:
     bool loadLayout(poryjson::Json);
     bool loadEntries();
 
-    void setEntries(QMap<QString, MapSectionEntry> *entries) { this->region_map_entries = entries; }
-    void setEntries(const QMap<QString, MapSectionEntry> &entries) { *(this->region_map_entries) = entries; }
+    void setEntries(QHash<QString, MapSectionEntry> *entries) { this->region_map_entries = entries; }
+    void setEntries(const QHash<QString, MapSectionEntry> &entries) { *(this->region_map_entries) = entries; }
     void clearEntries() { this->region_map_entries->clear(); }
     MapSectionEntry getEntry(QString section);
     void setEntry(QString section, MapSectionEntry entry);
@@ -151,7 +151,7 @@ signals:
     void mapNeedsDisplaying();
 
 private:
-    QMap<QString, MapSectionEntry> *region_map_entries = nullptr;
+    QHash<QString, MapSectionEntry> *region_map_entries = nullptr;
 
     QString alias = "";
 

--- a/include/core/regionmapeditcommands.h
+++ b/include/core/regionmapeditcommands.h
@@ -153,7 +153,7 @@ private:
 /// ClearEntries
 class ClearEntries : public QUndoCommand {
 public:
-    ClearEntries(RegionMap *map, QMap<QString, MapSectionEntry>, QUndoCommand *parent = nullptr);
+    ClearEntries(RegionMap *map, QHash<QString, MapSectionEntry>, QUndoCommand *parent = nullptr);
 
     void undo() override;
     void redo() override;
@@ -163,7 +163,7 @@ public:
 
 private:
     RegionMap *map;
-    QMap<QString, MapSectionEntry> entries;
+    QHash<QString, MapSectionEntry> entries;
 };
 
 #endif // REGIONMAPEDITCOMMANDS_H

--- a/include/core/wildmoninfo.h
+++ b/include/core/wildmoninfo.h
@@ -3,7 +3,7 @@
 #define GUARD_WILDMONINFO_H
 
 #include <QtWidgets>
-#include "orderedmap.h"
+#include "orderedjson.h"
 
 class WildPokemon {
 public:
@@ -13,22 +13,26 @@ public:
     int minLevel;
     int maxLevel;
     QString species;
+    OrderedJson::object customData;
 };
 
 struct WildMonInfo {
     bool active = false;
     int encounterRate = 0;
     QVector<WildPokemon> wildPokemon;
+    OrderedJson::object customData;
 };
 
 struct WildPokemonHeader {
-    tsl::ordered_map<QString, WildMonInfo> wildMons;
+    OrderedMap<QString, WildMonInfo> wildMons;
+    OrderedJson::object customData;
 };
 
 struct EncounterField {
     QString name; // Ex: "fishing_mons"
     QVector<int> encounterRates;
-    tsl::ordered_map<QString, QVector<int>> groups; // Ex: "good_rod", {2, 3, 4}
+    OrderedMap<QString, QVector<int>> groups; // Ex: "good_rod", {2, 3, 4}
+    OrderedJson::object customData;
 };
 
 typedef QVector<EncounterField> EncounterFields;

--- a/include/lib/orderedjson.h
+++ b/include/lib/orderedjson.h
@@ -132,7 +132,9 @@ public:
             int>::type = 0>
     Json(const V & v) : Json(array(v.begin(), v.end())) {}
 
-    static const Json fromQJsonValue(QJsonValue value);
+    static Json fromQJsonValue(const QJsonValue &value);
+    static void append(Json::array *array, const QJsonArray &qArray);
+    static void append(Json::object *object, const QJsonObject &qObject);
 
     // This prevents Json(some_pointer) from accidentally producing a bool. Use
     // Json(bool(some_pointer)) if that behavior is desired.

--- a/include/lib/orderedjson.h
+++ b/include/lib/orderedjson.h
@@ -99,7 +99,7 @@ public:
 
     // Array and object typedefs
     typedef QVector<Json> array;
-    typedef tsl::ordered_map<QString, Json> object;
+    typedef OrderedMap<QString, Json> object;
 
     // Constructors for the various types of JSON value.
     Json() noexcept;                // NUL
@@ -133,8 +133,21 @@ public:
     Json(const V & v) : Json(array(v.begin(), v.end())) {}
 
     static Json fromQJsonValue(const QJsonValue &value);
-    static void append(Json::array *array, const QJsonArray &qArray);
-    static void append(Json::object *object, const QJsonObject &qObject);
+
+    static void append(Json::array *array, const QJsonArray &addendum) {
+        for (const auto &i : addendum) array->push_back(fromQJsonValue(i));
+    }
+    static void append(Json::array *array, const Json::array &addendum) {
+        for (const auto &i : addendum) array->push_back(i);
+    }
+    static void append(Json::object *object, const QJsonObject &addendum) {
+        for (auto it = addendum.constBegin(); it != addendum.constEnd(); it++)
+            (*object)[it.key()] = fromQJsonValue(it.value());
+    }
+    static void append(Json::object *object, const Json::object &addendum) {
+        for (auto it = addendum.cbegin(); it != addendum.cend(); it++)
+            (*object)[it.key()] = it.value();
+    }
 
     // This prevents Json(some_pointer) from accidentally producing a bool. Use
     // Json(bool(some_pointer)) if that behavior is desired.

--- a/include/lib/orderedmap.h
+++ b/include/lib/orderedmap.h
@@ -1977,6 +1977,14 @@ public:
     size_type erase(const K& key, std::size_t precalculated_hash) { 
         return m_ht.erase(key, precalculated_hash); 
     }
+
+    // Naive solution for take, should probably be replaced with one that does a single lookup and no unnecessary insertion.
+    // We want to mirror the behavior of QMap::take, which returns a default-constructed value if the key is not present.
+    T take(const key_type& key) {
+        typename ValueSelect::value_type value = m_ht[key];
+        m_ht.erase(key);
+        return value;
+    }
     
     
     
@@ -2403,5 +2411,8 @@ private:
 };
 
 } // end namespace tsl
+
+template<class Key, class T>
+using OrderedMap = tsl::ordered_map<Key, T>;
 
 #endif

--- a/include/project.h
+++ b/include/project.h
@@ -71,7 +71,6 @@ public:
     QSet<QString> modifiedFiles;
     bool usingAsmTilesets;
     QSet<QString> disabledSettingsNames;
-    QSet<QString> topLevelMapFields;
     int pokemonMinLevel;
     int pokemonMaxLevel;
     int maxEncounterRate;
@@ -161,7 +160,6 @@ public:
     bool hasUnsavedChanges();
     bool hasUnsavedDataChanges = false;
 
-    void initTopLevelMapFields();
     bool readMapJson(const QString &mapName, QJsonDocument * out);
     bool loadMapEvent(Map *map, QJsonObject json, Event::Type defaultType = Event::Type::None);
     bool loadMapData(Map*);
@@ -240,6 +238,8 @@ public:
 
     void setRegionMapEntries(const QHash<QString, MapSectionEntry> &entries);
     QHash<QString, MapSectionEntry> getRegionMapEntries() const;
+
+    QSet<QString> getTopLevelMapFields() const;
 
     static QString getEmptyMapDefineName();
     static QString getDynamicMapDefineName();

--- a/include/project.h
+++ b/include/project.h
@@ -269,6 +269,12 @@ private:
     QHash<QString, QString> speciesToIconPath;
     QHash<QString, Map*> maps;
 
+    // Fields for preserving top-level JSON data that Porymap isn't expecting.
+    QJsonObject customLayoutsData;
+    QJsonObject customMapSectionsData;
+    QJsonObject customMapGroupsData;
+    QJsonObject customHealLocationsData;
+
     // Maps/layouts represented in these sets have been fully loaded from the project.
     // If a valid map name / layout id is not in these sets, a Map / Layout object exists
     // for it in Project::maps / Project::mapLayouts, but it has been minimally populated

--- a/include/project.h
+++ b/include/project.h
@@ -263,6 +263,7 @@ public:
 
 private:
     QHash<QString, QString> mapSectionDisplayNames;
+    QHash<QString, QJsonObject> mapSectionCustomData;
     QMap<QString, qint64> modifiedFileTimestamps;
     QMap<QString, QString> facingDirections;
     QHash<QString, QString> speciesToIconPath;

--- a/include/project.h
+++ b/include/project.h
@@ -164,7 +164,7 @@ public:
 
     void initTopLevelMapFields();
     bool readMapJson(const QString &mapName, QJsonDocument * out);
-    bool loadMapEvent(Map *map, const QJsonObject &json, Event::Type defaultType = Event::Type::None);
+    bool loadMapEvent(Map *map, QJsonObject json, Event::Type defaultType = Event::Type::None);
     bool loadMapData(Map*);
     bool readMapLayouts();
     Layout *loadLayout(QString layoutId);

--- a/include/project.h
+++ b/include/project.h
@@ -62,7 +62,6 @@ public:
     QStringList mapSectionIdNames;
     QMap<uint32_t, QString> encounterTypeToName;
     QMap<uint32_t, QString> terrainTypeToName;
-    QMap<QString, MapSectionEntry> regionMapEntries;
     QMap<QString, QMap<QString, uint16_t>> metatileLabelsMap;
     QMap<QString, uint16_t> unusedMetatileLabels;
     QMap<QString, uint32_t> metatileBehaviorMap;
@@ -157,7 +156,7 @@ public:
 
     bool addNewMapsec(const QString &idName, const QString &displayName = QString());
     void removeMapsec(const QString &idName);
-    QString getMapsecDisplayName(const QString &idName) const { return this->mapSectionDisplayNames.value(idName); }
+    QString getMapsecDisplayName(const QString &idName) const { return this->locationData.value(idName).displayName; }
     void setMapsecDisplayName(const QString &idName, const QString &displayName);
 
     bool hasUnsavedChanges();
@@ -240,6 +239,9 @@ public:
     static QString getExistingFilepath(QString filepath);
     void applyParsedLimits();
 
+    void setRegionMapEntries(const QHash<QString, MapSectionEntry> &entries);
+    QHash<QString, MapSectionEntry> getRegionMapEntries() const;
+
     static QString getEmptyMapDefineName();
     static QString getDynamicMapDefineName();
     static QString getDynamicMapName();
@@ -262,8 +264,6 @@ public:
     static QString getMapGroupPrefix();
 
 private:
-    QHash<QString, QString> mapSectionDisplayNames;
-    QHash<QString, QJsonObject> mapSectionCustomData;
     QMap<QString, qint64> modifiedFileTimestamps;
     QMap<QString, QString> facingDirections;
     QHash<QString, QString> speciesToIconPath;
@@ -297,6 +297,15 @@ private:
         bool inanimate = false;
     };
     QMap<QString, EventGraphics*> eventGraphicsMap;
+
+    // The extra data that can be associated with each MAPSEC name.
+    struct LocationData
+    {
+        MapSectionEntry map;
+        QString displayName;
+        QJsonObject custom;
+    };
+    QHash<QString, LocationData> locationData;
 
     void updateLayout(Layout *);
 

--- a/include/project.h
+++ b/include/project.h
@@ -143,12 +143,11 @@ public:
     QString getNewHealLocationName(const Map* map) const;
 
     bool readWildMonData();
-    tsl::ordered_map<QString, tsl::ordered_map<QString, WildPokemonHeader>> wildMonData;
+    OrderedMap<QString, OrderedMap<QString, WildPokemonHeader>> wildMonData;
 
     QString wildMonTableName;
     QVector<EncounterField> wildMonFields;
     QVector<QString> encounterGroupLabels;
-    QVector<poryjson::Json::object> extraEncounterGroups;
 
     bool readSpeciesIconPaths();
     QString getDefaultSpeciesIconPath(const QString &species);
@@ -274,6 +273,9 @@ private:
     QJsonObject customMapSectionsData;
     QJsonObject customMapGroupsData;
     QJsonObject customHealLocationsData;
+    OrderedJson::object customWildMonData;
+    OrderedJson::object customWildMonGroupData;
+    OrderedJson::array extraEncounterGroups;
 
     // Maps/layouts represented in these sets have been fully loaded from the project.
     // If a valid map name / layout id is not in these sets, a Map / Layout object exists

--- a/include/ui/customattributestable.h
+++ b/include/ui/customattributestable.h
@@ -13,8 +13,8 @@ public:
     explicit CustomAttributesTable(QWidget *parent = nullptr);
     ~CustomAttributesTable() {};
 
-    QMap<QString, QJsonValue> getAttributes() const;
-    void setAttributes(const QMap<QString, QJsonValue> &attributes);
+    QJsonObject getAttributes() const;
+    void setAttributes(const QJsonObject &attributes);
 
     void addNewAttribute(const QString &key, const QJsonValue &value);
     bool deleteSelectedAttributes();

--- a/include/ui/regionmapeditor.h
+++ b/include/ui/regionmapeditor.h
@@ -54,7 +54,7 @@ private:
     Project *project;
 
     RegionMap *region_map = nullptr;
-    tsl::ordered_map<QString, RegionMap *> region_maps;
+    OrderedMap<QString, RegionMap *> region_maps;
 
     QString configFilepath;
 

--- a/include/ui/regionmapeditor.h
+++ b/include/ui/regionmapeditor.h
@@ -95,7 +95,7 @@ private:
     void saveConfig();
     bool loadRegionMapEntries();
     bool saveRegionMapEntries();
-    QMap<QString, MapSectionEntry> region_map_entries;
+    QHash<QString, MapSectionEntry> region_map_entries;
 
     bool buildConfigDialog();
     poryjson::Json configRegionMapDialog();

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -809,6 +809,8 @@ void ProjectConfig::parseConfigKeyValue(QString key, QString value) {
         this->tilesetsHaveIsCompressed = getConfigBool(key, value);
     } else if (key == "set_transparent_pixels_black") {
         this->setTransparentPixelsBlack = getConfigBool(key, value);
+    } else if (key == "preserve_matching_only_data") {
+        this->preserveMatchingOnlyData = getConfigBool(key, value);
     } else if (key == "event_icon_path_object") {
         this->eventIconPaths[Event::Group::Object] = value;
     } else if (key == "event_icon_path_warp") {
@@ -899,6 +901,7 @@ QMap<QString, QString> ProjectConfig::getKeyValueMap() {
     map.insert("tilesets_have_callback", QString::number(this->tilesetsHaveCallback));
     map.insert("tilesets_have_is_compressed", QString::number(this->tilesetsHaveIsCompressed));
     map.insert("set_transparent_pixels_black", QString::number(this->setTransparentPixelsBlack));
+    map.insert("preserve_matching_only_data", QString::number(this->preserveMatchingOnlyData));
     map.insert("metatile_attributes_size", QString::number(this->metatileAttributesSize));
     map.insert("metatile_behavior_mask", Util::toHexString(this->metatileBehaviorMask));
     map.insert("metatile_terrain_type_mask", Util::toHexString(this->metatileTerrainTypeMask));

--- a/src/core/maplayout.cpp
+++ b/src/core/maplayout.cpp
@@ -31,6 +31,7 @@ void Layout::copyFrom(const Layout *other) {
     this->tileset_secondary = other->tileset_secondary;
     this->blockdata = other->blockdata;
     this->border = other->border;
+    this->customData = other->customData;
 }
 
 QString Layout::layoutConstantFromName(const QString &name) {

--- a/src/core/parseutil.cpp
+++ b/src/core/parseutil.cpp
@@ -610,12 +610,12 @@ bool ParseUtil::gameStringToBool(const QString &gameString, bool * ok) {
     return gameStringToInt(gameString, ok) != 0;
 }
 
-tsl::ordered_map<QString, QHash<QString, QString>> ParseUtil::readCStructs(const QString &filename, const QString &label, const QHash<int, QString> &memberMap) {
+OrderedMap<QString, QHash<QString, QString>> ParseUtil::readCStructs(const QString &filename, const QString &label, const QHash<int, QString> &memberMap) {
     QString filePath = pathWithRoot(filename);
     auto cParser = fex::Parser();
     auto tokens = fex::Lexer().LexFile(filePath);
     auto topLevelObjects = cParser.ParseTopLevelObjects(tokens);
-    tsl::ordered_map<QString, QHash<QString, QString>> structs;
+    OrderedMap<QString, QHash<QString, QString>> structs;
     for (auto it = topLevelObjects.begin(); it != topLevelObjects.end(); it++) {
         QString structLabel = QString::fromStdString(it->first);
         if (structLabel.isEmpty()) continue;

--- a/src/core/regionmapeditcommands.cpp
+++ b/src/core/regionmapeditcommands.cpp
@@ -260,7 +260,7 @@ void ResizeTilemap::undo() {
 
 ///
 
-ClearEntries::ClearEntries(RegionMap *map, QMap<QString, MapSectionEntry> entries, QUndoCommand *parent)
+ClearEntries::ClearEntries(RegionMap *map, QHash<QString, MapSectionEntry> entries, QUndoCommand *parent)
     : QUndoCommand(parent) {
     setText("Clear Entries");
 

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -596,7 +596,7 @@ void Editor::configureEncounterJSON(QWidget *window) {
         if (newNameDialog.exec() == QDialog::Accepted) {
             QString newFieldName = newNameEdit->text();
             QVector<int> newFieldRates(1, 100);
-            tempFields.append({newFieldName, newFieldRates, {}});
+            tempFields.append({newFieldName, newFieldRates, {}, {}});
             fieldChoices->addItem(newFieldName);
             fieldChoices->setCurrentIndex(fieldChoices->count() - 1);
         }
@@ -675,7 +675,7 @@ void Editor::saveEncounterTabData() {
 
     if (!stack->count()) return;
 
-    tsl::ordered_map<QString, WildPokemonHeader> &encounterMap = project->wildMonData[map->constantName()];
+    OrderedMap<QString, WildPokemonHeader> &encounterMap = project->wildMonData[map->constantName()];
 
     for (int groupIndex = 0; groupIndex < stack->count(); groupIndex++) {
         MonTabWidget *tabWidget = static_cast<MonTabWidget *>(stack->widget(groupIndex));

--- a/src/lib/orderedjson.cpp
+++ b/src/lib/orderedjson.cpp
@@ -311,32 +311,37 @@ const Json & JsonArray::operator[] (int i) const {
     else return m_value[i];
 }
 
-const Json Json::fromQJsonValue(QJsonValue value) {
+Json Json::fromQJsonValue(const QJsonValue &value) {
     switch (value.type())
     {
     case QJsonValue::String: return value.toString();
     case QJsonValue::Double: return value.toInt();
     case QJsonValue::Bool:   return value.toBool();
-    case QJsonValue::Array:
-    {
-        QJsonArray qArr = value.toArray();
-        Json::array arr;
-        for (const auto &i: qArr)
-            arr.push_back(Json::fromQJsonValue(i));
-        return arr;
+    case QJsonValue::Array: {
+        Json::array array;
+        Json::append(&array, value.toArray());
+        return array;
     }
-    case QJsonValue::Object:
-    {
-        QJsonObject qObj = value.toObject();
-        Json::object obj;
-        for (auto it = qObj.constBegin(); it != qObj.constEnd(); it++)
-            obj[it.key()] = Json::fromQJsonValue(it.value());
-        return obj;
+    case QJsonValue::Object: {
+        Json::object object;
+        Json::append(&object, value.toObject());
+        return object;
     }
     default: return static_null();
     }
 }
 
+void Json::append(Json::array *array, const QJsonArray &qArray) {
+    for (const auto &i: qArray) {
+        array->push_back(fromQJsonValue(i));
+    }
+}
+
+void Json::append(Json::object *object, const QJsonObject &qObject) {
+    for (auto it = qObject.constBegin(); it != qObject.constEnd(); it++) {
+        (*object)[it.key()] = fromQJsonValue(it.value());
+    }
+}
 
 /* * * * * * * * * * * * * * * * * * * *
  * Comparison

--- a/src/lib/orderedjson.cpp
+++ b/src/lib/orderedjson.cpp
@@ -331,18 +331,6 @@ Json Json::fromQJsonValue(const QJsonValue &value) {
     }
 }
 
-void Json::append(Json::array *array, const QJsonArray &qArray) {
-    for (const auto &i: qArray) {
-        array->push_back(fromQJsonValue(i));
-    }
-}
-
-void Json::append(Json::object *object, const QJsonObject &qObject) {
-    for (auto it = qObject.constBegin(); it != qObject.constEnd(); it++) {
-        (*object)[it.key()] = fromQJsonValue(it.value());
-    }
-}
-
 /* * * * * * * * * * * * * * * * * * * *
  * Comparison
  */

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1192,7 +1192,7 @@ bool MainWindow::setProjectUI() {
     ui->layoutList->setModel(layoutListProxyModel);
     ui->layoutList->sortByColumn(0, Qt::SortOrder::AscendingOrder);
 
-    ui->mapCustomAttributesFrame->table()->setRestrictedKeys(project->topLevelMapFields);
+    ui->mapCustomAttributesFrame->table()->setRestrictedKeys(project->getTopLevelMapFields());
 
     return true;
 }

--- a/src/project.cpp
+++ b/src/project.cpp
@@ -177,8 +177,8 @@ Map* Project::loadMap(const QString &mapName) {
     return map;
 }
 
-void Project::initTopLevelMapFields() {
-    static const QSet<QString> defaultTopLevelMapFields = {
+QSet<QString> Project::getTopLevelMapFields() const {
+    QSet<QString> fields = {
         "id",
         "name",
         "layout",
@@ -197,15 +197,15 @@ void Project::initTopLevelMapFields() {
         "shared_events_map",
         "shared_scripts_map",
     };
-    this->topLevelMapFields = defaultTopLevelMapFields;
     if (projectConfig.mapAllowFlagsEnabled) {
-        this->topLevelMapFields.insert("allow_cycling");
-        this->topLevelMapFields.insert("allow_escaping");
-        this->topLevelMapFields.insert("allow_running");
+        fields.insert("allow_cycling");
+        fields.insert("allow_escaping");
+        fields.insert("allow_running");
     }
     if (projectConfig.floorNumberEnabled) {
-        this->topLevelMapFields.insert("floor_number");
+        fields.insert("floor_number");
     }
+    return fields;
 }
 
 bool Project::readMapJson(const QString &mapName, QJsonDocument * out) {
@@ -1793,8 +1793,6 @@ bool Project::readMapGroups() {
     this->groupNames.clear();
     this->groupNameToMapNames.clear();
     this->customMapGroupsData = QJsonObject();
-
-    this->initTopLevelMapFields();
 
     const QString filepath = projectConfig.getFilePath(ProjectFilePath::json_map_groups);
     fileWatcher.addPath(root + "/" + filepath);

--- a/src/project.cpp
+++ b/src/project.cpp
@@ -1925,10 +1925,12 @@ bool Project::readMapGroups() {
     this->mapConstantsToMapNames.insert(dynamicMapConstant, dynamicMapName);
     this->mapNames.append(dynamicMapName);
 
-    // Save custom JSON data.
     // Chuck the "connections_include_order" field, this is only for matching.
-    // TODO: Setting not to do this, on the off chance someone wants this field.
-    mapGroupsObj.remove("connections_include_order");
+    if (!projectConfig.preserveMatchingOnlyData) {
+        mapGroupsObj.remove("connections_include_order");
+    }
+
+    // Preserve any remaining fields for when we save.
     this->customMapGroupsData = mapGroupsObj;
 
     return true;
@@ -2429,8 +2431,9 @@ bool Project::readRegionMapSections() {
         }
 
         // Chuck the "name_clone" field, this is only for matching.
-        // TODO: Setting not to do this, on the off chance someone wants this field.
-        mapSectionObj.remove("name_clone");
+        if (!projectConfig.preserveMatchingOnlyData) {
+            mapSectionObj.remove("name_clone");
+        }
 
         // Preserve any remaining fields for when we save.
         location.custom = mapSectionObj;

--- a/src/project.cpp
+++ b/src/project.cpp
@@ -1804,7 +1804,7 @@ bool Project::readMapGroups() {
     }
 
     QJsonObject mapGroupsObj = mapGroupsDoc.object();
-    QJsonArray mapGroupOrder = mapGroupsObj["group_order"].toArray();
+    QJsonArray mapGroupOrder = mapGroupsObj.take("group_order").toArray();
 
     const QString dynamicMapName = getDynamicMapName();
     const QString dynamicMapConstant = getDynamicMapDefineName();

--- a/src/ui/customattributestable.cpp
+++ b/src/ui/customattributestable.cpp
@@ -39,8 +39,8 @@ CustomAttributesTable::CustomAttributesTable(QWidget *parent) :
     });
 }
 
-QMap<QString, QJsonValue> CustomAttributesTable::getAttributes() const {
-    QMap<QString, QJsonValue> fields;
+QJsonObject CustomAttributesTable::getAttributes() const {
+    QJsonObject fields;
     for (int row = 0; row < this->rowCount(); row++) {
         auto keyValuePair = this->getAttribute(row);
         if (!keyValuePair.first.isEmpty())
@@ -145,10 +145,10 @@ void CustomAttributesTable::addNewAttribute(const QString &key, const QJsonValue
 }
 
 // For programmatically populating the table
-void CustomAttributesTable::setAttributes(const QMap<QString, QJsonValue> &attributes) {
+void CustomAttributesTable::setAttributes(const QJsonObject &attributes) {
     m_keys.clear();
     this->setRowCount(0); // Clear old values
-    for (auto it = attributes.cbegin(); it != attributes.cend(); it++)
+    for (auto it = attributes.constBegin(); it != attributes.constEnd(); it++)
         this->addAttribute(it.key(), it.value());
     this->resizeVertically();
 }

--- a/src/ui/projectsettingseditor.cpp
+++ b/src/ui/projectsettingseditor.cpp
@@ -443,6 +443,7 @@ void ProjectSettingsEditor::refresh() {
     ui->checkBox_OutputCallback->setChecked(projectConfig.tilesetsHaveCallback);
     ui->checkBox_OutputIsCompressed->setChecked(projectConfig.tilesetsHaveIsCompressed);
     ui->checkBox_DisableWarning->setChecked(porymapConfig.warpBehaviorWarningDisabled);
+    ui->checkBox_PreserveMatchingOnlyData->setChecked(projectConfig.preserveMatchingOnlyData);
 
     // Radio buttons
     if (projectConfig.setTransparentPixelsBlack)
@@ -524,6 +525,7 @@ void ProjectSettingsEditor::save() {
     projectConfig.tilesetsHaveIsCompressed = ui->checkBox_OutputIsCompressed->isChecked();
     porymapConfig.warpBehaviorWarningDisabled = ui->checkBox_DisableWarning->isChecked();
     projectConfig.setTransparentPixelsBlack = ui->radioButton_RenderBlack->isChecked();
+    projectConfig.preserveMatchingOnlyData = ui->checkBox_PreserveMatchingOnlyData->isChecked();
 
     // Save spin box settings
     projectConfig.defaultElevation = ui->spinBox_Elevation->value();

--- a/src/ui/regionmapeditor.cpp
+++ b/src/ui/regionmapeditor.cpp
@@ -108,12 +108,12 @@ void RegionMapEditor::applyUserShortcuts() {
 }
 
 bool RegionMapEditor::loadRegionMapEntries() {
-    this->region_map_entries = this->project->regionMapEntries;
+    this->region_map_entries = this->project->getRegionMapEntries();
     return true;
 }
 
 bool RegionMapEditor::saveRegionMapEntries() {
-    this->project->regionMapEntries = this->region_map_entries;
+    this->project->setRegionMapEntries(this->region_map_entries);
     this->project->saveRegionMapSections();
     return true;
 }


### PR DESCRIPTION
Porymap no longer discards unrecognized fields in any of the project JSON files it writes. It will now consume JSON object keys while they're being read, and whatever is left in the object after reading will be stored for writing later. This is to avoid needing a bunch of explicit lists of keys Porymap expects. Maps and events still have key lists like this, but now Porymap only uses them to restrict what keys are allowed in the `Custom Attributes` tables.

`connections_include_order` and `name_clone`, which are keys with data only needed for matching the original games, used to be discarded because of this behavior. Now they are explicitly discarded, and there's a new setting to stop discarding them if a user wants them for whatever reason.

Should be complete, but opening as a draft for now while I do some more testing.

Closes #461 