### PR TITLE
Better error handling if saving fails

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -26,7 +26,7 @@ static const QVersionNumber porymapVersion = QVersionNumber::fromString(PORYMAP_
 class KeyValueConfigBase
 {
 public:
-    void save();
+    bool save();
     void load();
     virtual ~KeyValueConfigBase();
     virtual void reset() = 0;

--- a/include/core/maplayout.h
+++ b/include/core/maplayout.h
@@ -116,8 +116,11 @@ public:
     void clearBorderCache();
     void cacheBorder();
 
-    void setClean();
     bool hasUnsavedChanges() const;
+
+    bool save(const QString &root);
+    bool saveBorder(const QString &root);
+    bool saveBlockdata(const QString &root);
 
     bool layoutBlockChanged(int i, const Blockdata &cache);
 
@@ -143,6 +146,7 @@ public:
 private:
     void setNewDimensionsBlockdata(int newWidth, int newHeight);
     void setNewBorderDimensionsBlockdata(int newWidth, int newHeight);
+    bool writeBlockdata(const QString &path, const Blockdata &blockdata) const;
 
     static int getBorderDrawDistance(int dimension, qreal minimum);
 

--- a/include/core/paletteutil.h
+++ b/include/core/paletteutil.h
@@ -7,7 +7,7 @@
 
 namespace PaletteUtil {
     QList<QRgb> parse(QString filepath, bool *error);
-    void writeJASC(QString filepath, QVector<QRgb> colors, int offset, int nColors);
+    bool writeJASC(const QString &filepath, const QVector<QRgb> &colors, int offset, int nColors);
 }
 
 #endif // PALETTEUTIL_H

--- a/include/core/tileset.h
+++ b/include/core/tileset.h
@@ -55,17 +55,17 @@ public:
     static QString getExpectedDir(QString tilesetName, bool isSecondary);
     QString getExpectedDir();
 
-    void load();
-    void loadMetatiles();
-    void loadMetatileAttributes();
-    void loadTilesImage(QImage *importedImage = nullptr);
-    void loadPalettes();
+    bool load();
+    bool loadMetatiles();
+    bool loadMetatileAttributes();
+    bool loadTilesImage(QImage *importedImage = nullptr);
+    bool loadPalettes();
 
-    void save();
-    void saveMetatileAttributes();
-    void saveMetatiles();
-    void saveTilesImage();
-    void savePalettes();
+    bool save();
+    bool saveMetatileAttributes();
+    bool saveMetatiles();
+    bool saveTilesImage();
+    bool savePalettes();
 
     bool appendToHeaders(QString root, QString friendlyName, bool usingAsm);
     bool appendToGraphics(QString root, QString friendlyName, bool usingAsm);

--- a/include/editor.h
+++ b/include/editor.h
@@ -57,8 +57,8 @@ public:
     GridSettings gridSettings;
 
     void setProject(Project * project);
-    void saveAll();
-    void saveCurrent();
+    bool saveAll();
+    bool saveCurrent();
     void saveEncounterTabData();
 
     void closeProject();
@@ -199,7 +199,7 @@ private:
 
     EditMode editMode = EditMode::None;
 
-    void save(bool currentOnly);
+    bool save(bool currentOnly);
     void clearMap();
     void clearMetatileSelector();
     void clearMovementPermissionSelector();

--- a/include/mainwindow.h
+++ b/include/mainwindow.h
@@ -175,7 +175,7 @@ private slots:
     void on_action_Reload_Project_triggered();
     void on_action_Close_Project_triggered();
     void on_action_Save_Project_triggered();
-    void save(bool currentOnly = false);
+    bool save(bool currentOnly = false);
 
     void openWarpMap(QString map_name, int event_id, Event::Group event_group);
 

--- a/include/project.h
+++ b/include/project.h
@@ -108,10 +108,6 @@ public:
     bool loadBlockdata(Layout *);
     bool loadLayoutBorder(Layout *);
 
-    void saveTextFile(QString path, QString text);
-    void appendTextFile(QString path, QString text);
-    void deleteFile(QString path);
-
     bool readMapGroups();
     void addNewMapGroup(const QString &groupName);
     QString mapNameToMapGroup(const QString &mapName) const;
@@ -168,25 +164,20 @@ public:
     bool loadLayout(Layout *);
     bool loadMapLayout(Map*);
     bool loadLayoutTilesets(Layout *);
-    void loadTilesetAssets(Tileset*);
+    bool loadTilesetAssets(Tileset*);
     void loadTilesetMetatileLabels(Tileset*);
     void readTilesetPaths(Tileset* tileset);
 
-    void saveAll();
-    void saveGlobalData();
-    void saveLayout(Layout *);
-    void saveLayoutBlockdata(Layout *);
-    void saveLayoutBorder(Layout *);
-    void writeBlockdata(QString, const Blockdata &);
-    void saveMap(Map *map, bool skipLayout = false);
-    void saveConfig();
-    void saveMapLayouts();
-    void saveMapGroups();
-    void saveRegionMapSections();
-    void saveWildMonData();
-    void saveHealLocations();
-    void saveTilesets(Tileset*, Tileset*);
-    void saveTilesetMetatileLabels(Tileset*, Tileset*);
+    bool saveAll();
+    bool saveGlobalData();
+    bool saveConfig();
+    bool saveLayout(Layout *layout);
+    bool saveMap(Map *map, bool skipLayout = false);
+    bool saveTextFile(const QString &path, const QString &text);
+    bool saveRegionMapSections();
+    bool saveTilesets(Tileset*, Tileset*);
+    bool saveTilesetMetatileLabels(Tileset*, Tileset*);
+
     void appendTilesetLabel(const QString &label, const QString &isSecondaryStr);
     bool readTilesetLabels();
     bool readTilesetMetatileLabels();
@@ -309,14 +300,18 @@ private:
     };
     QHash<QString, LocationData> locationData;
 
-    void updateLayout(Layout *);
-
     void setNewLayoutBlockdata(Layout *layout);
     void setNewLayoutBorder(Layout *layout);
 
     void ignoreWatchedFileTemporarily(QString filepath);
     void recordFileChange(const QString &filepath);
     void resetFileCache();
+
+    bool saveMapLayouts();
+    bool saveMapGroups();
+    bool saveWildMonData();
+    bool saveHealLocations();
+    bool appendTextFile(const QString &path, const QString &text);
 
     QString findSpeciesIconPath(const QStringList &names) const;
 

--- a/include/ui/tileseteditor.h
+++ b/include/ui/tileseteditor.h
@@ -71,8 +71,6 @@ private slots:
 
     void on_spinBox_paletteSelector_valueChanged(int arg1);
 
-    void on_actionSave_Tileset_triggered();
-
     void on_actionImport_Primary_Tiles_triggered();
 
     void on_actionImport_Secondary_Tiles_triggered();
@@ -172,6 +170,8 @@ private:
     QGraphicsScene *metatileLayersScene = nullptr;
     bool lockSelection = false;
     QSet<uint16_t> metatileReloadQueue;
+
+    bool save();
 
 signals:
     void tilesetsSaved(QString, QString);

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -233,7 +233,7 @@ void KeyValueConfigBase::load() {
     file.close();
 }
 
-void KeyValueConfigBase::save() {
+bool KeyValueConfigBase::save() {
     QString text = "";
     QMap<QString, QString> map = this->getKeyValueMap();
     for (QMap<QString, QString>::iterator it = map.begin(); it != map.end(); it++) {
@@ -241,12 +241,14 @@ void KeyValueConfigBase::save() {
     }
 
     QFile file(this->getConfigFilepath());
-    if (file.open(QIODevice::WriteOnly)) {
-        file.write(text.toUtf8());
-        file.close();
-    } else {
+    if (!file.open(QIODevice::WriteOnly)) {
         logError(QString("Could not open config file '%1' for writing: ").arg(this->getConfigFilepath()) + file.errorString());
+        return false;
     }
+
+    file.write(text.toUtf8());
+    file.close();
+    return true;
 }
 
 bool KeyValueConfigBase::getConfigBool(QString key, QString value) {

--- a/src/core/paletteutil.cpp
+++ b/src/core/paletteutil.cpp
@@ -38,14 +38,14 @@ QList<QRgb> PaletteUtil::parse(QString filepath, bool *error) {
     return QList<QRgb>();
 }
 
-void PaletteUtil::writeJASC(QString filepath, QVector<QRgb> palette, int offset, int nColors) {
+bool PaletteUtil::writeJASC(const QString &filepath, const QVector<QRgb> &palette, int offset, int nColors) {
     if (!nColors) {
-        logWarn(QString("Cannot save a palette with no colors."));
-        return;
+        logError(QString("Cannot save a palette with no colors."));
+        return false;
     }
     if (offset > palette.size() || offset + nColors > palette.size()) {
-        logWarn("Palette offset out of range for color table.");
-        return;
+        logError("Palette offset out of range for color table.");
+        return false;
     }
 
     QString text = "JASC-PAL\r\n0100\r\n";
@@ -59,11 +59,13 @@ void PaletteUtil::writeJASC(QString filepath, QVector<QRgb> palette, int offset,
     }
 
     QFile file(filepath);
-    if (file.open(QIODevice::WriteOnly)) {
-        file.write(text.toUtf8());
-    } else {
-        logWarn(QString("Could not write to file '%1': ").arg(filepath) + file.errorString());
+    if (!file.open(QIODevice::WriteOnly)) {
+        logError(QString("Could not write to file '%1': ").arg(filepath) + file.errorString());
+        return false;
     }
+
+    file.write(text.toUtf8());
+    return true;
 }
 
 QList<QRgb> parsePal(QString filepath, bool *error) {

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -68,30 +68,33 @@ Editor::~Editor()
     closeProject();
 }
 
-void Editor::saveCurrent() {
-    save(true);
+bool Editor::saveCurrent() {
+    return save(true);
 }
 
-void Editor::saveAll() {
-    save(false);
+bool Editor::saveAll() {
+    return save(false);
 }
 
-void Editor::save(bool currentOnly) {
+bool Editor::save(bool currentOnly) {
     if (!this->project)
-        return;
+        return true;
 
     saveEncounterTabData();
 
+    bool success = true;
     if (currentOnly) {
         if (this->map) {
-            this->project->saveMap(this->map);
+            success = this->project->saveMap(this->map);
         } else if (this->layout) {
-            this->project->saveLayout(this->layout);
+            success = this->project->saveLayout(this->layout);
         }
-        this->project->saveGlobalData();
+        if (!this->project->saveGlobalData())
+            success = false;
     } else {
-        this->project->saveAll();
+        success = this->project->saveAll();
     }
+    return success;
 }
 
 void Editor::setProject(Project * project) {


### PR DESCRIPTION
- If `File -> Save` / `File -> Save All` fail for any reason, display an error message to the user.
- If saving from a "save changes before closing?" prompt fails (either for the project or the tileset editor) then abort closing.
- Add details to some of the logging when file writing fails.

Prior to this the only indication that saving had partially or fully failed would be if the user checked the log file.