### PR TITLE
Fix deprecated code as of Qt 6.9

### DIFF
--- a/include/core/utility.h
+++ b/include/core/utility.h
@@ -9,6 +9,13 @@ namespace Util {
     int roundUp(int numToRound, int multiple);
     QString toDefineCase(QString input);
     QString toHexString(uint32_t value, int minLength = 0);
+    Qt::Orientations getOrientation(bool xflip, bool yflip);
 }
+
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 7, 0))
+    typedef Qt::CheckState CheckState;
+#else
+    typedef int CheckState;
+#endif
 
 #endif // UTILITY_H

--- a/include/core/utility.h
+++ b/include/core/utility.h
@@ -12,10 +12,4 @@ namespace Util {
     Qt::Orientations getOrientation(bool xflip, bool yflip);
 }
 
-#if (QT_VERSION >= QT_VERSION_CHECK(6, 7, 0))
-    typedef Qt::CheckState CheckState;
-#else
-    typedef int CheckState;
-#endif
-
 #endif // UTILITY_H

--- a/include/mainwindow.h
+++ b/include/mainwindow.h
@@ -435,9 +435,9 @@ private:
     void checkForUpdates(bool requestedByUser);
     void setDivingMapsVisible(bool visible);
 
-    void setSmartPathsEnabled(CheckState state);
-    void setBorderVisibility(CheckState state);
-    void setMirrorConnectionsEnabled(CheckState state);
+    void setSmartPathsEnabled(bool enabled);
+    void setBorderVisibility(bool visible);
+    void setMirrorConnectionsEnabled(bool enabled);
 };
 
 // These are namespaced in a struct to avoid colliding with e.g. class Map.

--- a/include/mainwindow.h
+++ b/include/mainwindow.h
@@ -248,8 +248,6 @@ private slots:
     void on_comboBox_PrimaryTileset_currentTextChanged(const QString &arg1);
     void on_comboBox_SecondaryTileset_currentTextChanged(const QString &arg1);
     void on_pushButton_ChangeDimensions_clicked();
-    void on_checkBox_smartPaths_stateChanged(int selected);
-    void on_checkBox_ToggleBorder_stateChanged(int selected);
 
     void resetMapViewScale();
 
@@ -260,7 +258,6 @@ private slots:
 
     void eventTabChanged(int index);
 
-    void on_checkBox_MirrorConnections_stateChanged(int selected);
     void on_actionDive_Emerge_Map_triggered();
     void on_actionShow_Events_In_Map_View_triggered();
     void on_groupBox_DiveMapOpacity_toggled(bool on);
@@ -437,6 +434,10 @@ private:
 
     void checkForUpdates(bool requestedByUser);
     void setDivingMapsVisible(bool visible);
+
+    void setSmartPathsEnabled(CheckState state);
+    void setBorderVisibility(CheckState state);
+    void setMirrorConnectionsEnabled(CheckState state);
 };
 
 // These are namespaced in a struct to avoid colliding with e.g. class Map.

--- a/include/ui/mapheaderform.h
+++ b/include/ui/mapheaderform.h
@@ -73,11 +73,11 @@ private:
     void onWeatherChanged(const QString &weather);
     void onTypeChanged(const QString &type);
     void onBattleSceneChanged(const QString &battleScene);
-    void onRequiresFlashChanged(CheckState selected);
-    void onShowLocationNameChanged(CheckState selected);
-    void onAllowRunningChanged(CheckState selected);
-    void onAllowBikingChanged(CheckState selected);
-    void onAllowEscapingChanged(CheckState selected);
+    void onRequiresFlashChanged(bool enabled);
+    void onShowLocationNameChanged(bool enabled);
+    void onAllowRunningChanged(bool enabled);
+    void onAllowBikingChanged(bool enabled);
+    void onAllowEscapingChanged(bool enabled);
     void onFloorNumberChanged(int offset);
 };
 

--- a/include/ui/mapheaderform.h
+++ b/include/ui/mapheaderform.h
@@ -73,11 +73,11 @@ private:
     void onWeatherChanged(const QString &weather);
     void onTypeChanged(const QString &type);
     void onBattleSceneChanged(const QString &battleScene);
-    void onRequiresFlashChanged(int selected);
-    void onShowLocationNameChanged(int selected);
-    void onAllowRunningChanged(int selected);
-    void onAllowBikingChanged(int selected);
-    void onAllowEscapingChanged(int selected);
+    void onRequiresFlashChanged(CheckState selected);
+    void onShowLocationNameChanged(CheckState selected);
+    void onAllowRunningChanged(CheckState selected);
+    void onAllowBikingChanged(CheckState selected);
+    void onAllowEscapingChanged(CheckState selected);
     void onFloorNumberChanged(int offset);
 };
 

--- a/include/ui/mapimageexporter.h
+++ b/include/ui/mapimageexporter.h
@@ -91,30 +91,27 @@ protected:
     virtual void showEvent(QShowEvent *) override;
     virtual void resizeEvent(QResizeEvent *) override;
 
-private slots:
-    void on_checkBox_Objects_stateChanged(int state);
-    void on_checkBox_Warps_stateChanged(int state);
-    void on_checkBox_BGs_stateChanged(int state);
-    void on_checkBox_Triggers_stateChanged(int state);
-    void on_checkBox_HealLocations_stateChanged(int state);
-    void on_checkBox_AllEvents_stateChanged(int state);
-
-    void on_checkBox_ConnectionUp_stateChanged(int state);
-    void on_checkBox_ConnectionDown_stateChanged(int state);
-    void on_checkBox_ConnectionLeft_stateChanged(int state);
-    void on_checkBox_ConnectionRight_stateChanged(int state);
-    void on_checkBox_AllConnections_stateChanged(int state);
-
-    void on_checkBox_Collision_stateChanged(int state);
-    void on_checkBox_Grid_stateChanged(int state);
-    void on_checkBox_Border_stateChanged(int state);
+private:
+    void setShowGrid(CheckState state);
+    void setShowBorder(CheckState state);
+    void setShowObjects(CheckState state);
+    void setShowWarps(CheckState state);
+    void setShowBgs(CheckState state);
+    void setShowTriggers(CheckState state);
+    void setShowHealLocations(CheckState state);
+    void setShowAllEvents(CheckState state);
+    void setShowConnectionUp(CheckState state);
+    void setShowConnectionDown(CheckState state);
+    void setShowConnectionLeft(CheckState state);
+    void setShowConnectionRight(CheckState state);
+    void setShowAllConnections(CheckState state);
+    void setShowCollision(CheckState state);
+    void setDisablePreviewScaling(CheckState state);
+    void setDisablePreviewUpdates(CheckState state);
 
     void on_pushButton_Reset_pressed();
     void on_spinBox_TimelapseDelay_editingFinished();
     void on_spinBox_FrameSkip_editingFinished();
-
-    void on_checkBox_DisablePreviewScaling_stateChanged(int state);
-    void on_checkBox_DisablePreviewUpdates_stateChanged(int state);
 };
 
 #endif // MAPIMAGEEXPORTER_H

--- a/include/ui/mapimageexporter.h
+++ b/include/ui/mapimageexporter.h
@@ -92,22 +92,22 @@ protected:
     virtual void resizeEvent(QResizeEvent *) override;
 
 private:
-    void setShowGrid(CheckState state);
-    void setShowBorder(CheckState state);
-    void setShowObjects(CheckState state);
-    void setShowWarps(CheckState state);
-    void setShowBgs(CheckState state);
-    void setShowTriggers(CheckState state);
-    void setShowHealLocations(CheckState state);
-    void setShowAllEvents(CheckState state);
-    void setShowConnectionUp(CheckState state);
-    void setShowConnectionDown(CheckState state);
-    void setShowConnectionLeft(CheckState state);
-    void setShowConnectionRight(CheckState state);
-    void setShowAllConnections(CheckState state);
-    void setShowCollision(CheckState state);
-    void setDisablePreviewScaling(CheckState state);
-    void setDisablePreviewUpdates(CheckState state);
+    void setShowGrid(bool checked);
+    void setShowBorder(bool checked);
+    void setShowObjects(bool checked);
+    void setShowWarps(bool checked);
+    void setShowBgs(bool checked);
+    void setShowTriggers(bool checked);
+    void setShowHealLocations(bool checked);
+    void setShowAllEvents(bool checked);
+    void setShowConnectionUp(bool checked);
+    void setShowConnectionDown(bool checked);
+    void setShowConnectionLeft(bool checked);
+    void setShowConnectionRight(bool checked);
+    void setShowAllConnections(bool checked);
+    void setShowCollision(bool checked);
+    void setDisablePreviewScaling(bool checked);
+    void setDisablePreviewUpdates(bool checked);
 
     void on_pushButton_Reset_pressed();
     void on_spinBox_TimelapseDelay_editingFinished();

--- a/include/ui/regionmapeditor.h
+++ b/include/ui/regionmapeditor.h
@@ -121,6 +121,9 @@ private:
     void restoreWindowState();
     void closeEvent(QCloseEvent* event);
 
+    void setTileHFlip(CheckState);
+    void setTileVFlip(CheckState);
+
 private slots:
     void on_action_RegionMap_Save_triggered();
     void on_actionSave_All_triggered();
@@ -145,8 +148,6 @@ private slots:
     void on_spinBox_RM_LayoutWidth_valueChanged(int);
     void on_spinBox_RM_LayoutHeight_valueChanged(int);
     void on_spinBox_tilePalette_valueChanged(int);
-    void on_checkBox_tileHFlip_stateChanged(int);
-    void on_checkBox_tileVFlip_stateChanged(int);
     void on_verticalSlider_Zoom_Map_Image_valueChanged(int);
     void on_verticalSlider_Zoom_Image_Tiles_valueChanged(int);
     void onHoveredRegionMapTileChanged(int x, int y);

--- a/include/ui/regionmapeditor.h
+++ b/include/ui/regionmapeditor.h
@@ -121,8 +121,8 @@ private:
     void restoreWindowState();
     void closeEvent(QCloseEvent* event);
 
-    void setTileHFlip(CheckState);
-    void setTileVFlip(CheckState);
+    void setTileHFlip(bool enabled);
+    void setTileVFlip(bool enabled);
 
 private slots:
     void on_action_RegionMap_Save_triggered();

--- a/include/ui/shortcut.h
+++ b/include/ui/shortcut.h
@@ -49,9 +49,6 @@ public:
     void setAutoRepeat(bool on);
     bool autoRepeat() const;
 
-    int id() const;
-    QList<int> ids() const;
-
     inline QWidget *parentWidget() const
     { return static_cast<QWidget *>(QObject::parent()); }
 

--- a/include/ui/tileseteditor.h
+++ b/include/ui/tileseteditor.h
@@ -145,8 +145,8 @@ private:
     void commitTerrainType();
     void commitLayerType();
     void setRawAttributesVisible(bool visible);
-    void setXFlip(CheckState state);
-    void setYFlip(CheckState state);
+    void setXFlip(bool enabled);
+    void setYFlip(bool enabled);
 
     Ui::TilesetEditor *ui;
     History<MetatileHistoryItem*> metatileHistory;

--- a/include/ui/tileseteditor.h
+++ b/include/ui/tileseteditor.h
@@ -71,10 +71,6 @@ private slots:
 
     void on_spinBox_paletteSelector_valueChanged(int arg1);
 
-    void on_checkBox_xFlip_stateChanged(int arg1);
-
-    void on_checkBox_yFlip_stateChanged(int arg1);
-
     void on_actionSave_Tileset_triggered();
 
     void on_actionImport_Primary_Tiles_triggered();
@@ -149,6 +145,8 @@ private:
     void commitTerrainType();
     void commitLayerType();
     void setRawAttributesVisible(bool visible);
+    void setXFlip(CheckState state);
+    void setYFlip(CheckState state);
 
     Ui::TilesetEditor *ui;
     History<MetatileHistoryItem*> metatileHistory;

--- a/src/core/utility.cpp
+++ b/src/core/utility.cpp
@@ -42,3 +42,10 @@ QString Util::toDefineCase(QString input) {
 QString Util::toHexString(uint32_t value, int minLength) {
     return "0x" + QString("%1").arg(value, minLength, 16, QChar('0')).toUpper();
 }
+
+Qt::Orientations Util::getOrientation(bool xflip, bool yflip) {
+    Qt::Orientations flags;
+    if (xflip) flags |= Qt::Orientation::Horizontal;
+    if (yflip) flags |= Qt::Orientation::Vertical;
+    return flags;
+}

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -296,12 +296,8 @@ void Editor::addNewWildMonGroup(QWidget *window) {
         form.addRow(new QLabel(monField.name), fieldCheckbox);
     }
     // Reading from ui here so not saving to disk before user.
-#if (QT_VERSION >= QT_VERSION_CHECK(6, 7, 0))
-    connect(copyCheckbox, &QCheckBox::checkStateChanged, [=](Qt::CheckState state){
-#else
-    connect(copyCheckbox, &QCheckBox::stateChanged, [=](int state){
-#endif
-        if (state == Qt::Checked) {
+    connect(copyCheckbox, &QCheckBox::toggled, [=](bool checked){
+        if (checked) {
             int fieldIndex = 0;
             MonTabWidget *monWidget = static_cast<MonTabWidget *>(stack->widget(stack->currentIndex()));
             for (EncounterField monField : project->wildMonFields) {
@@ -309,7 +305,7 @@ void Editor::addNewWildMonGroup(QWidget *window) {
                 fieldCheckboxes[fieldIndex]->setEnabled(false);
                 fieldIndex++;
             }
-        } else if (state == Qt::Unchecked) {
+        } else {
             int fieldIndex = 0;
             for (EncounterField monField : project->wildMonFields) {
                 fieldCheckboxes[fieldIndex]->setEnabled(true);

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -296,7 +296,11 @@ void Editor::addNewWildMonGroup(QWidget *window) {
         form.addRow(new QLabel(monField.name), fieldCheckbox);
     }
     // Reading from ui here so not saving to disk before user.
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 7, 0))
+    connect(copyCheckbox, &QCheckBox::checkStateChanged, [=](Qt::CheckState state){
+#else
     connect(copyCheckbox, &QCheckBox::stateChanged, [=](int state){
+#endif
         if (state == Qt::Checked) {
             int fieldIndex = 0;
             MonTabWidget *monWidget = static_cast<MonTabWidget *>(stack->widget(stack->currentIndex()));

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -299,16 +299,9 @@ void MainWindow::initExtraSignals() {
     connect(ui->action_NewLayout, &QAction::triggered, this, &MainWindow::openNewLayoutDialog);
     connect(ui->actionDuplicate_Current_Map_Layout, &QAction::triggered, this, &MainWindow::openDuplicateMapOrLayoutDialog);
     connect(ui->comboBox_LayoutSelector->lineEdit(), &QLineEdit::editingFinished, this, &MainWindow::onLayoutSelectorEditingFinished);
-
-#if (QT_VERSION >= QT_VERSION_CHECK(6, 7, 0))
-    connect(ui->checkBox_smartPaths,        &QCheckBox::checkStateChanged, this, &MainWindow::setSmartPathsEnabled);
-    connect(ui->checkBox_ToggleBorder,      &QCheckBox::checkStateChanged, this, &MainWindow::setBorderVisibility);
-    connect(ui->checkBox_MirrorConnections, &QCheckBox::checkStateChanged, this, &MainWindow::setMirrorConnectionsEnabled);
-#else
-    connect(ui->checkBox_smartPaths,        &QCheckBox::stateChanged, this, &MainWindow::setSmartPathsEnabled);
-    connect(ui->checkBox_ToggleBorder,      &QCheckBox::stateChanged, this, &MainWindow::setBorderVisibility);
-    connect(ui->checkBox_MirrorConnections, &QCheckBox::stateChanged, this, &MainWindow::setMirrorConnectionsEnabled);
-#endif
+    connect(ui->checkBox_smartPaths, &QCheckBox::toggled, this, &MainWindow::setSmartPathsEnabled);
+    connect(ui->checkBox_ToggleBorder, &QCheckBox::toggled, this, &MainWindow::setBorderVisibility);
+    connect(ui->checkBox_MirrorConnections, &QCheckBox::toggled, this, &MainWindow::setMirrorConnectionsEnabled);
 }
 
 void MainWindow::on_actionCheck_for_Updates_triggered() {
@@ -2721,21 +2714,20 @@ void MainWindow::on_pushButton_ChangeDimensions_clicked() {
     }
 }
 
-void MainWindow::setSmartPathsEnabled(CheckState state)
+void MainWindow::setSmartPathsEnabled(bool enabled)
 {
-    bool enabled = (state == Qt::Checked);
     this->editor->settings->smartPathsEnabled = enabled;
     this->editor->cursorMapTileRect->setSmartPathMode(enabled);
 }
 
-void MainWindow::setBorderVisibility(CheckState state)
+void MainWindow::setBorderVisibility(bool visible)
 {
-    editor->toggleBorderVisibility(state == Qt::Checked);
+    editor->toggleBorderVisibility(visible);
 }
 
-void MainWindow::setMirrorConnectionsEnabled(CheckState state)
+void MainWindow::setMirrorConnectionsEnabled(bool enabled)
 {
-    porymapConfig.mirrorConnectingMaps = (state == Qt::Checked);
+    porymapConfig.mirrorConnectingMaps = enabled;
 }
 
 void MainWindow::on_actionTileset_Editor_triggered()

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -299,6 +299,16 @@ void MainWindow::initExtraSignals() {
     connect(ui->action_NewLayout, &QAction::triggered, this, &MainWindow::openNewLayoutDialog);
     connect(ui->actionDuplicate_Current_Map_Layout, &QAction::triggered, this, &MainWindow::openDuplicateMapOrLayoutDialog);
     connect(ui->comboBox_LayoutSelector->lineEdit(), &QLineEdit::editingFinished, this, &MainWindow::onLayoutSelectorEditingFinished);
+
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 7, 0))
+    connect(ui->checkBox_smartPaths,        &QCheckBox::checkStateChanged, this, &MainWindow::setSmartPathsEnabled);
+    connect(ui->checkBox_ToggleBorder,      &QCheckBox::checkStateChanged, this, &MainWindow::setBorderVisibility);
+    connect(ui->checkBox_MirrorConnections, &QCheckBox::checkStateChanged, this, &MainWindow::setMirrorConnectionsEnabled);
+#else
+    connect(ui->checkBox_smartPaths,        &QCheckBox::stateChanged, this, &MainWindow::setSmartPathsEnabled);
+    connect(ui->checkBox_ToggleBorder,      &QCheckBox::stateChanged, this, &MainWindow::setBorderVisibility);
+    connect(ui->checkBox_MirrorConnections, &QCheckBox::stateChanged, this, &MainWindow::setMirrorConnectionsEnabled);
+#endif
 }
 
 void MainWindow::on_actionCheck_for_Updates_triggered() {
@@ -2711,25 +2721,21 @@ void MainWindow::on_pushButton_ChangeDimensions_clicked() {
     }
 }
 
-void MainWindow::on_checkBox_smartPaths_stateChanged(int selected)
+void MainWindow::setSmartPathsEnabled(CheckState state)
 {
-    bool enabled = selected == Qt::Checked;
-    editor->settings->smartPathsEnabled = enabled;
-    if (enabled) {
-        editor->cursorMapTileRect->setSmartPathMode(true);
-    } else {
-        editor->cursorMapTileRect->setSmartPathMode(false);
-    }
+    bool enabled = (state == Qt::Checked);
+    this->editor->settings->smartPathsEnabled = enabled;
+    this->editor->cursorMapTileRect->setSmartPathMode(enabled);
 }
 
-void MainWindow::on_checkBox_ToggleBorder_stateChanged(int selected)
+void MainWindow::setBorderVisibility(CheckState state)
 {
-    editor->toggleBorderVisibility(selected != 0);
+    editor->toggleBorderVisibility(state == Qt::Checked);
 }
 
-void MainWindow::on_checkBox_MirrorConnections_stateChanged(int selected)
+void MainWindow::setMirrorConnectionsEnabled(CheckState state)
 {
-    porymapConfig.mirrorConnectingMaps = (selected == Qt::Checked);
+    porymapConfig.mirrorConnectingMaps = (state == Qt::Checked);
 }
 
 void MainWindow::on_actionTileset_Editor_triggered()

--- a/src/scriptapi/apioverlay.cpp
+++ b/src/scriptapi/apioverlay.cpp
@@ -276,7 +276,12 @@ void MapView::addTileImage(int x, int y, int tileId, bool xflip, bool yflip, int
                                         this->editor->layout->tileset_primary,
                                         this->editor->layout->tileset_secondary,
                                         paletteId)
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 9, 0))
+                                        .flipped(Util::getOrientation(xflip, yflip));
+#else
                                         .mirrored(xflip, yflip);
+#endif
+
     if (setTransparency)
         image.setColor(0, qRgba(0, 0, 0, 0));
     if (this->getOverlay(layer)->addImage(x, y, image))

--- a/src/ui/customscriptseditor.cpp
+++ b/src/ui/customscriptseditor.cpp
@@ -105,7 +105,11 @@ void CustomScriptsEditor::displayScript(const QString &filepath, bool enabled) {
     connect(widget->ui->b_Choose, &QAbstractButton::clicked, [this, item](bool) { this->replaceScript(item); });
     connect(widget->ui->b_Edit,   &QAbstractButton::clicked, [this, item](bool) { this->openScript(item); });
     connect(widget->ui->b_Delete, &QAbstractButton::clicked, [this, item](bool) { this->removeScript(item); });
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 7, 0))
+    connect(widget->ui->checkBox_Enable, &QCheckBox::checkStateChanged, this, &CustomScriptsEditor::markEdited);
+#else
     connect(widget->ui->checkBox_Enable, &QCheckBox::stateChanged, this, &CustomScriptsEditor::markEdited);
+#endif
     connect(widget->ui->lineEdit_filepath, &QLineEdit::textEdited, this, &CustomScriptsEditor::markEdited);
 
     // Per the Qt manual, for performance reasons QListWidget::setItemWidget shouldn't be used with non-static items.

--- a/src/ui/customscriptseditor.cpp
+++ b/src/ui/customscriptseditor.cpp
@@ -105,11 +105,7 @@ void CustomScriptsEditor::displayScript(const QString &filepath, bool enabled) {
     connect(widget->ui->b_Choose, &QAbstractButton::clicked, [this, item](bool) { this->replaceScript(item); });
     connect(widget->ui->b_Edit,   &QAbstractButton::clicked, [this, item](bool) { this->openScript(item); });
     connect(widget->ui->b_Delete, &QAbstractButton::clicked, [this, item](bool) { this->removeScript(item); });
-#if (QT_VERSION >= QT_VERSION_CHECK(6, 7, 0))
-    connect(widget->ui->checkBox_Enable, &QCheckBox::checkStateChanged, this, &CustomScriptsEditor::markEdited);
-#else
-    connect(widget->ui->checkBox_Enable, &QCheckBox::stateChanged, this, &CustomScriptsEditor::markEdited);
-#endif
+    connect(widget->ui->checkBox_Enable, &QCheckBox::toggled, this, &CustomScriptsEditor::markEdited);
     connect(widget->ui->lineEdit_filepath, &QLineEdit::textEdited, this, &CustomScriptsEditor::markEdited);
 
     // Per the Qt manual, for performance reasons QListWidget::setItemWidget shouldn't be used with non-static items.

--- a/src/ui/eventframes.cpp
+++ b/src/ui/eventframes.cpp
@@ -853,7 +853,11 @@ void HiddenItemFrame::connectSignals(MainWindow *window) {
 
     // underfoot
     this->check_itemfinder->disconnect();
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 7, 0))
+    connect(this->check_itemfinder, &QCheckBox::checkStateChanged, [=](Qt::CheckState state) {
+#else
     connect(this->check_itemfinder, &QCheckBox::stateChanged, [=](int state) {
+#endif
         this->hiddenItem->setUnderfoot(state == Qt::Checked);
         this->hiddenItem->modify();
     });

--- a/src/ui/eventframes.cpp
+++ b/src/ui/eventframes.cpp
@@ -853,12 +853,8 @@ void HiddenItemFrame::connectSignals(MainWindow *window) {
 
     // underfoot
     this->check_itemfinder->disconnect();
-#if (QT_VERSION >= QT_VERSION_CHECK(6, 7, 0))
-    connect(this->check_itemfinder, &QCheckBox::checkStateChanged, [=](Qt::CheckState state) {
-#else
-    connect(this->check_itemfinder, &QCheckBox::stateChanged, [=](int state) {
-#endif
-        this->hiddenItem->setUnderfoot(state == Qt::Checked);
+    connect(this->check_itemfinder, &QCheckBox::toggled, [=](bool checked) {
+        this->hiddenItem->setUnderfoot(checked);
         this->hiddenItem->modify();
     });
 }

--- a/src/ui/imageproviders.cpp
+++ b/src/ui/imageproviders.cpp
@@ -127,7 +127,12 @@ QImage getMetatileImage(
         color.setAlpha(0);
         tile_image.setColor(0, color.rgba());
 
-        metatile_painter.drawImage(origin, tile_image.mirrored(tile.xflip, tile.yflip));
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 9, 0))
+        tile_image.flip(Util::getOrientation(tile.xflip, tile.yflip));
+#else
+        tile_image = tile_image.mirrored(tile.xflip, tile.yflip);
+#endif
+        metatile_painter.drawImage(origin, tile_image);
     }
     metatile_painter.end();
 

--- a/src/ui/mapheaderform.cpp
+++ b/src/ui/mapheaderform.cpp
@@ -20,20 +20,11 @@ MapHeaderForm::MapHeaderForm(QWidget *parent)
     connect(ui->comboBox_Weather,     &QComboBox::currentTextChanged, this, &MapHeaderForm::onWeatherChanged);
     connect(ui->comboBox_Type,        &QComboBox::currentTextChanged, this, &MapHeaderForm::onTypeChanged);
     connect(ui->comboBox_BattleScene, &QComboBox::currentTextChanged, this, &MapHeaderForm::onBattleSceneChanged);
-
-#if (QT_VERSION >= QT_VERSION_CHECK(6, 7, 0))
-    connect(ui->checkBox_RequiresFlash,    &QCheckBox::checkStateChanged, this, &MapHeaderForm::onRequiresFlashChanged);
-    connect(ui->checkBox_ShowLocationName, &QCheckBox::checkStateChanged, this, &MapHeaderForm::onShowLocationNameChanged);
-    connect(ui->checkBox_AllowRunning,     &QCheckBox::checkStateChanged, this, &MapHeaderForm::onAllowRunningChanged);
-    connect(ui->checkBox_AllowBiking,      &QCheckBox::checkStateChanged, this, &MapHeaderForm::onAllowBikingChanged);
-    connect(ui->checkBox_AllowEscaping,    &QCheckBox::checkStateChanged, this, &MapHeaderForm::onAllowEscapingChanged);
-#else
-    connect(ui->checkBox_RequiresFlash,    &QCheckBox::stateChanged, this, &MapHeaderForm::onRequiresFlashChanged);
-    connect(ui->checkBox_ShowLocationName, &QCheckBox::stateChanged, this, &MapHeaderForm::onShowLocationNameChanged);
-    connect(ui->checkBox_AllowRunning,     &QCheckBox::stateChanged, this, &MapHeaderForm::onAllowRunningChanged);
-    connect(ui->checkBox_AllowBiking,      &QCheckBox::stateChanged, this, &MapHeaderForm::onAllowBikingChanged);
-    connect(ui->checkBox_AllowEscaping,    &QCheckBox::stateChanged, this, &MapHeaderForm::onAllowEscapingChanged);
-#endif
+    connect(ui->checkBox_RequiresFlash,    &QCheckBox::toggled, this, &MapHeaderForm::onRequiresFlashChanged);
+    connect(ui->checkBox_ShowLocationName, &QCheckBox::toggled, this, &MapHeaderForm::onShowLocationNameChanged);
+    connect(ui->checkBox_AllowRunning,     &QCheckBox::toggled, this, &MapHeaderForm::onAllowRunningChanged);
+    connect(ui->checkBox_AllowBiking,      &QCheckBox::toggled, this, &MapHeaderForm::onAllowBikingChanged);
+    connect(ui->checkBox_AllowEscaping,    &QCheckBox::toggled, this, &MapHeaderForm::onAllowEscapingChanged);
 
     connect(ui->spinBox_FloorNumber, QOverload<int>::of(&QSpinBox::valueChanged), this, &MapHeaderForm::onFloorNumberChanged);
 
@@ -215,11 +206,11 @@ void MapHeaderForm::onSongUpdated(const QString &song) {               if (m_hea
 void MapHeaderForm::onWeatherChanged(const QString &weather) {         if (m_header) m_header->setWeather(weather); }
 void MapHeaderForm::onTypeChanged(const QString &type) {               if (m_header) m_header->setType(type); }
 void MapHeaderForm::onBattleSceneChanged(const QString &battleScene) { if (m_header) m_header->setBattleScene(battleScene); }
-void MapHeaderForm::onRequiresFlashChanged(CheckState selected) {      if (m_header) m_header->setRequiresFlash(selected == Qt::Checked); }
-void MapHeaderForm::onShowLocationNameChanged(CheckState selected) {   if (m_header) m_header->setShowsLocationName(selected == Qt::Checked); }
-void MapHeaderForm::onAllowRunningChanged(CheckState selected) {       if (m_header) m_header->setAllowsRunning(selected == Qt::Checked); }
-void MapHeaderForm::onAllowBikingChanged(CheckState selected) {        if (m_header) m_header->setAllowsBiking(selected == Qt::Checked); }
-void MapHeaderForm::onAllowEscapingChanged(CheckState selected) {      if (m_header) m_header->setAllowsEscaping(selected == Qt::Checked); }
+void MapHeaderForm::onRequiresFlashChanged(bool enabled) {             if (m_header) m_header->setRequiresFlash(enabled); }
+void MapHeaderForm::onShowLocationNameChanged(bool enabled) {          if (m_header) m_header->setShowsLocationName(enabled); }
+void MapHeaderForm::onAllowRunningChanged(bool enabled) {              if (m_header) m_header->setAllowsRunning(enabled); }
+void MapHeaderForm::onAllowBikingChanged(bool enabled) {               if (m_header) m_header->setAllowsBiking(enabled); }
+void MapHeaderForm::onAllowEscapingChanged(bool enabled) {             if (m_header) m_header->setAllowsEscaping(enabled); }
 void MapHeaderForm::onFloorNumberChanged(int offset) {                 if (m_header) m_header->setFloorNumber(offset); }
 void MapHeaderForm::onLocationChanged(const QString &location) {
     if (m_header) m_header->setLocation(location);

--- a/src/ui/mapheaderform.cpp
+++ b/src/ui/mapheaderform.cpp
@@ -21,11 +21,19 @@ MapHeaderForm::MapHeaderForm(QWidget *parent)
     connect(ui->comboBox_Type,        &QComboBox::currentTextChanged, this, &MapHeaderForm::onTypeChanged);
     connect(ui->comboBox_BattleScene, &QComboBox::currentTextChanged, this, &MapHeaderForm::onBattleSceneChanged);
 
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 7, 0))
+    connect(ui->checkBox_RequiresFlash,    &QCheckBox::checkStateChanged, this, &MapHeaderForm::onRequiresFlashChanged);
+    connect(ui->checkBox_ShowLocationName, &QCheckBox::checkStateChanged, this, &MapHeaderForm::onShowLocationNameChanged);
+    connect(ui->checkBox_AllowRunning,     &QCheckBox::checkStateChanged, this, &MapHeaderForm::onAllowRunningChanged);
+    connect(ui->checkBox_AllowBiking,      &QCheckBox::checkStateChanged, this, &MapHeaderForm::onAllowBikingChanged);
+    connect(ui->checkBox_AllowEscaping,    &QCheckBox::checkStateChanged, this, &MapHeaderForm::onAllowEscapingChanged);
+#else
     connect(ui->checkBox_RequiresFlash,    &QCheckBox::stateChanged, this, &MapHeaderForm::onRequiresFlashChanged);
     connect(ui->checkBox_ShowLocationName, &QCheckBox::stateChanged, this, &MapHeaderForm::onShowLocationNameChanged);
     connect(ui->checkBox_AllowRunning,     &QCheckBox::stateChanged, this, &MapHeaderForm::onAllowRunningChanged);
     connect(ui->checkBox_AllowBiking,      &QCheckBox::stateChanged, this, &MapHeaderForm::onAllowBikingChanged);
     connect(ui->checkBox_AllowEscaping,    &QCheckBox::stateChanged, this, &MapHeaderForm::onAllowEscapingChanged);
+#endif
 
     connect(ui->spinBox_FloorNumber, QOverload<int>::of(&QSpinBox::valueChanged), this, &MapHeaderForm::onFloorNumberChanged);
 
@@ -207,11 +215,11 @@ void MapHeaderForm::onSongUpdated(const QString &song) {               if (m_hea
 void MapHeaderForm::onWeatherChanged(const QString &weather) {         if (m_header) m_header->setWeather(weather); }
 void MapHeaderForm::onTypeChanged(const QString &type) {               if (m_header) m_header->setType(type); }
 void MapHeaderForm::onBattleSceneChanged(const QString &battleScene) { if (m_header) m_header->setBattleScene(battleScene); }
-void MapHeaderForm::onRequiresFlashChanged(int selected) {             if (m_header) m_header->setRequiresFlash(selected == Qt::Checked); }
-void MapHeaderForm::onShowLocationNameChanged(int selected) {          if (m_header) m_header->setShowsLocationName(selected == Qt::Checked); }
-void MapHeaderForm::onAllowRunningChanged(int selected) {              if (m_header) m_header->setAllowsRunning(selected == Qt::Checked); }
-void MapHeaderForm::onAllowBikingChanged(int selected) {               if (m_header) m_header->setAllowsBiking(selected == Qt::Checked); }
-void MapHeaderForm::onAllowEscapingChanged(int selected) {             if (m_header) m_header->setAllowsEscaping(selected == Qt::Checked); }
+void MapHeaderForm::onRequiresFlashChanged(CheckState selected) {      if (m_header) m_header->setRequiresFlash(selected == Qt::Checked); }
+void MapHeaderForm::onShowLocationNameChanged(CheckState selected) {   if (m_header) m_header->setShowsLocationName(selected == Qt::Checked); }
+void MapHeaderForm::onAllowRunningChanged(CheckState selected) {       if (m_header) m_header->setAllowsRunning(selected == Qt::Checked); }
+void MapHeaderForm::onAllowBikingChanged(CheckState selected) {        if (m_header) m_header->setAllowsBiking(selected == Qt::Checked); }
+void MapHeaderForm::onAllowEscapingChanged(CheckState selected) {      if (m_header) m_header->setAllowsEscaping(selected == Qt::Checked); }
 void MapHeaderForm::onFloorNumberChanged(int offset) {                 if (m_header) m_header->setFloorNumber(offset); }
 void MapHeaderForm::onLocationChanged(const QString &location) {
     if (m_header) m_header->setLocation(location);

--- a/src/ui/mapimageexporter.cpp
+++ b/src/ui/mapimageexporter.cpp
@@ -60,41 +60,22 @@ MapImageExporter::MapImageExporter(QWidget *parent, Project *project, Map *map, 
     connect(ui->comboBox_MapSelection, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &MapImageExporter::updateMapSelection);
     connect(ui->comboBox_MapSelection->lineEdit(), &QLineEdit::editingFinished, this, &MapImageExporter::updateMapSelection);
 
-#if (QT_VERSION >= QT_VERSION_CHECK(6, 7, 0))
-    connect(ui->checkBox_Objects,               &QCheckBox::checkStateChanged, this, &MapImageExporter::setShowObjects);
-    connect(ui->checkBox_Warps,                 &QCheckBox::checkStateChanged, this, &MapImageExporter::setShowWarps);
-    connect(ui->checkBox_BGs,                   &QCheckBox::checkStateChanged, this, &MapImageExporter::setShowBgs);
-    connect(ui->checkBox_Triggers,              &QCheckBox::checkStateChanged, this, &MapImageExporter::setShowTriggers);
-    connect(ui->checkBox_HealLocations,         &QCheckBox::checkStateChanged, this, &MapImageExporter::setShowHealLocations);
-    connect(ui->checkBox_AllEvents,             &QCheckBox::checkStateChanged, this, &MapImageExporter::setShowAllEvents);
-    connect(ui->checkBox_ConnectionUp,          &QCheckBox::checkStateChanged, this, &MapImageExporter::setShowConnectionUp);
-    connect(ui->checkBox_ConnectionDown,        &QCheckBox::checkStateChanged, this, &MapImageExporter::setShowConnectionDown);
-    connect(ui->checkBox_ConnectionLeft,        &QCheckBox::checkStateChanged, this, &MapImageExporter::setShowConnectionLeft);
-    connect(ui->checkBox_ConnectionRight,       &QCheckBox::checkStateChanged, this, &MapImageExporter::setShowConnectionRight);
-    connect(ui->checkBox_AllConnections,        &QCheckBox::checkStateChanged, this, &MapImageExporter::setShowAllConnections);
-    connect(ui->checkBox_Collision,             &QCheckBox::checkStateChanged, this, &MapImageExporter::setShowCollision);
-    connect(ui->checkBox_Grid,                  &QCheckBox::checkStateChanged, this, &MapImageExporter::setShowGrid);
-    connect(ui->checkBox_Border,                &QCheckBox::checkStateChanged, this, &MapImageExporter::setShowBorder);
-    connect(ui->checkBox_DisablePreviewScaling, &QCheckBox::checkStateChanged, this, &MapImageExporter::setDisablePreviewScaling);
-    connect(ui->checkBox_DisablePreviewUpdates, &QCheckBox::checkStateChanged, this, &MapImageExporter::setDisablePreviewUpdates);
-#else
-    connect(ui->checkBox_Objects,               &QCheckBox::stateChanged, this, &MapImageExporter::setShowObjects);
-    connect(ui->checkBox_Warps,                 &QCheckBox::stateChanged, this, &MapImageExporter::setShowWarps);
-    connect(ui->checkBox_BGs,                   &QCheckBox::stateChanged, this, &MapImageExporter::setShowBgs);
-    connect(ui->checkBox_Triggers,              &QCheckBox::stateChanged, this, &MapImageExporter::setShowTriggers);
-    connect(ui->checkBox_HealLocations,         &QCheckBox::stateChanged, this, &MapImageExporter::setShowHealLocations);
-    connect(ui->checkBox_AllEvents,             &QCheckBox::stateChanged, this, &MapImageExporter::setShowAllEvents);
-    connect(ui->checkBox_ConnectionUp,          &QCheckBox::stateChanged, this, &MapImageExporter::setShowConnectionUp);
-    connect(ui->checkBox_ConnectionDown,        &QCheckBox::stateChanged, this, &MapImageExporter::setShowConnectionDown);
-    connect(ui->checkBox_ConnectionLeft,        &QCheckBox::stateChanged, this, &MapImageExporter::setShowConnectionLeft);
-    connect(ui->checkBox_ConnectionRight,       &QCheckBox::stateChanged, this, &MapImageExporter::setShowConnectionRight);
-    connect(ui->checkBox_AllConnections,        &QCheckBox::stateChanged, this, &MapImageExporter::setShowAllConnections);
-    connect(ui->checkBox_Collision,             &QCheckBox::stateChanged, this, &MapImageExporter::setShowCollision);
-    connect(ui->checkBox_Grid,                  &QCheckBox::stateChanged, this, &MapImageExporter::setShowGrid);
-    connect(ui->checkBox_Border,                &QCheckBox::stateChanged, this, &MapImageExporter::setShowBorder);
-    connect(ui->checkBox_DisablePreviewScaling, &QCheckBox::stateChanged, this, &MapImageExporter::setDisablePreviewScaling);
-    connect(ui->checkBox_DisablePreviewUpdates, &QCheckBox::stateChanged, this, &MapImageExporter::setDisablePreviewUpdates);
-#endif
+    connect(ui->checkBox_Objects,               &QCheckBox::toggled, this, &MapImageExporter::setShowObjects);
+    connect(ui->checkBox_Warps,                 &QCheckBox::toggled, this, &MapImageExporter::setShowWarps);
+    connect(ui->checkBox_BGs,                   &QCheckBox::toggled, this, &MapImageExporter::setShowBgs);
+    connect(ui->checkBox_Triggers,              &QCheckBox::toggled, this, &MapImageExporter::setShowTriggers);
+    connect(ui->checkBox_HealLocations,         &QCheckBox::toggled, this, &MapImageExporter::setShowHealLocations);
+    connect(ui->checkBox_AllEvents,             &QCheckBox::toggled, this, &MapImageExporter::setShowAllEvents);
+    connect(ui->checkBox_ConnectionUp,          &QCheckBox::toggled, this, &MapImageExporter::setShowConnectionUp);
+    connect(ui->checkBox_ConnectionDown,        &QCheckBox::toggled, this, &MapImageExporter::setShowConnectionDown);
+    connect(ui->checkBox_ConnectionLeft,        &QCheckBox::toggled, this, &MapImageExporter::setShowConnectionLeft);
+    connect(ui->checkBox_ConnectionRight,       &QCheckBox::toggled, this, &MapImageExporter::setShowConnectionRight);
+    connect(ui->checkBox_AllConnections,        &QCheckBox::toggled, this, &MapImageExporter::setShowAllConnections);
+    connect(ui->checkBox_Collision,             &QCheckBox::toggled, this, &MapImageExporter::setShowCollision);
+    connect(ui->checkBox_Grid,                  &QCheckBox::toggled, this, &MapImageExporter::setShowGrid);
+    connect(ui->checkBox_Border,                &QCheckBox::toggled, this, &MapImageExporter::setShowBorder);
+    connect(ui->checkBox_DisablePreviewScaling, &QCheckBox::toggled, this, &MapImageExporter::setDisablePreviewScaling);
+    connect(ui->checkBox_DisablePreviewUpdates, &QCheckBox::toggled, this, &MapImageExporter::setDisablePreviewUpdates);
 
     ui->graphicsView_Preview->setFocus();
 }
@@ -755,127 +736,123 @@ void MapImageExporter::setConnectionDirectionEnabled(const QString &dir, bool en
     }
 }
 
-void MapImageExporter::setShowCollision(CheckState state) {
-    m_settings.showCollision = (state == Qt::Checked);
+void MapImageExporter::setShowCollision(bool checked) {
+    m_settings.showCollision = checked;
     updatePreview();
 }
 
-void MapImageExporter::setShowGrid(CheckState state) {
-    m_settings.showGrid = (state == Qt::Checked);
+void MapImageExporter::setShowGrid(bool checked) {
+    m_settings.showGrid = checked;
     updatePreview();
 }
 
-void MapImageExporter::setShowBorder(CheckState state) {
-    m_settings.showBorder = (state == Qt::Checked);
+void MapImageExporter::setShowBorder(bool checked) {
+    m_settings.showBorder = checked;
     updatePreview();
 }
 
-void MapImageExporter::setShowObjects(CheckState state) {
-    setEventGroupEnabled(Event::Group::Object, state == Qt::Checked);
+void MapImageExporter::setShowObjects(bool checked) {
+    setEventGroupEnabled(Event::Group::Object, checked);
     updatePreview();
 }
 
-void MapImageExporter::setShowWarps(CheckState state) {
-    setEventGroupEnabled(Event::Group::Warp, state == Qt::Checked);
+void MapImageExporter::setShowWarps(bool checked) {
+    setEventGroupEnabled(Event::Group::Warp, checked);
     updatePreview();
 }
 
-void MapImageExporter::setShowBgs(CheckState state) {
-    setEventGroupEnabled(Event::Group::Bg, state == Qt::Checked);
+void MapImageExporter::setShowBgs(bool checked) {
+    setEventGroupEnabled(Event::Group::Bg, checked);
     updatePreview();
 }
 
-void MapImageExporter::setShowTriggers(CheckState state) {
-    setEventGroupEnabled(Event::Group::Coord, state == Qt::Checked);
+void MapImageExporter::setShowTriggers(bool checked) {
+    setEventGroupEnabled(Event::Group::Coord, checked);
     updatePreview();
 }
 
-void MapImageExporter::setShowHealLocations(CheckState state) {
-    setEventGroupEnabled(Event::Group::Heal, state == Qt::Checked);
+void MapImageExporter::setShowHealLocations(bool checked) {
+    setEventGroupEnabled(Event::Group::Heal, checked);
     updatePreview();
 }
 
 // Shortcut setting for enabling all events
-void MapImageExporter::setShowAllEvents(CheckState state) {
-    bool on = (state == Qt::Checked);
-
+void MapImageExporter::setShowAllEvents(bool checked) {
     const QSignalBlocker b_Objects(ui->checkBox_Objects);
-    ui->checkBox_Objects->setChecked(on);
-    ui->checkBox_Objects->setDisabled(on);
-    setEventGroupEnabled(Event::Group::Object, on);
+    ui->checkBox_Objects->setChecked(checked);
+    ui->checkBox_Objects->setDisabled(checked);
+    setEventGroupEnabled(Event::Group::Object, checked);
 
     const QSignalBlocker b_Warps(ui->checkBox_Warps);
-    ui->checkBox_Warps->setChecked(on);
-    ui->checkBox_Warps->setDisabled(on);
-    setEventGroupEnabled(Event::Group::Warp, on);
+    ui->checkBox_Warps->setChecked(checked);
+    ui->checkBox_Warps->setDisabled(checked);
+    setEventGroupEnabled(Event::Group::Warp, checked);
 
     const QSignalBlocker b_BGs(ui->checkBox_BGs);
-    ui->checkBox_BGs->setChecked(on);
-    ui->checkBox_BGs->setDisabled(on);
-    setEventGroupEnabled(Event::Group::Bg, on);
+    ui->checkBox_BGs->setChecked(checked);
+    ui->checkBox_BGs->setDisabled(checked);
+    setEventGroupEnabled(Event::Group::Bg, checked);
 
     const QSignalBlocker b_Triggers(ui->checkBox_Triggers);
-    ui->checkBox_Triggers->setChecked(on);
-    ui->checkBox_Triggers->setDisabled(on);
-    setEventGroupEnabled(Event::Group::Coord, on);
+    ui->checkBox_Triggers->setChecked(checked);
+    ui->checkBox_Triggers->setDisabled(checked);
+    setEventGroupEnabled(Event::Group::Coord, checked);
 
     const QSignalBlocker b_HealLocations(ui->checkBox_HealLocations);
-    ui->checkBox_HealLocations->setChecked(on);
-    ui->checkBox_HealLocations->setDisabled(on);
-    setEventGroupEnabled(Event::Group::Heal, on);
+    ui->checkBox_HealLocations->setChecked(checked);
+    ui->checkBox_HealLocations->setDisabled(checked);
+    setEventGroupEnabled(Event::Group::Heal, checked);
 
     updatePreview();
 }
 
-void MapImageExporter::setShowConnectionUp(CheckState state) {
-    setConnectionDirectionEnabled("up", state == Qt::Checked);
+void MapImageExporter::setShowConnectionUp(bool checked) {
+    setConnectionDirectionEnabled("up", checked);
     updatePreview();
 }
 
-void MapImageExporter::setShowConnectionDown(CheckState state) {
-    setConnectionDirectionEnabled("down", state == Qt::Checked);
+void MapImageExporter::setShowConnectionDown(bool checked) {
+    setConnectionDirectionEnabled("down", checked);
     updatePreview();
 }
 
-void MapImageExporter::setShowConnectionLeft(CheckState state) {
-    setConnectionDirectionEnabled("left", state == Qt::Checked);
+void MapImageExporter::setShowConnectionLeft(bool checked) {
+    setConnectionDirectionEnabled("left", checked);
     updatePreview();
 }
 
-void MapImageExporter::setShowConnectionRight(CheckState state) {
-    setConnectionDirectionEnabled("right", state == Qt::Checked);
+void MapImageExporter::setShowConnectionRight(bool checked) {
+    setConnectionDirectionEnabled("right", checked);
     updatePreview();
 }
 
 // Shortcut setting for enabling all connection directions
-void MapImageExporter::setShowAllConnections(CheckState state) {
-    bool on = (state == Qt::Checked);
-
+void MapImageExporter::setShowAllConnections(bool checked) {
     const QSignalBlocker b_Up(ui->checkBox_ConnectionUp);
-    ui->checkBox_ConnectionUp->setChecked(on);
-    ui->checkBox_ConnectionUp->setDisabled(on);
-    setConnectionDirectionEnabled("up", on);
+    ui->checkBox_ConnectionUp->setChecked(checked);
+    ui->checkBox_ConnectionUp->setDisabled(checked);
+    setConnectionDirectionEnabled("up", checked);
 
     const QSignalBlocker b_Down(ui->checkBox_ConnectionDown);
-    ui->checkBox_ConnectionDown->setChecked(on);
-    ui->checkBox_ConnectionDown->setDisabled(on);
-    setConnectionDirectionEnabled("down", on);
+    ui->checkBox_ConnectionDown->setChecked(checked);
+    ui->checkBox_ConnectionDown->setDisabled(checked);
+    setConnectionDirectionEnabled("down", checked);
 
     const QSignalBlocker b_Left(ui->checkBox_ConnectionLeft);
-    ui->checkBox_ConnectionLeft->setChecked(on);
-    ui->checkBox_ConnectionLeft->setDisabled(on);
-    setConnectionDirectionEnabled("left", on);
+    ui->checkBox_ConnectionLeft->setChecked(checked);
+    ui->checkBox_ConnectionLeft->setDisabled(checked);
+    setConnectionDirectionEnabled("left", checked);
 
     const QSignalBlocker b_Right(ui->checkBox_ConnectionRight);
-    ui->checkBox_ConnectionRight->setChecked(on);
-    ui->checkBox_ConnectionRight->setDisabled(on);
-    setConnectionDirectionEnabled("right", on);
+    ui->checkBox_ConnectionRight->setChecked(checked);
+    ui->checkBox_ConnectionRight->setDisabled(checked);
+    setConnectionDirectionEnabled("right", checked);
 
     updatePreview();
 }
 
-void MapImageExporter::setDisablePreviewScaling(CheckState state) {
-    m_settings.disablePreviewScaling = (state == Qt::Checked);
+void MapImageExporter::setDisablePreviewScaling(bool checked) {
+    m_settings.disablePreviewScaling = checked;
     if (m_settings.disablePreviewScaling) {
         ui->graphicsView_Preview->resetTransform();
     } else {
@@ -883,8 +860,8 @@ void MapImageExporter::setDisablePreviewScaling(CheckState state) {
     }
 }
 
-void MapImageExporter::setDisablePreviewUpdates(CheckState state) {
-    m_settings.disablePreviewUpdates = (state == Qt::Checked);
+void MapImageExporter::setDisablePreviewUpdates(bool checked) {
+    m_settings.disablePreviewUpdates = checked;
     if (m_settings.disablePreviewUpdates) {
         if (m_timelapseMovie) {
             m_timelapseMovie->stop();

--- a/src/ui/mapimageexporter.cpp
+++ b/src/ui/mapimageexporter.cpp
@@ -60,6 +60,42 @@ MapImageExporter::MapImageExporter(QWidget *parent, Project *project, Map *map, 
     connect(ui->comboBox_MapSelection, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &MapImageExporter::updateMapSelection);
     connect(ui->comboBox_MapSelection->lineEdit(), &QLineEdit::editingFinished, this, &MapImageExporter::updateMapSelection);
 
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 7, 0))
+    connect(ui->checkBox_Objects,               &QCheckBox::checkStateChanged, this, &MapImageExporter::setShowObjects);
+    connect(ui->checkBox_Warps,                 &QCheckBox::checkStateChanged, this, &MapImageExporter::setShowWarps);
+    connect(ui->checkBox_BGs,                   &QCheckBox::checkStateChanged, this, &MapImageExporter::setShowBgs);
+    connect(ui->checkBox_Triggers,              &QCheckBox::checkStateChanged, this, &MapImageExporter::setShowTriggers);
+    connect(ui->checkBox_HealLocations,         &QCheckBox::checkStateChanged, this, &MapImageExporter::setShowHealLocations);
+    connect(ui->checkBox_AllEvents,             &QCheckBox::checkStateChanged, this, &MapImageExporter::setShowAllEvents);
+    connect(ui->checkBox_ConnectionUp,          &QCheckBox::checkStateChanged, this, &MapImageExporter::setShowConnectionUp);
+    connect(ui->checkBox_ConnectionDown,        &QCheckBox::checkStateChanged, this, &MapImageExporter::setShowConnectionDown);
+    connect(ui->checkBox_ConnectionLeft,        &QCheckBox::checkStateChanged, this, &MapImageExporter::setShowConnectionLeft);
+    connect(ui->checkBox_ConnectionRight,       &QCheckBox::checkStateChanged, this, &MapImageExporter::setShowConnectionRight);
+    connect(ui->checkBox_AllConnections,        &QCheckBox::checkStateChanged, this, &MapImageExporter::setShowAllConnections);
+    connect(ui->checkBox_Collision,             &QCheckBox::checkStateChanged, this, &MapImageExporter::setShowCollision);
+    connect(ui->checkBox_Grid,                  &QCheckBox::checkStateChanged, this, &MapImageExporter::setShowGrid);
+    connect(ui->checkBox_Border,                &QCheckBox::checkStateChanged, this, &MapImageExporter::setShowBorder);
+    connect(ui->checkBox_DisablePreviewScaling, &QCheckBox::checkStateChanged, this, &MapImageExporter::setDisablePreviewScaling);
+    connect(ui->checkBox_DisablePreviewUpdates, &QCheckBox::checkStateChanged, this, &MapImageExporter::setDisablePreviewUpdates);
+#else
+    connect(ui->checkBox_Objects,               &QCheckBox::stateChanged, this, &MapImageExporter::setShowObjects);
+    connect(ui->checkBox_Warps,                 &QCheckBox::stateChanged, this, &MapImageExporter::setShowWarps);
+    connect(ui->checkBox_BGs,                   &QCheckBox::stateChanged, this, &MapImageExporter::setShowBgs);
+    connect(ui->checkBox_Triggers,              &QCheckBox::stateChanged, this, &MapImageExporter::setShowTriggers);
+    connect(ui->checkBox_HealLocations,         &QCheckBox::stateChanged, this, &MapImageExporter::setShowHealLocations);
+    connect(ui->checkBox_AllEvents,             &QCheckBox::stateChanged, this, &MapImageExporter::setShowAllEvents);
+    connect(ui->checkBox_ConnectionUp,          &QCheckBox::stateChanged, this, &MapImageExporter::setShowConnectionUp);
+    connect(ui->checkBox_ConnectionDown,        &QCheckBox::stateChanged, this, &MapImageExporter::setShowConnectionDown);
+    connect(ui->checkBox_ConnectionLeft,        &QCheckBox::stateChanged, this, &MapImageExporter::setShowConnectionLeft);
+    connect(ui->checkBox_ConnectionRight,       &QCheckBox::stateChanged, this, &MapImageExporter::setShowConnectionRight);
+    connect(ui->checkBox_AllConnections,        &QCheckBox::stateChanged, this, &MapImageExporter::setShowAllConnections);
+    connect(ui->checkBox_Collision,             &QCheckBox::stateChanged, this, &MapImageExporter::setShowCollision);
+    connect(ui->checkBox_Grid,                  &QCheckBox::stateChanged, this, &MapImageExporter::setShowGrid);
+    connect(ui->checkBox_Border,                &QCheckBox::stateChanged, this, &MapImageExporter::setShowBorder);
+    connect(ui->checkBox_DisablePreviewScaling, &QCheckBox::stateChanged, this, &MapImageExporter::setDisablePreviewScaling);
+    connect(ui->checkBox_DisablePreviewUpdates, &QCheckBox::stateChanged, this, &MapImageExporter::setDisablePreviewUpdates);
+#endif
+
     ui->graphicsView_Preview->setFocus();
 }
 
@@ -719,48 +755,48 @@ void MapImageExporter::setConnectionDirectionEnabled(const QString &dir, bool en
     }
 }
 
-void MapImageExporter::on_checkBox_Collision_stateChanged(int state) {
+void MapImageExporter::setShowCollision(CheckState state) {
     m_settings.showCollision = (state == Qt::Checked);
     updatePreview();
 }
 
-void MapImageExporter::on_checkBox_Grid_stateChanged(int state) {
+void MapImageExporter::setShowGrid(CheckState state) {
     m_settings.showGrid = (state == Qt::Checked);
     updatePreview();
 }
 
-void MapImageExporter::on_checkBox_Border_stateChanged(int state) {
+void MapImageExporter::setShowBorder(CheckState state) {
     m_settings.showBorder = (state == Qt::Checked);
     updatePreview();
 }
 
-void MapImageExporter::on_checkBox_Objects_stateChanged(int state) {
+void MapImageExporter::setShowObjects(CheckState state) {
     setEventGroupEnabled(Event::Group::Object, state == Qt::Checked);
     updatePreview();
 }
 
-void MapImageExporter::on_checkBox_Warps_stateChanged(int state) {
+void MapImageExporter::setShowWarps(CheckState state) {
     setEventGroupEnabled(Event::Group::Warp, state == Qt::Checked);
     updatePreview();
 }
 
-void MapImageExporter::on_checkBox_BGs_stateChanged(int state) {
+void MapImageExporter::setShowBgs(CheckState state) {
     setEventGroupEnabled(Event::Group::Bg, state == Qt::Checked);
     updatePreview();
 }
 
-void MapImageExporter::on_checkBox_Triggers_stateChanged(int state) {
+void MapImageExporter::setShowTriggers(CheckState state) {
     setEventGroupEnabled(Event::Group::Coord, state == Qt::Checked);
     updatePreview();
 }
 
-void MapImageExporter::on_checkBox_HealLocations_stateChanged(int state) {
+void MapImageExporter::setShowHealLocations(CheckState state) {
     setEventGroupEnabled(Event::Group::Heal, state == Qt::Checked);
     updatePreview();
 }
 
 // Shortcut setting for enabling all events
-void MapImageExporter::on_checkBox_AllEvents_stateChanged(int state) {
+void MapImageExporter::setShowAllEvents(CheckState state) {
     bool on = (state == Qt::Checked);
 
     const QSignalBlocker b_Objects(ui->checkBox_Objects);
@@ -791,28 +827,28 @@ void MapImageExporter::on_checkBox_AllEvents_stateChanged(int state) {
     updatePreview();
 }
 
-void MapImageExporter::on_checkBox_ConnectionUp_stateChanged(int state) {
+void MapImageExporter::setShowConnectionUp(CheckState state) {
     setConnectionDirectionEnabled("up", state == Qt::Checked);
     updatePreview();
 }
 
-void MapImageExporter::on_checkBox_ConnectionDown_stateChanged(int state) {
+void MapImageExporter::setShowConnectionDown(CheckState state) {
     setConnectionDirectionEnabled("down", state == Qt::Checked);
     updatePreview();
 }
 
-void MapImageExporter::on_checkBox_ConnectionLeft_stateChanged(int state) {
+void MapImageExporter::setShowConnectionLeft(CheckState state) {
     setConnectionDirectionEnabled("left", state == Qt::Checked);
     updatePreview();
 }
 
-void MapImageExporter::on_checkBox_ConnectionRight_stateChanged(int state) {
+void MapImageExporter::setShowConnectionRight(CheckState state) {
     setConnectionDirectionEnabled("right", state == Qt::Checked);
     updatePreview();
 }
 
 // Shortcut setting for enabling all connection directions
-void MapImageExporter::on_checkBox_AllConnections_stateChanged(int state) {
+void MapImageExporter::setShowAllConnections(CheckState state) {
     bool on = (state == Qt::Checked);
 
     const QSignalBlocker b_Up(ui->checkBox_ConnectionUp);
@@ -838,7 +874,7 @@ void MapImageExporter::on_checkBox_AllConnections_stateChanged(int state) {
     updatePreview();
 }
 
-void MapImageExporter::on_checkBox_DisablePreviewScaling_stateChanged(int state) {
+void MapImageExporter::setDisablePreviewScaling(CheckState state) {
     m_settings.disablePreviewScaling = (state == Qt::Checked);
     if (m_settings.disablePreviewScaling) {
         ui->graphicsView_Preview->resetTransform();
@@ -847,7 +883,7 @@ void MapImageExporter::on_checkBox_DisablePreviewScaling_stateChanged(int state)
     }
 }
 
-void MapImageExporter::on_checkBox_DisablePreviewUpdates_stateChanged(int state) {
+void MapImageExporter::setDisablePreviewUpdates(CheckState state) {
     m_settings.disablePreviewUpdates = (state == Qt::Checked);
     if (m_settings.disablePreviewUpdates) {
         if (m_timelapseMovie) {

--- a/src/ui/metatilelayersitem.cpp
+++ b/src/ui/metatilelayersitem.cpp
@@ -1,6 +1,7 @@
 #include "config.h"
 #include "metatilelayersitem.h"
 #include "imageproviders.h"
+#include "utility.h"
 #include <QPainter>
 
 static const QList<QPoint> tilePositions = {
@@ -28,7 +29,11 @@ void MetatileLayersItem::draw() {
     for (int i = 0; i < numTiles; i++) {
         Tile tile = this->metatile->tiles.at(i);
         QImage tileImage = getPalettedTileImage(tile.tileId, this->primaryTileset, this->secondaryTileset, tile.palette, true)
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 9, 0))
+                .flipped(Util::getOrientation(tile.xflip, tile.yflip))
+#else
                 .mirrored(tile.xflip, tile.yflip)
+#endif
                 .scaled(16, 16);
         painter.drawImage(tilePositions.at(i) * 16, tileImage);
     }

--- a/src/ui/projectsettingseditor.cpp
+++ b/src/ui/projectsettingseditor.cpp
@@ -45,7 +45,11 @@ void ProjectSettingsEditor::connectSignals() {
     connect(ui->comboBox_BaseGameVersion, &QComboBox::currentTextChanged, this, &ProjectSettingsEditor::promptRestoreDefaults);
     connect(ui->comboBox_AttributesSize, &QComboBox::currentTextChanged, this, &ProjectSettingsEditor::updateAttributeLimits);
     connect(ui->comboBox_IconSpecies, &QComboBox::currentTextChanged, this, &ProjectSettingsEditor::updatePokemonIconPath);
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 7, 0))
+    connect(ui->checkBox_EnableCustomBorderSize, &QCheckBox::checkStateChanged, [this](Qt::CheckState state) {
+#else
     connect(ui->checkBox_EnableCustomBorderSize, &QCheckBox::stateChanged, [this](int state) {
+#endif
         bool customSize = (state == Qt::Checked);
         // When switching between the spin boxes or line edit for border metatiles we set
         // the newly-shown UI using the values from the hidden UI.
@@ -82,8 +86,12 @@ void ProjectSettingsEditor::connectSignals() {
             connect(combo, &QComboBox::currentTextChanged, this, &ProjectSettingsEditor::markEdited);
     }
     for (auto checkBox : ui->centralwidget->findChildren<QCheckBox *>())
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 7, 0))
+        connect(checkBox, &QCheckBox::checkStateChanged, this, &ProjectSettingsEditor::markEdited);
+#else
         connect(checkBox, &QCheckBox::stateChanged, this, &ProjectSettingsEditor::markEdited);
-     for (auto radioButton : ui->centralwidget->findChildren<QRadioButton *>())
+#endif
+    for (auto radioButton : ui->centralwidget->findChildren<QRadioButton *>())
         connect(radioButton, &QRadioButton::toggled, this, &ProjectSettingsEditor::markEdited);
     for (auto lineEdit : ui->centralwidget->findChildren<QLineEdit *>())
         connect(lineEdit, &QLineEdit::textEdited, this, &ProjectSettingsEditor::markEdited);

--- a/src/ui/projectsettingseditor.cpp
+++ b/src/ui/projectsettingseditor.cpp
@@ -45,16 +45,11 @@ void ProjectSettingsEditor::connectSignals() {
     connect(ui->comboBox_BaseGameVersion, &QComboBox::currentTextChanged, this, &ProjectSettingsEditor::promptRestoreDefaults);
     connect(ui->comboBox_AttributesSize, &QComboBox::currentTextChanged, this, &ProjectSettingsEditor::updateAttributeLimits);
     connect(ui->comboBox_IconSpecies, &QComboBox::currentTextChanged, this, &ProjectSettingsEditor::updatePokemonIconPath);
-#if (QT_VERSION >= QT_VERSION_CHECK(6, 7, 0))
-    connect(ui->checkBox_EnableCustomBorderSize, &QCheckBox::checkStateChanged, [this](Qt::CheckState state) {
-#else
-    connect(ui->checkBox_EnableCustomBorderSize, &QCheckBox::stateChanged, [this](int state) {
-#endif
-        bool customSize = (state == Qt::Checked);
+    connect(ui->checkBox_EnableCustomBorderSize, &QCheckBox::toggled, [this](bool enabled) {
         // When switching between the spin boxes or line edit for border metatiles we set
         // the newly-shown UI using the values from the hidden UI.
-        this->setBorderMetatileIds(customSize, this->getBorderMetatileIds(!customSize));
-        this->setBorderMetatilesUi(customSize);
+        this->setBorderMetatileIds(enabled, this->getBorderMetatileIds(!enabled));
+        this->setBorderMetatilesUi(enabled);
     });
     connect(ui->button_AddWarpBehavior,    &QAbstractButton::clicked, [this](bool) { this->updateWarpBehaviorsList(true); });
     connect(ui->button_RemoveWarpBehavior, &QAbstractButton::clicked, [this](bool) { this->updateWarpBehaviorsList(false); });
@@ -86,11 +81,7 @@ void ProjectSettingsEditor::connectSignals() {
             connect(combo, &QComboBox::currentTextChanged, this, &ProjectSettingsEditor::markEdited);
     }
     for (auto checkBox : ui->centralwidget->findChildren<QCheckBox *>())
-#if (QT_VERSION >= QT_VERSION_CHECK(6, 7, 0))
-        connect(checkBox, &QCheckBox::checkStateChanged, this, &ProjectSettingsEditor::markEdited);
-#else
-        connect(checkBox, &QCheckBox::stateChanged, this, &ProjectSettingsEditor::markEdited);
-#endif
+        connect(checkBox, &QCheckBox::toggled, this, &ProjectSettingsEditor::markEdited);
     for (auto radioButton : ui->centralwidget->findChildren<QRadioButton *>())
         connect(radioButton, &QRadioButton::toggled, this, &ProjectSettingsEditor::markEdited);
     for (auto lineEdit : ui->centralwidget->findChildren<QLineEdit *>())

--- a/src/ui/regionmapeditor.cpp
+++ b/src/ui/regionmapeditor.cpp
@@ -27,13 +27,8 @@ RegionMapEditor::RegionMapEditor(QWidget *parent, Project *project) :
     this->ui->setupUi(this);
     this->project = project;
     connect(this->project, &Project::mapSectionIdNamesChanged, this, &RegionMapEditor::setLocations);
-#if (QT_VERSION >= QT_VERSION_CHECK(6, 7, 0))
-    connect(ui->checkBox_tileHFlip, &QCheckBox::checkStateChanged, this, &RegionMapEditor::setTileHFlip);
-    connect(ui->checkBox_tileVFlip, &QCheckBox::checkStateChanged, this, &RegionMapEditor::setTileVFlip);
-#else
-    connect(ui->checkBox_tileHFlip, &QCheckBox::stateChanged, this, &RegionMapEditor::setTileHFlip);
-    connect(ui->checkBox_tileVFlip, &QCheckBox::stateChanged, this, &RegionMapEditor::setTileVFlip);
-#endif
+    connect(ui->checkBox_tileHFlip, &QCheckBox::toggled, this, &RegionMapEditor::setTileHFlip);
+    connect(ui->checkBox_tileVFlip, &QCheckBox::toggled, this, &RegionMapEditor::setTileVFlip);
 
 
     this->configFilepath = QString("%1/%2").arg(this->project->root).arg(projectConfig.getFilePath(ProjectFilePath::json_region_porymap_cfg));
@@ -1043,14 +1038,14 @@ void RegionMapEditor::on_spinBox_tilePalette_valueChanged(int value) {
         this->mapsquare_selector_item->selectPalette(value);
 }
 
-void RegionMapEditor::setTileHFlip(CheckState state) {
+void RegionMapEditor::setTileHFlip(bool enabled) {
     if (this->mapsquare_selector_item)
-        this->mapsquare_selector_item->selectHFlip(state == Qt::Checked);
+        this->mapsquare_selector_item->selectHFlip(enabled);
 }
 
-void RegionMapEditor::setTileVFlip(CheckState state) {
+void RegionMapEditor::setTileVFlip(bool enabled) {
     if (this->mapsquare_selector_item)
-        this->mapsquare_selector_item->selectVFlip(state == Qt::Checked);
+        this->mapsquare_selector_item->selectVFlip(enabled);
 }
 
 void RegionMapEditor::on_action_RegionMap_Resize_triggered() {

--- a/src/ui/regionmapeditor.cpp
+++ b/src/ui/regionmapeditor.cpp
@@ -27,6 +27,15 @@ RegionMapEditor::RegionMapEditor(QWidget *parent, Project *project) :
     this->ui->setupUi(this);
     this->project = project;
     connect(this->project, &Project::mapSectionIdNamesChanged, this, &RegionMapEditor::setLocations);
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 7, 0))
+    connect(ui->checkBox_tileHFlip, &QCheckBox::checkStateChanged, this, &RegionMapEditor::setTileHFlip);
+    connect(ui->checkBox_tileVFlip, &QCheckBox::checkStateChanged, this, &RegionMapEditor::setTileVFlip);
+#else
+    connect(ui->checkBox_tileHFlip, &QCheckBox::stateChanged, this, &RegionMapEditor::setTileHFlip);
+    connect(ui->checkBox_tileVFlip, &QCheckBox::stateChanged, this, &RegionMapEditor::setTileVFlip);
+#endif
+
+
     this->configFilepath = QString("%1/%2").arg(this->project->root).arg(projectConfig.getFilePath(ProjectFilePath::json_region_porymap_cfg));
     this->initShortcuts();
     this->restoreWindowState();
@@ -1030,15 +1039,18 @@ void RegionMapEditor::on_pushButton_RM_Options_delete_clicked() {
 }
 
 void RegionMapEditor::on_spinBox_tilePalette_valueChanged(int value) {
-    this->mapsquare_selector_item->selectPalette(value);
+    if (this->mapsquare_selector_item)
+        this->mapsquare_selector_item->selectPalette(value);
 }
 
-void RegionMapEditor::on_checkBox_tileHFlip_stateChanged(int state) {
-    this->mapsquare_selector_item->selectHFlip(state == Qt::Checked);
+void RegionMapEditor::setTileHFlip(CheckState state) {
+    if (this->mapsquare_selector_item)
+        this->mapsquare_selector_item->selectHFlip(state == Qt::Checked);
 }
 
-void RegionMapEditor::on_checkBox_tileVFlip_stateChanged(int state) {
-    this->mapsquare_selector_item->selectVFlip(state == Qt::Checked);
+void RegionMapEditor::setTileVFlip(CheckState state) {
+    if (this->mapsquare_selector_item)
+        this->mapsquare_selector_item->selectVFlip(state == Qt::Checked);
 }
 
 void RegionMapEditor::on_action_RegionMap_Resize_triggered() {

--- a/src/ui/shortcut.cpp
+++ b/src/ui/shortcut.cpp
@@ -123,21 +123,10 @@ bool Shortcut::autoRepeat() const {
     return sc_vec.first()->autoRepeat();
 }
 
-int Shortcut::id() const {
-    return sc_vec.first()->id();
-}
-
-QList<int> Shortcut::ids() const {
-    QList<int> id_list;
-    for (auto *sc : sc_vec)
-        id_list.append(sc->id());
-    return id_list;
-}
-
 bool Shortcut::event(QEvent *e) {
     if (isEnabled() && e->type() == QEvent::Shortcut) {
         auto se = static_cast<QShortcutEvent *>(e);
-        if (ids().contains(se->shortcutId()) && keys().contains(se->key())) {
+        if (keys().contains(se->key())) {
             if (QWhatsThis::inWhatsThisMode()) {
                 QWhatsThis::showText(QCursor::pos(), whatsThis());
             } else {

--- a/src/ui/tilemaptileselector.cpp
+++ b/src/ui/tilemaptileselector.cpp
@@ -93,7 +93,11 @@ QImage TilemapTileSelector::tileImg(shared_ptr<TilemapTile> tile) {
 
     // take a tile from the tileset
     QImage img = tilesetImage.copy(pos.x() * 8, pos.y() * 8, 8, 8);
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 9, 0))
+    img.flip(Util::getOrientation(tile->hFlip(), tile->vFlip()));
+#else
     img = img.mirrored(tile->hFlip(), tile->vFlip());
+#endif
     return img;
 }
 

--- a/src/ui/tileseteditor.cpp
+++ b/src/ui/tileseteditor.cpp
@@ -26,14 +26,8 @@ TilesetEditor::TilesetEditor(Project *project, Layout *layout, QWidget *parent) 
     setAttribute(Qt::WA_DeleteOnClose);
     setTilesets(this->layout->tileset_primary_label, this->layout->tileset_secondary_label);
     ui->setupUi(this);
-
-#if (QT_VERSION >= QT_VERSION_CHECK(6, 7, 0))
-    connect(ui->checkBox_xFlip, &QCheckBox::checkStateChanged, this, &TilesetEditor::setXFlip);
-    connect(ui->checkBox_yFlip, &QCheckBox::checkStateChanged, this, &TilesetEditor::setYFlip);
-#else
-    connect(ui->checkBox_xFlip, &QCheckBox::stateChanged, this, &TilesetEditor::setXFlip);
-    connect(ui->checkBox_yFlip, &QCheckBox::stateChanged, this, &TilesetEditor::setYFlip);
-#endif
+    connect(ui->checkBox_xFlip, &QCheckBox::toggled, this, &TilesetEditor::setXFlip);
+    connect(ui->checkBox_yFlip, &QCheckBox::toggled, this, &TilesetEditor::setYFlip);
 
     this->tileXFlip = ui->checkBox_xFlip->isChecked();
     this->tileYFlip = ui->checkBox_yFlip->isChecked();
@@ -553,17 +547,17 @@ void TilesetEditor::on_spinBox_paletteSelector_valueChanged(int paletteId)
     this->metatileLayersItem->clearLastModifiedCoords();
 }
 
-void TilesetEditor::setXFlip(CheckState state)
+void TilesetEditor::setXFlip(bool enabled)
 {
-    this->tileXFlip = (state == Qt::Checked);
+    this->tileXFlip = enabled;
     this->tileSelector->setTileFlips(this->tileXFlip, this->tileYFlip);
     this->drawSelectedTiles();
     this->metatileLayersItem->clearLastModifiedCoords();
 }
 
-void TilesetEditor::setYFlip(CheckState state)
+void TilesetEditor::setYFlip(bool enabled)
 {
-    this->tileYFlip = (state == Qt::Checked);
+    this->tileYFlip = enabled;
     this->tileSelector->setTileFlips(this->tileXFlip, this->tileYFlip);
     this->drawSelectedTiles();
     this->metatileLayersItem->clearLastModifiedCoords();

--- a/src/ui/updatepromoter.cpp
+++ b/src/ui/updatepromoter.cpp
@@ -19,7 +19,11 @@ UpdatePromoter::UpdatePromoter(QWidget *parent, NetworkAccessManager *manager)
     // Set up "Do not alert me" check box
     this->updatePreferences();
     ui->checkBox_StopAlerts->setVisible(false);
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 7, 0))
+    connect(ui->checkBox_StopAlerts, &QCheckBox::checkStateChanged, [this](Qt::CheckState state) {
+#else
     connect(ui->checkBox_StopAlerts, &QCheckBox::stateChanged, [this](int state) {
+#endif
         porymapConfig.checkForUpdates = (state != Qt::Checked);
         emit this->changedPreferences();
     });

--- a/src/ui/updatepromoter.cpp
+++ b/src/ui/updatepromoter.cpp
@@ -19,12 +19,8 @@ UpdatePromoter::UpdatePromoter(QWidget *parent, NetworkAccessManager *manager)
     // Set up "Do not alert me" check box
     this->updatePreferences();
     ui->checkBox_StopAlerts->setVisible(false);
-#if (QT_VERSION >= QT_VERSION_CHECK(6, 7, 0))
-    connect(ui->checkBox_StopAlerts, &QCheckBox::checkStateChanged, [this](Qt::CheckState state) {
-#else
-    connect(ui->checkBox_StopAlerts, &QCheckBox::stateChanged, [this](int state) {
-#endif
-        porymapConfig.checkForUpdates = (state != Qt::Checked);
+    connect(ui->checkBox_StopAlerts, &QCheckBox::toggled, [this](bool stopAlerts) {
+        porymapConfig.checkForUpdates = !stopAlerts;
         emit this->changedPreferences();
     });
 


### PR DESCRIPTION
Add version checks to replace functions that are deprecated as of Qt version 6.9.

As a side note, Qt's LTS for 5.15 ends May 26. If we want to bump the minimum required Qt version to 6.0, we'll lose support for the following platforms:
- Windows 7, 8
- Ubuntu 18.04, 20.04
- RHEL 7.6, 8.6
- openSUSE 15.4
- macOS 10.13, 10.14, 10.15

All these platforms are themselves no longer maintained, with the exception of Ubuntu 20.04 (which ends May 31).