### PR TITLE
Fix some issues from the Connections tab redesign

### DIFF
--- a/forms/mainwindow.ui
+++ b/forms/mainwindow.ui
@@ -2429,6 +2429,9 @@
                   </item>
                   <item row="1" column="0">
                    <widget class="QToolButton" name="button_OpenDiveMap">
+                    <property name="enabled">
+                     <bool>false</bool>
+                    </property>
                     <property name="toolTip">
                      <string>Open the selected Dive Map</string>
                     </property>
@@ -2563,6 +2566,9 @@
                   </item>
                   <item row="0" column="0">
                    <widget class="QToolButton" name="button_OpenEmergeMap">
+                    <property name="enabled">
+                     <bool>false</bool>
+                    </property>
                     <property name="toolTip">
                      <string>Open the selected Emerge Map</string>
                     </property>

--- a/forms/mainwindow.ui
+++ b/forms/mainwindow.ui
@@ -2589,7 +2589,7 @@
                  <property name="orientation">
                   <enum>Qt::Orientation::Horizontal</enum>
                  </property>
-                 <widget class="QGraphicsView" name="graphicsView_Connections">
+                 <widget class="ConnectionsView" name="graphicsView_Connections">
                   <property name="sizePolicy">
                    <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
                     <horstretch>0</horstretch>
@@ -3310,8 +3310,13 @@
   </customwidget>
   <customwidget>
    <class>MapView</class>
-   <extends>QWidget</extends>
+   <extends>QGraphicsView</extends>
    <header>mapview.h</header>
+  </customwidget>
+  <customwidget>
+   <class>ConnectionsView</class>
+   <extends>QGraphicsView</extends>
+   <header>graphicsview.h</header>
   </customwidget>
   <customwidget>
    <class>MapTree</class>
@@ -3321,7 +3326,7 @@
   <customwidget>
    <class>NoScrollGraphicsView</class>
    <extends>QGraphicsView</extends>
-   <header>mapview.h</header>
+   <header>graphicsview.h</header>
   </customwidget>
   <customwidget>
    <class>MapListToolBar</class>

--- a/forms/mainwindow.ui
+++ b/forms/mainwindow.ui
@@ -351,12 +351,6 @@
                      <property name="autoFillBackground">
                       <bool>false</bool>
                      </property>
-                     <property name="transformationAnchor">
-                      <enum>QGraphicsView::ViewportAnchor::AnchorUnderMouse</enum>
-                     </property>
-                     <property name="resizeAnchor">
-                      <enum>QGraphicsView::ViewportAnchor::AnchorUnderMouse</enum>
-                     </property>
                     </widget>
                    </item>
                   </layout>

--- a/include/core/map.h
+++ b/include/core/map.h
@@ -87,6 +87,7 @@ public:
 
     void deleteConnections();
     QList<MapConnection*> getConnections() const { return m_connections; }
+    MapConnection* getConnection(const QString &direction) const;
     void removeConnection(MapConnection *);
     void addConnection(MapConnection *);
     void loadConnection(MapConnection *);

--- a/include/editor.h
+++ b/include/editor.h
@@ -98,8 +98,8 @@ public:
     void deleteWildMonGroup();
     void configureEncounterJSON(QWidget *);
     EncounterTableModel* getCurrentWildMonTable();
-    void updateDiveMap(QString mapName);
-    void updateEmergeMap(QString mapName);
+    bool setDivingMapName(const QString &mapName, const QString &direction);
+    QString getDivingMapName(const QString &direction) const;
     void setSelectedConnection(MapConnection *connection);
 
     void updatePrimaryTileset(QString tilesetLabel, bool forceLoad = false);
@@ -218,8 +218,9 @@ private:
     void removeConnectionPixmap(MapConnection *connection);
     void displayConnection(MapConnection *connection);
     void displayDivingConnection(MapConnection *connection);
-    void setDivingMapName(QString mapName, QString direction);
     void removeDivingMapPixmap(MapConnection *connection);
+    void onDivingMapEditingFinished(NoScrollComboBox* combo, const QString &direction);
+    void updateDivingMapButton(QToolButton* button, const QString &mapName);
     void updateEncounterFields(EncounterFields newFields);
     QString getMovementPermissionText(uint16_t collision, uint16_t elevation);
     QString getMetatileDisplayMessage(uint16_t metatileId);

--- a/include/editor.h
+++ b/include/editor.h
@@ -92,7 +92,8 @@ public:
     void setConnectionsVisibility(bool visible);
     void updateDivingMapsVisibility();
     void renderDivingConnections();
-    void addConnection(MapConnection* connection);
+    void addNewConnection(const QString &mapName, const QString &direction);
+    void replaceConnection(const QString &mapName, const QString &direction);
     void removeConnection(MapConnection* connection);
     void addNewWildMonGroup(QWidget *window);
     void deleteWildMonGroup();

--- a/include/editor.h
+++ b/include/editor.h
@@ -95,6 +95,7 @@ public:
     void addNewConnection(const QString &mapName, const QString &direction);
     void replaceConnection(const QString &mapName, const QString &direction);
     void removeConnection(MapConnection* connection);
+    void removeSelectedConnection();
     void addNewWildMonGroup(QWidget *window);
     void deleteWildMonGroup();
     void configureEncounterJSON(QWidget *);

--- a/include/mainwindow.h
+++ b/include/mainwindow.h
@@ -243,8 +243,6 @@ private slots:
     void on_pushButton_AddConnection_clicked();
     void on_button_OpenDiveMap_clicked();
     void on_button_OpenEmergeMap_clicked();
-    void on_comboBox_DiveMap_currentTextChanged(const QString &mapName);
-    void on_comboBox_EmergeMap_currentTextChanged(const QString &mapName);
     void on_comboBox_PrimaryTileset_currentTextChanged(const QString &arg1);
     void on_comboBox_SecondaryTileset_currentTextChanged(const QString &arg1);
     void on_pushButton_ChangeDimensions_clicked();

--- a/include/ui/connectionpixmapitem.h
+++ b/include/ui/connectionpixmapitem.h
@@ -43,8 +43,6 @@ protected:
     virtual void mousePressEvent(QGraphicsSceneMouseEvent*) override;
     virtual void mouseReleaseEvent(QGraphicsSceneMouseEvent*) override;
     virtual void mouseDoubleClickEvent(QGraphicsSceneMouseEvent*) override;
-    virtual void keyPressEvent(QKeyEvent*) override;
-    virtual void focusInEvent(QFocusEvent*) override;
 
 signals:
     void connectionItemDoubleClicked(MapConnection*);

--- a/include/ui/connectionslistitem.h
+++ b/include/ui/connectionslistitem.h
@@ -36,7 +36,6 @@ private:
 
 protected:
     virtual void mousePressEvent(QMouseEvent*) override;
-    virtual void keyPressEvent(QKeyEvent*) override;
     virtual bool eventFilter(QObject*, QEvent *event) override;
 
 signals:

--- a/include/ui/connectionslistitem.h
+++ b/include/ui/connectionslistitem.h
@@ -36,19 +36,18 @@ private:
 
 protected:
     virtual void mousePressEvent(QMouseEvent*) override;
-    virtual void focusInEvent(QFocusEvent*) override;
     virtual void keyPressEvent(QKeyEvent*) override;
+    virtual bool eventFilter(QObject*, QEvent *event) override;
 
 signals:
     void selected();
     void openMapClicked(MapConnection*);
 
-private slots:
-    void on_comboBox_Direction_currentTextChanged(QString direction);
-    void on_comboBox_Map_currentTextChanged(QString mapName);
-    void on_spinBox_Offset_valueChanged(int offset);
-    void on_button_Delete_clicked();
-    void on_button_OpenMap_clicked();
+private:
+    void commitDirection();
+    void commitMap(const QString &mapName);
+    void commitMove(int offset);
+    void commitRemove();
 };
 
 #endif // CONNECTIONSLISTITEM_H

--- a/include/ui/graphicsview.h
+++ b/include/ui/graphicsview.h
@@ -32,6 +32,19 @@ signals:
     void clicked(QMouseEvent *event);
 };
 
+class ConnectionsView : public QGraphicsView
+{
+    Q_OBJECT
+public:
+    ConnectionsView(QWidget *parent = nullptr) : QGraphicsView(parent) {}
+
+signals:
+    void pressedDelete();
+
+protected:
+    virtual void keyPressEvent(QKeyEvent *event) override;
+};
+
 class Editor;
 
 // TODO: This should just be MapView. It makes map-based assumptions, and no other class inherits GraphicsView.

--- a/include/ui/newmapconnectiondialog.h
+++ b/include/ui/newmapconnectiondialog.h
@@ -20,13 +20,16 @@ public:
     virtual void accept() override;
 
 signals:
-    void accepted(MapConnection *result);
+    void newConnectionedAdded(const QString &mapName, const QString &direction);
+    void connectionReplaced(const QString &mapName, const QString &direction);
 
 private:
     Ui::NewMapConnectionDialog *ui;
+    Map *m_map;
 
     bool mapNameIsValid();
     void setWarningVisible(bool visible);
+    bool askReplaceConnection(MapConnection *connection, const QString &newMapName);
 };
 
 #endif // NEWMAPCONNECTIONDIALOG_H

--- a/include/ui/noscrollcombobox.h
+++ b/include/ui/noscrollcombobox.h
@@ -18,6 +18,9 @@ public:
     void setLineEdit(QLineEdit *edit);
     void setFocusedScrollingEnabled(bool enabled);
 
+signals:
+    void editingFinished();
+
 private:
     void setItem(int index, const QString &text);
 

--- a/src/core/map.cpp
+++ b/src/core/map.cpp
@@ -288,6 +288,15 @@ void Map::removeConnection(MapConnection *connection) {
     emit connectionRemoved(connection);
 }
 
+// Return the first map connection that has the given direction.
+MapConnection* Map::getConnection(const QString &direction) const {
+    for (const auto &connection : m_connections) {
+        if (connection->direction() == direction)
+            return connection;
+    }
+    return nullptr;
+}
+
 void Map::commit(QUndoCommand *cmd) {
     m_editHistory->push(cmd);
 }

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -818,19 +818,32 @@ void Editor::displayConnection(MapConnection *connection) {
     }
 }
 
-void Editor::addConnection(MapConnection *connection) {
-    if (!connection)
+void Editor::addNewConnection(const QString &mapName, const QString &direction) {
+    if (!this->map)
         return;
+
+    MapConnection *connection = new MapConnection(mapName, direction);
 
     // Mark this connection to be selected once its display elements have been created.
     // It's possible this is a Dive/Emerge connection, but that's ok (no selection will occur).
-    connection_to_select = connection;
+    this->connection_to_select = connection;
 
     this->map->commit(new MapConnectionAdd(this->map, connection));
 }
 
+void Editor::replaceConnection(const QString &mapName, const QString &direction) {
+    if (!this->map)
+        return;
+
+    MapConnection *connection = this->map->getConnection(direction);
+    if (!connection || connection->targetMapName() == mapName)
+        return;
+
+    this->map->commit(new MapConnectionChangeMap(connection, mapName));
+}
+
 void Editor::removeConnection(MapConnection *connection) {
-    if (!connection)
+    if (!this->map || !connection)
         return;
     this->map->commit(new MapConnectionRemove(this->map, connection));
 }
@@ -948,7 +961,7 @@ bool Editor::setDivingMapName(const QString &mapName, const QString &direction) 
         }
     } else if (!mapName.isEmpty()) {
         // Create new connection
-        addConnection(new MapConnection(mapName, direction));
+        addNewConnection(mapName, direction);
     }
     return true;
 }

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -848,6 +848,11 @@ void Editor::removeConnection(MapConnection *connection) {
     this->map->commit(new MapConnectionRemove(this->map, connection));
 }
 
+void Editor::removeSelectedConnection() {
+    if (selected_connection_item)
+        removeConnection(selected_connection_item->connection);
+}
+
 void Editor::removeConnectionPixmap(MapConnection *connection) {
     if (!connection)
         return;

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -2588,7 +2588,8 @@ void MainWindow::on_pushButton_AddConnection_clicked() {
         return;
 
     auto dialog = new NewMapConnectionDialog(this, this->editor->map, this->editor->project->mapNames);
-    connect(dialog, &NewMapConnectionDialog::accepted, this->editor, &Editor::addConnection);
+    connect(dialog, &NewMapConnectionDialog::newConnectionedAdded, this->editor, &Editor::addNewConnection);
+    connect(dialog, &NewMapConnectionDialog::connectionReplaced, this->editor, &Editor::replaceConnection);
     dialog->open();
 }
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1217,10 +1217,7 @@ void MainWindow::clearProjectUI() {
     const QSignalBlocker b_SecondaryTileset(ui->comboBox_SecondaryTileset);
     ui->comboBox_SecondaryTileset->clear();
 
-    const QSignalBlocker b_DiveMap(ui->comboBox_DiveMap);
     ui->comboBox_DiveMap->clear();
-
-    const QSignalBlocker b_EmergeMap(ui->comboBox_EmergeMap);
     ui->comboBox_EmergeMap->clear();
 
     const QSignalBlocker b_LayoutSelector(ui->comboBox_LayoutSelector);
@@ -1381,8 +1378,6 @@ void MainWindow::onNewMapCreated(Map *newMap, const QString &groupName) {
     // (other combo boxes like for warp destinations are repopulated when the map changes).
     int mapIndex = this->editor->project->mapNames.indexOf(newMap->name());
     if (mapIndex >= 0) {
-        const QSignalBlocker b_DiveMap(ui->comboBox_DiveMap);
-        const QSignalBlocker b_EmergeMap(ui->comboBox_EmergeMap);
         ui->comboBox_DiveMap->insertItem(mapIndex, newMap->name());
         ui->comboBox_EmergeMap->insertItem(mapIndex, newMap->name());
     }
@@ -2644,17 +2639,6 @@ void MainWindow::on_button_OpenDiveMap_clicked() {
 
 void MainWindow::on_button_OpenEmergeMap_clicked() {
     userSetMap(ui->comboBox_EmergeMap->currentText());
-}
-
-void MainWindow::on_comboBox_DiveMap_currentTextChanged(const QString &mapName) {
-    // Include empty names as an update (user is deleting the connection)
-    if (mapName.isEmpty() || editor->project->mapNames.contains(mapName))
-        editor->updateDiveMap(mapName);
-}
-
-void MainWindow::on_comboBox_EmergeMap_currentTextChanged(const QString &mapName) {
-    if (mapName.isEmpty() || editor->project->mapNames.contains(mapName))
-        editor->updateEmergeMap(mapName);
 }
 
 void MainWindow::on_comboBox_PrimaryTileset_currentTextChanged(const QString &tilesetLabel)

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -352,6 +352,7 @@ void MainWindow::initEditor() {
     connect(this->editor, &Editor::tilesetUpdated, this, &Scripting::cb_TilesetUpdated);
     connect(ui->newEventToolButton, &NewEventToolButton::newEventAdded, this->editor, &Editor::addNewEvent);
     connect(ui->toolButton_deleteEvent, &QAbstractButton::clicked, this->editor, &Editor::deleteSelectedEvents);
+    connect(ui->graphicsView_Connections, &ConnectionsView::pressedDelete, this->editor, &Editor::removeSelectedConnection);
 
     this->loadUserSettings();
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -261,6 +261,10 @@ void MainWindow::initCustomUI() {
     // Create map header data widget
     this->mapHeaderForm = new MapHeaderForm();
     ui->layout_HeaderData->addWidget(this->mapHeaderForm);
+
+    // Center zooming on the mouse
+    ui->graphicsView_Map->setTransformationAnchor(QGraphicsView::ViewportAnchor::AnchorUnderMouse);
+    ui->graphicsView_Map->setResizeAnchor(QGraphicsView::ViewportAnchor::AnchorUnderMouse);
 }
 
 void MainWindow::initExtraSignals() {

--- a/src/ui/connectionpixmapitem.cpp
+++ b/src/ui/connectionpixmapitem.cpp
@@ -9,7 +9,6 @@ ConnectionPixmapItem::ConnectionPixmapItem(MapConnection* connection)
       connection(connection)
 {
     this->setEditable(true);
-    setFlag(ItemIsFocusable, true);
     this->basePixmap = pixmap();
     updateOrigin();
     render(false);
@@ -118,10 +117,6 @@ bool ConnectionPixmapItem::getEditable() {
 }
 
 void ConnectionPixmapItem::setSelected(bool selected) {
-    if (selected && !hasFocus()) {
-        setFocus(Qt::OtherFocusReason);
-    }
-
     if (this->selected == selected)
         return;
     this->selected = selected;
@@ -131,7 +126,7 @@ void ConnectionPixmapItem::setSelected(bool selected) {
 }
 
 void ConnectionPixmapItem::mousePressEvent(QGraphicsSceneMouseEvent *) {
-    setFocus(Qt::MouseFocusReason);
+    this->setSelected(true);
 }
 
 void ConnectionPixmapItem::mouseReleaseEvent(QGraphicsSceneMouseEvent *event) {
@@ -141,21 +136,4 @@ void ConnectionPixmapItem::mouseReleaseEvent(QGraphicsSceneMouseEvent *event) {
 
 void ConnectionPixmapItem::mouseDoubleClickEvent(QGraphicsSceneMouseEvent *) {
     emit connectionItemDoubleClicked(this->connection);
-}
-
-// TODO: Rather than listening for this here and on the list item, listen for it on the connections graphics view,
-//       and delete whichever map connections are currently selected. This should fix our weird focus requirements in here.
-void ConnectionPixmapItem::keyPressEvent(QKeyEvent* event) {
-    if (event->key() == Qt::Key_Delete || event->key() == Qt::Key_Backspace) {
-        emit deleteRequested(this->connection);
-    } else {
-        QGraphicsPixmapItem::keyPressEvent(event);
-    }
-}
-
-void ConnectionPixmapItem::focusInEvent(QFocusEvent* event) {
-    if (!this->getEditable())
-        return;
-    this->setSelected(true);
-    QGraphicsPixmapItem::focusInEvent(event);
 }

--- a/src/ui/connectionpixmapitem.cpp
+++ b/src/ui/connectionpixmapitem.cpp
@@ -143,6 +143,8 @@ void ConnectionPixmapItem::mouseDoubleClickEvent(QGraphicsSceneMouseEvent *) {
     emit connectionItemDoubleClicked(this->connection);
 }
 
+// TODO: Rather than listening for this here and on the list item, listen for it on the connections graphics view,
+//       and delete whichever map connections are currently selected. This should fix our weird focus requirements in here.
 void ConnectionPixmapItem::keyPressEvent(QKeyEvent* event) {
     if (event->key() == Qt::Key_Delete || event->key() == Qt::Key_Backspace) {
         emit deleteRequested(this->connection);

--- a/src/ui/connectionslistitem.cpp
+++ b/src/ui/connectionslistitem.cpp
@@ -100,7 +100,17 @@ void ConnectionsListItem::mousePressEvent(QMouseEvent *) {
 
 void ConnectionsListItem::commitDirection() {
     const QString direction = ui->comboBox_Direction->currentText();
-    if (this->map && this->connection && this->connection->direction() != direction) {
+    if (!this->connection || this->connection->direction() == direction)
+        return;
+
+    if (MapConnection::isDiving(direction)) {
+        // Diving maps are displayed separately, no support right now for replacing a list item with a diving map.
+        // For now just restore the original direction.
+        ui->comboBox_Direction->setCurrentText(this->connection->direction());
+        return;
+    }
+
+    if (this->map) {
         this->map->commit(new MapConnectionChangeDirection(this->connection, direction));
     }
 }

--- a/src/ui/connectionslistitem.cpp
+++ b/src/ui/connectionslistitem.cpp
@@ -46,7 +46,7 @@ ConnectionsListItem::ConnectionsListItem(QWidget *parent, MapConnection * connec
     ui->spinBox_Offset->installEventFilter(this);
 
     connect(ui->spinBox_Offset, &QSpinBox::editingFinished, [this] { this->actionId++; }); // Distinguish between move actions for the edit history
-    connect(ui->spinBox_Offset, &QSpinBox::valueChanged, this, &ConnectionsListItem::commitMove);
+    connect(ui->spinBox_Offset, QOverload<int>::of(&QSpinBox::valueChanged), this, &ConnectionsListItem::commitMove);
 
     // If the connection changes externally we want to update to reflect the change.
     connect(connection, &MapConnection::offsetChanged, this, &ConnectionsListItem::updateUI);

--- a/src/ui/connectionslistitem.cpp
+++ b/src/ui/connectionslistitem.cpp
@@ -129,12 +129,3 @@ void ConnectionsListItem::commitRemove() {
     if (this->map)
         this->map->commit(new MapConnectionRemove(this->map, this->connection));
 }
-
-void ConnectionsListItem::keyPressEvent(QKeyEvent* event) {
-    if (event->key() == Qt::Key_Delete || event->key() == Qt::Key_Backspace) {
-        commitRemove();
-        event->accept();
-    } else {
-        QFrame::keyPressEvent(event);
-    }
-}

--- a/src/ui/connectionslistitem.cpp
+++ b/src/ui/connectionslistitem.cpp
@@ -20,9 +20,7 @@ ConnectionsListItem::ConnectionsListItem(QWidget *parent, MapConnection * connec
     ui->comboBox_Direction->addItems(MapConnection::cardinalDirections);
     ui->comboBox_Direction->installEventFilter(this);
 
-    // We don't use QComboBox::currentTextChanged here to avoid unnecessary commits while typing.
-    connect(ui->comboBox_Direction, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &ConnectionsListItem::commitDirection);
-    connect(ui->comboBox_Direction->lineEdit(), &QLineEdit::editingFinished, this, &ConnectionsListItem::commitDirection);
+    connect(ui->comboBox_Direction, &NoScrollComboBox::editingFinished, this, &ConnectionsListItem::commitDirection);
 
     // Map
     const QSignalBlocker b_Map(ui->comboBox_Map);
@@ -32,7 +30,6 @@ ConnectionsListItem::ConnectionsListItem(QWidget *parent, MapConnection * connec
     ui->comboBox_Map->setInsertPolicy(QComboBox::NoInsert);
     ui->comboBox_Map->installEventFilter(this);
 
-    // The map combo box only commits the change if it's a valid map name, so unlike Direction we can use QComboBox::currentTextChanged.
     connect(ui->comboBox_Map, &QComboBox::currentTextChanged, this, &ConnectionsListItem::commitMap);
 
     // Invalid map names are not considered a change. If editing finishes with an invalid name, restore the previous name.

--- a/src/ui/divingmappixmapitem.cpp
+++ b/src/ui/divingmappixmapitem.cpp
@@ -38,9 +38,5 @@ void DivingMapPixmapItem::onTargetMapChanged() {
 }
 
 void DivingMapPixmapItem::setComboText(const QString &text) {
-    if (!m_combo)
-        return;
-
-    const QSignalBlocker blocker(m_combo);
-    m_combo->setCurrentText(text);
+    if (m_combo) m_combo->setCurrentText(text);
 }

--- a/src/ui/graphicsview.cpp
+++ b/src/ui/graphicsview.cpp
@@ -79,3 +79,12 @@ Overlay * MapView::getOverlay(int layer) {
     }
     return overlay;
 }
+
+void ConnectionsView::keyPressEvent(QKeyEvent *event) {
+    if (event->key() == Qt::Key_Delete || event->key() == Qt::Key_Backspace) {
+        emit pressedDelete();
+        event->accept();
+    } else {
+        QGraphicsView::keyPressEvent(event);
+    }
+}

--- a/src/ui/mapimageexporter.cpp
+++ b/src/ui/mapimageexporter.cpp
@@ -55,10 +55,7 @@ MapImageExporter::MapImageExporter(QWidget *parent, Project *project, Map *map, 
     connect(ui->pushButton_Save,   &QPushButton::pressed, this, &MapImageExporter::saveImage);
     connect(ui->pushButton_Cancel, &QPushButton::pressed, this, &MapImageExporter::close);
 
-    // Update the map selector when the text changes.
-    // We don't use QComboBox::currentTextChanged to avoid unnecessary re-rendering.
-    connect(ui->comboBox_MapSelection, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &MapImageExporter::updateMapSelection);
-    connect(ui->comboBox_MapSelection->lineEdit(), &QLineEdit::editingFinished, this, &MapImageExporter::updateMapSelection);
+    connect(ui->comboBox_MapSelection, &NoScrollComboBox::editingFinished, this, &MapImageExporter::updateMapSelection);
 
     connect(ui->checkBox_Objects,               &QCheckBox::toggled, this, &MapImageExporter::setShowObjects);
     connect(ui->checkBox_Warps,                 &QCheckBox::toggled, this, &MapImageExporter::setShowWarps);

--- a/src/ui/newlayoutform.cpp
+++ b/src/ui/newlayoutform.cpp
@@ -18,8 +18,8 @@ NewLayoutForm::NewLayoutForm(QWidget *parent)
     connect(ui->spinBox_MapWidth,  QOverload<int>::of(&QSpinBox::valueChanged), [=](int){ validateMapDimensions(); });
     connect(ui->spinBox_MapHeight, QOverload<int>::of(&QSpinBox::valueChanged), [=](int){ validateMapDimensions(); });
 
-    connect(ui->comboBox_PrimaryTileset->lineEdit(),   &QLineEdit::editingFinished, [this]{ validatePrimaryTileset(true); });
-    connect(ui->comboBox_SecondaryTileset->lineEdit(), &QLineEdit::editingFinished, [this]{ validateSecondaryTileset(true); });
+    connect(ui->comboBox_PrimaryTileset,   &NoScrollComboBox::editingFinished, [this]{ validatePrimaryTileset(true); });
+    connect(ui->comboBox_SecondaryTileset, &NoScrollComboBox::editingFinished, [this]{ validateSecondaryTileset(true); });
 }
 
 NewLayoutForm::~NewLayoutForm()

--- a/src/ui/newmapconnectiondialog.cpp
+++ b/src/ui/newmapconnectiondialog.cpp
@@ -8,7 +8,6 @@ NewMapConnectionDialog::NewMapConnectionDialog(QWidget *parent, Map* map, const 
     ui->setupUi(this);
     setAttribute(Qt::WA_DeleteOnClose);
 
-    ui->comboBox_Direction->setEditable(false);
     ui->comboBox_Direction->addItems(MapConnection::cardinalDirections);
 
     ui->comboBox_Map->addItems(mapNames);

--- a/src/ui/newmapconnectiondialog.cpp
+++ b/src/ui/newmapconnectiondialog.cpp
@@ -1,9 +1,11 @@
 #include "newmapconnectiondialog.h"
 #include "ui_newmapconnectiondialog.h"
+#include "message.h"
 
 NewMapConnectionDialog::NewMapConnectionDialog(QWidget *parent, Map* map, const QStringList &mapNames) :
     QDialog(parent),
-    ui(new Ui::NewMapConnectionDialog)
+    ui(new Ui::NewMapConnectionDialog),
+    m_map(map)
 {
     ui->setupUi(this);
     setAttribute(Qt::WA_DeleteOnClose);
@@ -15,7 +17,7 @@ NewMapConnectionDialog::NewMapConnectionDialog(QWidget *parent, Map* map, const 
 
     // Choose default direction
     QMap<QString, int> directionCounts;
-    for (auto connection : map->getConnections()) {
+    for (auto connection : m_map->getConnections()) {
         directionCounts[connection->direction()]++;
     }
     QString defaultDirection;
@@ -32,7 +34,7 @@ NewMapConnectionDialog::NewMapConnectionDialog(QWidget *parent, Map* map, const 
     QString defaultMapName;
     if (mapNames.isEmpty()) {
         defaultMapName = QString();
-    } else if (mapNames.first() == map->name() && mapNames.length() > 1) {
+    } else if (mapNames.first() == m_map->name() && mapNames.length() > 1) {
         // Prefer not to connect the map to itself
         defaultMapName = mapNames.at(1);
     } else {
@@ -61,11 +63,43 @@ void NewMapConnectionDialog::setWarningVisible(bool visible) {
     adjustSize();
 }
 
+bool NewMapConnectionDialog::askReplaceConnection(MapConnection *connection, const QString &newMapName) {
+    QString message = QString("%1 already has a %2 connection to '%3'. Replace it with a %2 connection to '%4'?")
+                                .arg(m_map->name())
+                                .arg(connection->direction())
+                                .arg(connection->targetMapName())
+                                .arg(newMapName);
+    return QuestionMessage::show(message, this) == QMessageBox::Yes;
+}
+
 void NewMapConnectionDialog::accept() {
     if (!mapNameIsValid()) {
         setWarningVisible(true);
         return;
     }
-    emit accepted(new MapConnection(ui->comboBox_Map->currentText(), ui->comboBox_Direction->currentText()));
+
+    const QString direction = ui->comboBox_Direction->currentText();
+    const QString targetMapName = ui->comboBox_Map->currentText();
+
+    // This is a very niche use case. Normally the user should add Dive/Emerge map connections using the line edits at the top of
+    // the Connections tab, but because we allow custom direction names in this dialog's Direction drop-down, a user could type
+    // in "dive" or "emerge" and we have to decide what to do. If there's no existing Dive/Emerge map we can just add it normally
+    // as if they had typed in the regular line edits. If there's already an existing connection we need to replace it.
+    if (MapConnection::isDiving(direction)) {
+        MapConnection *connection = m_map->getConnection(direction);
+        if (connection) {
+            if (connection->targetMapName() != targetMapName) {
+                if (!askReplaceConnection(connection, targetMapName))
+                    return; // Canceled
+                emit connectionReplaced(targetMapName, direction);
+            }
+            // Replaced the diving connection (or no-op, if adding a diving connection with the same map name)
+            QDialog::accept();
+            return;
+        }
+        // Adding a new diving connection that doesn't exist yet, proceed normally.
+    }
+
+    emit newConnectionedAdded(targetMapName, direction);
     QDialog::accept();
 }

--- a/src/ui/noscrollcombobox.cpp
+++ b/src/ui/noscrollcombobox.cpp
@@ -26,7 +26,7 @@ NoScrollComboBox::NoScrollComboBox(QWidget *parent)
 
     // QComboBox (as of writing) has no 'editing finished' signal to capture
     // changes made either through the text edit or the drop-down.
-    connect(this, &QComboBox::activated, this, &NoScrollComboBox::editingFinished);
+    connect(this, QOverload<int>::of(&QComboBox::activated), this, &NoScrollComboBox::editingFinished);
     connect(this->lineEdit(), &QLineEdit::editingFinished, this, &NoScrollComboBox::editingFinished);
 }
 

--- a/src/ui/noscrollcombobox.cpp
+++ b/src/ui/noscrollcombobox.cpp
@@ -23,6 +23,11 @@ NoScrollComboBox::NoScrollComboBox(QWidget *parent)
     static const QRegularExpression re("[^\\s]*");
     QValidator *validator = new QRegularExpressionValidator(re, this);
     this->setValidator(validator);
+
+    // QComboBox (as of writing) has no 'editing finished' signal to capture
+    // changes made either through the text edit or the drop-down.
+    connect(this, &QComboBox::activated, this, &NoScrollComboBox::editingFinished);
+    connect(this->lineEdit(), &QLineEdit::editingFinished, this, &NoScrollComboBox::editingFinished);
 }
 
 // On macOS QComboBox::setEditable and QComboBox::setLineEdit will override our changes to the focus policy, so we enforce it here.

--- a/src/ui/tileseteditor.cpp
+++ b/src/ui/tileseteditor.cpp
@@ -125,16 +125,10 @@ void TilesetEditor::setTilesets(QString primaryTilesetLabel, QString secondaryTi
 }
 
 void TilesetEditor::initAttributesUi() {
-    // Update the metatile's attributes values when the attribute combo boxes are edited.
-    // We avoid using the 'currentTextChanged' signal here, we want to know when we can clean up the input field and commit changes.
-    connect(ui->comboBox_metatileBehaviors->lineEdit(), &QLineEdit::editingFinished, this, &TilesetEditor::commitMetatileBehavior);
-    connect(ui->comboBox_encounterType->lineEdit(), &QLineEdit::editingFinished, this, &TilesetEditor::commitEncounterType);
-    connect(ui->comboBox_terrainType->lineEdit(), &QLineEdit::editingFinished, this, &TilesetEditor::commitTerrainType);
-    connect(ui->comboBox_layerType->lineEdit(), &QLineEdit::editingFinished, this, &TilesetEditor::commitLayerType);
-    connect(ui->comboBox_metatileBehaviors, QOverload<int>::of(&QComboBox::activated), this, &TilesetEditor::commitMetatileBehavior);
-    connect(ui->comboBox_encounterType,  QOverload<int>::of(&QComboBox::activated), this, &TilesetEditor::commitEncounterType);
-    connect(ui->comboBox_terrainType, QOverload<int>::of(&QComboBox::activated), this, &TilesetEditor::commitTerrainType);
-    connect(ui->comboBox_layerType, QOverload<int>::of(&QComboBox::activated), this, &TilesetEditor::commitLayerType);
+    connect(ui->comboBox_metatileBehaviors, &NoScrollComboBox::editingFinished, this, &TilesetEditor::commitMetatileBehavior);
+    connect(ui->comboBox_encounterType,     &NoScrollComboBox::editingFinished, this, &TilesetEditor::commitEncounterType);
+    connect(ui->comboBox_terrainType,       &NoScrollComboBox::editingFinished, this, &TilesetEditor::commitTerrainType);
+    connect(ui->comboBox_layerType,         &NoScrollComboBox::editingFinished, this, &TilesetEditor::commitLayerType);
 
     // Behavior
     if (projectConfig.metatileBehaviorMask) {


### PR DESCRIPTION
- The `direction` combo boxes are now editable again. Fixed some weird things you could do with that in the last release.
- The "open dive/emerge map" buttons are now visually disabled when there's no dive/emerge map
- Fix the connection pixmaps being sensitive to focus, which could select them unexpectedly or make deleting them with the keyboard unresponsive.