### PR TITLE
Support local ID strings, misc event fixes

### DIFF
--- a/include/core/editcommands.h
+++ b/include/core/editcommands.h
@@ -14,7 +14,7 @@ class Map;
 class Layout;
 class Blockdata;
 class Event;
-class DraggablePixmapItem;
+class EventPixmapItem;
 class Editor;
 
 enum CommandId {

--- a/include/core/events.h
+++ b/include/core/events.h
@@ -153,7 +153,7 @@ public:
     QJsonObject getCustomAttributes() const { return this->customAttributes; }
     void setCustomAttributes(const QJsonObject &newCustomAttributes) { this->customAttributes = newCustomAttributes; }
 
-    virtual void loadPixmap(Project *project);
+    virtual QPixmap loadPixmap(Project *project);
 
     void setPixmap(QPixmap newPixmap) { this->pixmap = newPixmap; }
     QPixmap getPixmap() const { return this->pixmap; }
@@ -233,7 +233,7 @@ public:
 
     virtual QSet<QString> getExpectedFields() override;
 
-    virtual void loadPixmap(Project *project) override;
+    virtual QPixmap loadPixmap(Project *project) override;
 
     void setGfx(QString newGfx) { this->gfx = newGfx; }
     QString getGfx() const { return this->gfx; }
@@ -300,7 +300,7 @@ public:
 
     virtual QSet<QString> getExpectedFields() override;
 
-    virtual void loadPixmap(Project *project) override;
+    virtual QPixmap loadPixmap(Project *project) override;
 
     void setTargetMap(QString newTargetMap) { this->targetMap = newTargetMap; }
     QString getTargetMap() const { return this->targetMap; }

--- a/include/core/events.h
+++ b/include/core/events.h
@@ -300,12 +300,12 @@ public:
     void setTargetMap(QString newTargetMap) { this->targetMap = newTargetMap; }
     QString getTargetMap() const { return this->targetMap; }
 
-    void setTargetID(int newTargetID) { this->targetID = newTargetID; }
-    int getTargetID() const { return this->targetID; }
+    void setTargetID(QString newTargetID) { this->targetID = newTargetID; }
+    QString getTargetID() const { return this->targetID; }
 
 private:
     QString targetMap;
-    int targetID = 0;
+    QString targetID;
 };
 
 

--- a/include/core/events.h
+++ b/include/core/events.h
@@ -79,9 +79,13 @@ public:
         None,
     };
 
-    // all event groups except warps have IDs that start at 1
+    // Normally we refer to events using their index in the list of that group's events.
+    // Object events often get referred to with a special "local ID", which is really just the index + 1.
+    // We use this local ID number in the index spinner for object events instead of the actual index.
+    // This distinction is only really important for object and warp events, because these are normally
+    // the only two groups of events that need to be explicitly referred to.
     static int getIndexOffset(Event::Group group) {
-        return (group == Event::Group::Warp) ? 0 : 1;
+        return (group == Event::Group::Object) ? 1 : 0;
     }
 
     static Event::Group typeToGroup(Event::Type type) {

--- a/include/core/events.h
+++ b/include/core/events.h
@@ -19,7 +19,7 @@ class EventFrame;
 class ObjectFrame;
 class CloneObjectFrame;
 class WarpFrame;
-class DraggablePixmapItem;
+class EventPixmapItem;
 
 class Event;
 class ObjectEvent;
@@ -154,8 +154,8 @@ public:
     void setPixmap(QPixmap newPixmap) { this->pixmap = newPixmap; }
     QPixmap getPixmap() const { return this->pixmap; }
 
-    void setPixmapItem(DraggablePixmapItem *item);
-    DraggablePixmapItem *getPixmapItem() const { return this->pixmapItem; }
+    void setPixmapItem(EventPixmapItem *item);
+    EventPixmapItem *getPixmapItem() const { return this->pixmapItem; }
 
     void setUsesDefaultPixmap(bool newUsesDefaultPixmap) { this->usesDefaultPixmap = newUsesDefaultPixmap; }
     bool getUsesDefaultPixmap() const { return this->usesDefaultPixmap; }
@@ -194,7 +194,7 @@ protected:
     QJsonObject customAttributes;
 
     QPixmap pixmap;
-    DraggablePixmapItem *pixmapItem = nullptr;
+    EventPixmapItem *pixmapItem = nullptr;
 
     QPointer<EventFrame> eventFrame;
 

--- a/include/core/map.h
+++ b/include/core/map.h
@@ -77,6 +77,7 @@ public:
     QList<Event *> getEvents(Event::Group group = Event::Group::None) const;
     Event* getEvent(Event::Group group, int index) const;
     Event* getEvent(Event::Group group, const QString &idName) const;
+    QStringList getEventIdNames(Event::Group group) const;
     int getNumEvents(Event::Group group = Event::Group::None) const;
     QStringList getScriptLabels(Event::Group group = Event::Group::None);
     QString getScriptsFilePath() const;

--- a/include/core/map.h
+++ b/include/core/map.h
@@ -76,6 +76,7 @@ public:
     void resetEvents();
     QList<Event *> getEvents(Event::Group group = Event::Group::None) const;
     Event* getEvent(Event::Group group, int index) const;
+    Event* getEvent(Event::Group group, const QString &idName) const;
     int getNumEvents(Event::Group group = Event::Group::None) const;
     QStringList getScriptLabels(Event::Group group = Event::Group::None);
     QString getScriptsFilePath() const;

--- a/include/editor.h
+++ b/include/editor.h
@@ -122,6 +122,8 @@ public:
     void updateCursorRectPos(int x, int y);
     void setCursorRectVisible(bool visible);
 
+    void onEventDragged(Event *event, const QPoint &oldPosition, const QPoint &newPosition);
+    void onEventReleased(Event *event, const QPoint &position);
     void updateWarpEventWarning(Event *event);
     void updateWarpEventWarnings();
 
@@ -172,10 +174,7 @@ public:
     static QList<QList<const QImage*>> collisionIcons;
 
     int eventShiftActionId = 0;
-
-    void eventsView_onMousePress(QMouseEvent *event);
-
-    bool selectingEvent = false;
+    int eventMoveActionId = 0;
 
     void deleteSelectedEvents();
     void shouldReselectEvents();

--- a/include/editor.h
+++ b/include/editor.h
@@ -251,11 +251,11 @@ private slots:
 
 signals:
     void eventsChanged();
+    void openEventMap(Event*);
     void openConnectedMap(MapConnection*);
     void wildMonTableOpened(EncounterTableModel*);
     void wildMonTableClosed();
     void wildMonTableEdited();
-    void warpEventDoubleClicked(QString, int, Event::Group);
     void currentMetatilesSelectionChanged();
     void mapRulerStatusChanged(const QString &);
     void tilesetUpdated(QString);

--- a/include/editor.h
+++ b/include/editor.h
@@ -117,6 +117,7 @@ public:
     void redrawAllEvents();
     void redrawEvents(const QList<Event*> &events);
     void redrawEventPixmapItem(EventPixmapItem *item);
+    void updateEventPixmapItemZValue(EventPixmapItem *item);
     qreal getEventOpacity(const Event *event) const;
 
     void updateCursorRectPos(int x, int y);
@@ -181,6 +182,22 @@ public:
     void scaleMapView(int);
     static void openInTextEditor(const QString &path, int lineNum = 0);
     void setCollisionGraphics();
+
+    enum ZValue {
+        MapBorder = -4,
+        MapConnectionInactive = -3,
+        MapConnectionActive = -2,
+        MapConnectionMask = -1,
+
+        // Event pixmaps set their z value to be their y position on the map.
+        // Their y value is int16_t, so we have enough space to allocate the
+        // full range + 1 for the selected event (which should always be on top).
+        EventMinimum = 1,
+        EventMaximum = EventMinimum + 0x10000,
+
+        Ruler,
+        ResizeLayoutPopup
+    };
 
 public slots:
     void openMapScripts() const;

--- a/include/editor.h
+++ b/include/editor.h
@@ -30,7 +30,7 @@
 #include "mapruler.h"
 #include "encountertablemodel.h"
 
-class DraggablePixmapItem;
+class EventPixmapItem;
 class MetatilesPixmapItem;
 
 class Editor : public QObject
@@ -107,7 +107,7 @@ public:
     void toggleBorderVisibility(bool visible, bool enableScriptCallback = true);
     void updateCustomMapAttributes();
 
-    DraggablePixmapItem *addEventPixmapItem(Event *event);
+    EventPixmapItem *addEventPixmapItem(Event *event);
     void removeEventPixmapItem(Event *event);
     bool canAddEvents(const QList<Event*> &events);
     void selectMapEvent(Event *event, bool toggle = false);
@@ -116,7 +116,7 @@ public:
     void duplicateSelectedEvents();
     void redrawAllEvents();
     void redrawEvents(const QList<Event*> &events);
-    void redrawEventPixmapItem(DraggablePixmapItem *item);
+    void redrawEventPixmapItem(EventPixmapItem *item);
     qreal getEventOpacity(const Event *event) const;
 
     void updateCursorRectPos(int x, int y);

--- a/include/mainwindow.h
+++ b/include/mainwindow.h
@@ -177,7 +177,7 @@ private slots:
     void on_action_Save_Project_triggered();
     void save(bool currentOnly = false);
 
-    void openWarpMap(QString map_name, int event_id, Event::Group event_group);
+    void openEventMap(Event *event);
 
     void duplicate();
     void setClipboardData(poryjson::Json::object);

--- a/include/mainwindow.h
+++ b/include/mainwindow.h
@@ -197,8 +197,7 @@ private slots:
     void onMapLoaded(Map *map);
     void onMapRulerStatusChanged(const QString &);
     void applyUserShortcuts();
-    void markMapEdited();
-    void markSpecificMapEdited(Map*);
+    void markMapEdited(Map*);
     void markLayoutEdited();
 
     void on_actionNew_Tileset_triggered();

--- a/include/ui/draggablepixmapitem.h
+++ b/include/ui/draggablepixmapitem.h
@@ -42,29 +42,13 @@ signals:
     void positionChanged(Event *event);
     void xChanged(int);
     void yChanged(int);
-    void elevationChanged(int);
     void spriteChanged(QPixmap pixmap);
-    void onPropertyChanged(QString key, QString value);
-
-public slots:
-    void set_x(int x) {
-        event->setX(x);
-        updatePosition();
-    }
-    void set_y(int y) {
-        event->setY(y);
-        updatePosition();
-    }
-    void set_elevation(int z) {
-        event->setElevation(z);
-        updatePosition();
-    }
 
 protected:
-    void mousePressEvent(QGraphicsSceneMouseEvent*);
-    void mouseMoveEvent(QGraphicsSceneMouseEvent*);
-    void mouseReleaseEvent(QGraphicsSceneMouseEvent*);
-    void mouseDoubleClickEvent(QGraphicsSceneMouseEvent*);
+    virtual void mousePressEvent(QGraphicsSceneMouseEvent*) override;
+    virtual void mouseMoveEvent(QGraphicsSceneMouseEvent*) override;
+    virtual void mouseReleaseEvent(QGraphicsSceneMouseEvent*) override;
+    virtual void mouseDoubleClickEvent(QGraphicsSceneMouseEvent*) override;
 };
 
 #endif // DRAGGABLEPIXMAPITEM_H

--- a/include/ui/draggablepixmapitem.h
+++ b/include/ui/draggablepixmapitem.h
@@ -42,13 +42,14 @@ signals:
     void positionChanged(Event *event);
     void xChanged(int);
     void yChanged(int);
-    void spriteChanged(QPixmap pixmap);
+    void spriteChanged(const QPixmap &pixmap);
+    void doubleClicked(Event *event);
 
 protected:
     virtual void mousePressEvent(QGraphicsSceneMouseEvent*) override;
     virtual void mouseMoveEvent(QGraphicsSceneMouseEvent*) override;
     virtual void mouseReleaseEvent(QGraphicsSceneMouseEvent*) override;
-    virtual void mouseDoubleClickEvent(QGraphicsSceneMouseEvent*) override;
+    virtual void mouseDoubleClickEvent(QGraphicsSceneMouseEvent*) override { emit doubleClicked(this->event); }
 };
 
 #endif // DRAGGABLEPIXMAPITEM_H

--- a/include/ui/eventframes.h
+++ b/include/ui/eventframes.h
@@ -58,6 +58,7 @@ protected:
     bool connected = false;
 
     void populateScriptDropdown(NoScrollComboBox * combo, Project * project);
+    void populateIdNameDropdown(NoScrollComboBox * combo, Project * project, const QString &mapName, Event::Group group);
 
 private:
     Event *event;
@@ -78,6 +79,7 @@ public:
     virtual void populate(Project *project) override;
 
 public:
+    QLineEdit *line_edit_local_id;
     NoScrollComboBox *combo_sprite;
     NoScrollComboBox *combo_movement;
     NoScrollSpinBox *spinner_radius_x;
@@ -108,6 +110,7 @@ public:
     virtual void populate(Project *project) override;
 
 public:
+    QLineEdit *line_edit_local_id;
     NoScrollComboBox *combo_sprite;
     NoScrollComboBox *combo_target_id;
     NoScrollComboBox *combo_target_map;
@@ -131,6 +134,7 @@ public:
     virtual void populate(Project *project) override;
 
 public:
+    QLineEdit *line_edit_id;
     NoScrollComboBox *combo_dest_map;
     NoScrollComboBox *combo_dest_warp;
     QPushButton *warning;

--- a/include/ui/eventframes.h
+++ b/include/ui/eventframes.h
@@ -109,7 +109,7 @@ public:
 
 public:
     NoScrollComboBox *combo_sprite;
-    NoScrollSpinBox *spinner_target_id;
+    NoScrollComboBox *combo_target_id;
     NoScrollComboBox *combo_target_map;
 
 private:

--- a/include/ui/eventframes.h
+++ b/include/ui/eventframes.h
@@ -57,6 +57,7 @@ protected:
     bool initialized = false;
     bool connected = false;
 
+    void populateDropdown(NoScrollComboBox * combo, const QStringList &items);
     void populateScriptDropdown(NoScrollComboBox * combo, Project * project);
     void populateIdNameDropdown(NoScrollComboBox * combo, Project * project, const QString &mapName, Event::Group group);
 
@@ -117,6 +118,8 @@ public:
 
 private:
     CloneObjectEvent *clone;
+
+    void tryInvalidateIdDropdown(Map *map);
 };
 
 
@@ -141,6 +144,8 @@ public:
 
 private:
     WarpEvent *warp;
+
+    void tryInvalidateIdDropdown(Map *map);
 };
 
 
@@ -279,6 +284,8 @@ public:
 
 private:
     HealLocationEvent *healLocation;
+
+    void tryInvalidateIdDropdown(Map *map);
 };
 
 #endif // EVENTRAMES_H

--- a/include/ui/eventpixmapitem.h
+++ b/include/ui/eventpixmapitem.h
@@ -1,5 +1,5 @@
-#ifndef DRAGGABLEPIXMAPITEM_H
-#define DRAGGABLEPIXMAPITEM_H
+#ifndef EVENTPIXMAPITEM_H
+#define EVENTPIXMAPITEM_H
 
 #include <QString>
 #include <QGraphicsItemGroup>
@@ -12,12 +12,12 @@
 
 class Editor;
 
-class DraggablePixmapItem : public QObject, public QGraphicsPixmapItem {
+class EventPixmapItem : public QObject, public QGraphicsPixmapItem {
     Q_OBJECT
 public:
-    DraggablePixmapItem(QPixmap pixmap): QGraphicsPixmapItem(pixmap) {}
+    EventPixmapItem(QPixmap pixmap): QGraphicsPixmapItem(pixmap) {}
     
-    DraggablePixmapItem(Event *event, Editor *editor) : QGraphicsPixmapItem(event->getPixmap()) {
+    EventPixmapItem(Event *event, Editor *editor) : QGraphicsPixmapItem(event->getPixmap()) {
         this->event = event;
         event->setPixmapItem(this);
         this->editor = editor;
@@ -52,4 +52,4 @@ protected:
     virtual void mouseDoubleClickEvent(QGraphicsSceneMouseEvent*) override { emit doubleClicked(this->event); }
 };
 
-#endif // DRAGGABLEPIXMAPITEM_H
+#endif // EVENTPIXMAPITEM_H

--- a/include/ui/eventpixmapitem.h
+++ b/include/ui/eventpixmapitem.h
@@ -10,38 +10,39 @@
 
 #include "events.h"
 
-class Editor;
+class Project;
 
 class EventPixmapItem : public QObject, public QGraphicsPixmapItem {
     Q_OBJECT
 public:
-    EventPixmapItem(QPixmap pixmap): QGraphicsPixmapItem(pixmap) {}
-    
-    EventPixmapItem(Event *event, Editor *editor) : QGraphicsPixmapItem(event->getPixmap()) {
-        this->event = event;
-        event->setPixmapItem(this);
-        this->editor = editor;
-        updatePosition();
-    }
+    explicit EventPixmapItem(Event *event);
 
-    Event *event = nullptr;
+    void render(Project *project);
 
-    void updatePosition();
+    bool isSelected() const { return m_selected; }
+    void setSelected(bool selected) { m_selected = selected; }
+
+    Event * getEvent() const { return m_event; }
+
     void move(int dx, int dy);
+    void moveTo(int x, int y);
     void moveTo(const QPoint &pos);
-    void emitPositionChanged();
-    void updatePixmap();
 
 private:
-    Editor *editor = nullptr;
-    QPoint lastPos;
-    bool active = false;
-    bool releaseSelectionQueued = false;
+    QPixmap m_basePixmap;
+    Event *const m_event = nullptr;
+    QPoint m_lastPos;
+    bool m_active = false;
+    bool m_selected = false;
+    bool m_releaseSelectionQueued = false;
+
+    void updatePixelPosition();
 
 signals:
-    void xChanged(int);
-    void yChanged(int);
-    void spriteChanged(const QPixmap &pixmap);
+    void xChanged(int x);
+    void yChanged(int y);
+    void posChanged(int x, int y);
+    void rendered(const QPixmap &pixmap);
     void selected(Event *event, bool toggle);
     void dragged(Event *event, const QPoint &oldPosition, const QPoint &newPosition);
     void released(Event *event, const QPoint &position);
@@ -51,7 +52,7 @@ protected:
     virtual void mousePressEvent(QGraphicsSceneMouseEvent*) override;
     virtual void mouseMoveEvent(QGraphicsSceneMouseEvent*) override;
     virtual void mouseReleaseEvent(QGraphicsSceneMouseEvent*) override;
-    virtual void mouseDoubleClickEvent(QGraphicsSceneMouseEvent*) override { emit doubleClicked(this->event); }
+    virtual void mouseDoubleClickEvent(QGraphicsSceneMouseEvent*) override { emit doubleClicked(m_event); }
 };
 
 #endif // EVENTPIXMAPITEM_H

--- a/include/ui/eventpixmapitem.h
+++ b/include/ui/eventpixmapitem.h
@@ -39,10 +39,12 @@ private:
     bool releaseSelectionQueued = false;
 
 signals:
-    void positionChanged(Event *event);
     void xChanged(int);
     void yChanged(int);
     void spriteChanged(const QPixmap &pixmap);
+    void selected(Event *event, bool toggle);
+    void dragged(Event *event, const QPoint &oldPosition, const QPoint &newPosition);
+    void released(Event *event, const QPoint &position);
     void doubleClicked(Event *event);
 
 protected:

--- a/include/ui/graphicsview.h
+++ b/include/ui/graphicsview.h
@@ -32,25 +32,4 @@ signals:
     void clicked(QMouseEvent *event);
 };
 
-class Editor;
-
-// TODO: This should just be MapView. It makes map-based assumptions, and no other class inherits GraphicsView.
-class GraphicsView : public QGraphicsView
-{
-public:
-    GraphicsView() : QGraphicsView() {}
-    GraphicsView(QWidget *parent) : QGraphicsView(parent) {}
-
-public:
-//    GraphicsView_Object object;
-    Editor *editor;
-protected:
-    virtual void mousePressEvent(QMouseEvent *event) override;
-    virtual void mouseMoveEvent(QMouseEvent *event) override;
-    virtual void mouseReleaseEvent(QMouseEvent *event) override;
-    virtual void moveEvent(QMoveEvent *event) override;
-};
-
-//Q_DECLARE_METATYPE(GraphicsView)
-
 #endif // GRAPHICSVIEW_H

--- a/include/ui/mapview.h
+++ b/include/ui/mapview.h
@@ -5,13 +5,17 @@
 #include "graphicsview.h"
 #include "overlay.h"
 
-class MapView : public GraphicsView
+class Editor;
+
+class MapView : public QGraphicsView
 {
     Q_OBJECT
 
 public:
-    MapView() : GraphicsView() {}
-    MapView(QWidget *parent) : GraphicsView(parent) {}
+    MapView() : QGraphicsView() {}
+    MapView(QWidget *parent) : QGraphicsView(parent) {}
+
+    Editor *editor;
 
     Overlay * getOverlay(int layer);
     void clearOverlayMap();
@@ -73,6 +77,7 @@ public:
 protected:
     virtual void drawForeground(QPainter *painter, const QRectF &rect) override;
     virtual void keyPressEvent(QKeyEvent*) override;
+    virtual void moveEvent(QMoveEvent *event) override;
 private:
     QMap<int, Overlay*> overlayMap;
 

--- a/porymap.pro
+++ b/porymap.pro
@@ -73,7 +73,7 @@ SOURCES += src/core/advancemapparser.cpp \
     src/ui/customscriptseditor.cpp \
     src/ui/customscriptslistitem.cpp \
     src/ui/divingmappixmapitem.cpp \
-    src/ui/draggablepixmapitem.cpp \
+    src/ui/eventpixmapitem.cpp \
     src/ui/bordermetatilespixmapitem.cpp \
     src/ui/collisionpixmapitem.cpp \
     src/ui/connectionpixmapitem.cpp \
@@ -184,7 +184,7 @@ HEADERS  += include/core/advancemapparser.h \
     include/ui/customscriptseditor.h \
     include/ui/customscriptslistitem.h \
     include/ui/divingmappixmapitem.h \
-    include/ui/draggablepixmapitem.h \
+    include/ui/eventpixmapitem.h \
     include/ui/bordermetatilespixmapitem.h \
     include/ui/collisionpixmapitem.h \
     include/ui/connectionpixmapitem.h \

--- a/src/core/editcommands.cpp
+++ b/src/core/editcommands.cpp
@@ -1,5 +1,5 @@
 #include "editcommands.h"
-#include "draggablepixmapitem.h"
+#include "eventpixmapitem.h"
 #include "bordermetatilespixmapitem.h"
 #include "editor.h"
 

--- a/src/core/events.cpp
+++ b/src/core/events.cpp
@@ -20,8 +20,7 @@ Event* Event::create(Event::Type type) {
 }
 
 Event::~Event() {
-    if (this->eventFrame)
-        this->eventFrame->deleteLater();
+    delete this->eventFrame;
 }
 
 EventFrame *Event::getEventFrame() {

--- a/src/core/events.cpp
+++ b/src/core/events.cpp
@@ -114,9 +114,10 @@ QString Event::typeToString(Event::Type type) {
     return typeToStringMap.value(type);
 }
 
-void Event::loadPixmap(Project *project) {
+QPixmap Event::loadPixmap(Project *project) {
     this->pixmap = project->getEventPixmap(this->getEventGroup());
     this->usesDefaultPixmap = true;
+    return this->pixmap;
 }
 
 
@@ -225,13 +226,13 @@ QSet<QString> ObjectEvent::getExpectedFields() {
     return expectedFields;
 }
 
-void ObjectEvent::loadPixmap(Project *project) {
+QPixmap ObjectEvent::loadPixmap(Project *project) {
     this->pixmap = project->getEventPixmap(this->gfx, this->movement);
     if (!this->pixmap.isNull()) {
         this->usesDefaultPixmap = false;
-    } else {
-        Event::loadPixmap(project);
+        return this->pixmap;
     }
+    return Event::loadPixmap(project);
 }
 
 
@@ -314,7 +315,7 @@ QSet<QString> CloneObjectEvent::getExpectedFields() {
     return expectedFields;
 }
 
-void CloneObjectEvent::loadPixmap(Project *project) {
+QPixmap CloneObjectEvent::loadPixmap(Project *project) {
     // Try to get the targeted object to clone
     Map *clonedMap = project->loadMap(this->targetMap);
     Event *clonedEvent = clonedMap ? clonedMap->getEvent(Event::Group::Object, this->targetID) : nullptr;
@@ -329,7 +330,7 @@ void CloneObjectEvent::loadPixmap(Project *project) {
         this->gfx = project->gfxDefines.key(0, "0");
         this->movement = project->movementTypes.value(0, "0");
     }
-    ObjectEvent::loadPixmap(project);
+    return ObjectEvent::loadPixmap(project);
 }
 
 

--- a/src/core/events.cpp
+++ b/src/core/events.cpp
@@ -34,7 +34,7 @@ void Event::destroyEventFrame() {
     this->eventFrame = nullptr;
 }
 
-void Event::setPixmapItem(DraggablePixmapItem *item) {
+void Event::setPixmapItem(EventPixmapItem *item) {
     this->pixmapItem = item;
     if (this->eventFrame) {
         this->eventFrame->invalidateConnections();

--- a/src/core/events.cpp
+++ b/src/core/events.cpp
@@ -146,12 +146,13 @@ EventFrame *ObjectEvent::createEventFrame() {
 OrderedJson::object ObjectEvent::buildEventJson(Project *) {
     OrderedJson::object objectJson;
 
-    if (projectConfig.eventCloneObjectEnabled) {
-        objectJson["type"] = Event::typeToJsonKey(Event::Type::Object);
-    }
     QString idName = this->getIdName();
     if (!idName.isEmpty())
         objectJson["local_id"] = idName;
+
+    if (projectConfig.eventCloneObjectEnabled) {
+        objectJson["type"] = Event::typeToJsonKey(Event::Type::Object);
+    }
     objectJson["graphics_id"] = this->getGfx();
     objectJson["x"] = this->getX();
     objectJson["y"] = this->getY();
@@ -255,10 +256,11 @@ EventFrame *CloneObjectEvent::createEventFrame() {
 OrderedJson::object CloneObjectEvent::buildEventJson(Project *project) {
     OrderedJson::object cloneJson;
 
-    cloneJson["type"] = Event::typeToJsonKey(Event::Type::CloneObject);
     QString idName = this->getIdName();
     if (!idName.isEmpty())
         cloneJson["local_id"] = idName;
+
+    cloneJson["type"] = Event::typeToJsonKey(Event::Type::CloneObject);
     cloneJson["graphics_id"] = this->getGfx();
     cloneJson["x"] = this->getX();
     cloneJson["y"] = this->getY();

--- a/src/core/events.cpp
+++ b/src/core/events.cpp
@@ -275,7 +275,7 @@ bool CloneObjectEvent::loadFromJson(QJsonObject json, Project *project) {
     this->setY(readInt(&json, "y"));
     this->setIdName(readString(&json, "local_id"));
     this->setGfx(readString(&json, "graphics_id"));
-    this->setTargetID(readInt(&json, "target_local_id"));
+    this->setTargetID(readString(&json, "target_local_id"));
 
     // Log a warning if "target_map" isn't a known map ID, but don't overwrite user data.
     const QString mapConstant = readString(&json, "target_map");
@@ -289,7 +289,7 @@ bool CloneObjectEvent::loadFromJson(QJsonObject json, Project *project) {
 
 void CloneObjectEvent::setDefaultValues(Project *project) {
     this->setGfx(project->gfxDefines.key(0, "0"));
-    this->setTargetID(1);
+    this->setTargetID(QString::number(Event::getIndexOffset(Event::Group::Object)));
     if (this->getMap()) this->setTargetMap(this->getMap()->name());
 }
 
@@ -308,9 +308,8 @@ QSet<QString> CloneObjectEvent::getExpectedFields() {
 
 void CloneObjectEvent::loadPixmap(Project *project) {
     // Try to get the targeted object to clone
-    int eventIndex = this->targetID - 1;
     Map *clonedMap = project->loadMap(this->targetMap);
-    Event *clonedEvent = clonedMap ? clonedMap->getEvent(Event::Group::Object, eventIndex) : nullptr;
+    Event *clonedEvent = clonedMap ? clonedMap->getEvent(Event::Group::Object, this->targetID) : nullptr;
 
     if (clonedEvent && clonedEvent->getEventType() == Event::Type::Object) {
         // Get graphics data from cloned object

--- a/src/core/events.cpp
+++ b/src/core/events.cpp
@@ -99,7 +99,7 @@ QString Event::typeToString(Event::Type type) {
         {Event::Type::CloneObject, "Clone Object"},
         {Event::Type::Warp, "Warp"},
         {Event::Type::Trigger, "Trigger"},
-        {Event::Type::WeatherTrigger, "Weather"},
+        {Event::Type::WeatherTrigger, "Weather Trigger"},
         {Event::Type::Sign, "Sign"},
         {Event::Type::HiddenItem, "Hidden Item"},
         {Event::Type::SecretBase, "Secret Base"},

--- a/src/core/map.cpp
+++ b/src/core/map.cpp
@@ -212,6 +212,31 @@ Event* Map::getEvent(Event::Group group, const QString &idName) const {
     return nullptr;
 }
 
+// Returns a list of ID names for the given event group (or all events, if no group is given).
+// For events with no explicit ID name, their index string is given instead.
+QStringList Map::getEventIdNames(Event::Group group) const {
+    QList<Event::Group> groups;
+    if (group == Event::Group::None) {
+        groups = Event::groups();
+    } else {
+        groups.append(group);
+    }
+
+    QStringList idNames;
+    for (const auto &group : groups) {
+        const auto events = m_events[group];
+        int indexOffset = Event::getIndexOffset(group);
+        for (int i = 0; i < events.length(); i++) {
+            QString idName = events.at(i)->getIdName();
+            if (idName.isEmpty()) {
+                idName = QString::number(i + indexOffset);
+            }
+            idNames.append(idName);
+        }
+    }
+    return idNames;
+}
+
 int Map::getNumEvents(Event::Group group) const {
     if (group == Event::Group::None) {
         // Total number of events

--- a/src/core/map.cpp
+++ b/src/core/map.cpp
@@ -194,6 +194,21 @@ Event* Map::getEvent(Event::Group group, int index) const {
     return m_events[group].value(index, nullptr);
 }
 
+Event* Map::getEvent(Event::Group group, const QString &idName) const {
+    bool idIsNumber;
+    int id = idName.toInt(&idIsNumber, 0);
+    if (idIsNumber)
+        return getEvent(group, id - Event::getIndexOffset(group));
+
+    auto events = getEvents(group);
+    for (const auto &event : events) {
+        if (event->getIdName() == idName) {
+            return event;
+        }
+    }
+    return nullptr;
+}
+
 int Map::getNumEvents(Event::Group group) const {
     if (group == Event::Group::None) {
         // Total number of events

--- a/src/core/map.cpp
+++ b/src/core/map.cpp
@@ -195,6 +195,9 @@ Event* Map::getEvent(Event::Group group, int index) const {
 }
 
 Event* Map::getEvent(Event::Group group, const QString &idName) const {
+    if (idName.isEmpty())
+        return nullptr;
+
     bool idIsNumber;
     int id = idName.toInt(&idIsNumber, 0);
     if (idIsNumber)

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -1,5 +1,5 @@
 #include "editor.h"
-#include "draggablepixmapitem.h"
+#include "eventpixmapitem.h"
 #include "imageproviders.h"
 #include "log.h"
 #include "connectionslistitem.h"
@@ -1692,10 +1692,10 @@ void Editor::displayMapEvents() {
     events_group->setHandlesChildEvents(false);
 }
 
-DraggablePixmapItem *Editor::addEventPixmapItem(Event *event) {
+EventPixmapItem *Editor::addEventPixmapItem(Event *event) {
     this->project->loadEventPixmap(event);
-    auto item = new DraggablePixmapItem(event, this);
-    connect(item, &DraggablePixmapItem::doubleClicked, this, &Editor::openEventMap);
+    auto item = new EventPixmapItem(event, this);
+    connect(item, &EventPixmapItem::doubleClicked, this, &Editor::openEventMap);
     redrawEventPixmapItem(item);
     this->events_group->addToGroup(item);
     return item;
@@ -1971,7 +1971,7 @@ qreal Editor::getEventOpacity(const Event *event) const {
     return event->getUsesDefaultPixmap() ? 0.7 : 1.0;
 }
 
-void Editor::redrawEventPixmapItem(DraggablePixmapItem *item) {
+void Editor::redrawEventPixmapItem(EventPixmapItem *item) {
     if (!item || !item->event)
         return;
 
@@ -2287,8 +2287,8 @@ bool Editor::startDetachedProcess(const QString &command, const QString &working
 }
 
 // It doesn't seem to be possible to prevent the mousePress event
-// from triggering both event's DraggablePixmapItem and the background mousePress.
-// Since the DraggablePixmapItem's event fires first, we can set a temp
+// from triggering both event's EventPixmapItem and the background mousePress.
+// Since the EventPixmapItem's event fires first, we can set a temp
 // variable "selectingEvent" so that we can detect whether or not the user
 // is clicking on the background instead of an event.
 void Editor::eventsView_onMousePress(QMouseEvent *event) {

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -1699,6 +1699,7 @@ void Editor::displayMapEvents() {
 DraggablePixmapItem *Editor::addEventPixmapItem(Event *event) {
     this->project->loadEventPixmap(event);
     auto item = new DraggablePixmapItem(event, this);
+    connect(item, &DraggablePixmapItem::doubleClicked, this, &Editor::openEventMap);
     redrawEventPixmapItem(item);
     this->events_group->addToGroup(item);
     return item;

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -1673,9 +1673,6 @@ void Editor::clearMapEvents() {
         if (events_group->scene()) {
             events_group->scene()->removeItem(events_group);
         }
-        // events_group does not own its children, the childrens' parent
-        // is set to the group's parent (and our group has no parent).
-        qDeleteAll(events_group->childItems());
         delete events_group;
         events_group = nullptr;
     }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1081,8 +1081,13 @@ void MainWindow::openEventMap(Event *sourceEvent) {
         // Secret Bases open to their secret base entrance
         const QString mapPrefix = projectConfig.getIdentifier(ProjectIdentifier::define_map_prefix);
         SecretBaseEvent *base = dynamic_cast<SecretBaseEvent *>(sourceEvent);
+
+        // Extract the map name from the secret base ID.
         QString baseId = base->getBaseID();
         targetMapName = this->editor->project->mapConstantsToMapNames.value(mapPrefix + baseId.left(baseId.lastIndexOf("_")));
+
+        // Just select the first warp. Normally the only warp event on every secret base map is the entrance/exit, so this is usually correct.
+        // The warp IDs for secret bases are specified in the project's C code, not in the map data, so we don't have an easy way to read the actual IDs.
         targetEventIdName = "0";
         targetEventGroup = Event::Group::Warp;
     } else if (eventType == Event::Type::HealLocation && projectConfig.healLocationRespawnDataEnabled) {

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1112,13 +1112,8 @@ void MainWindow::openEventMap(Event *sourceEvent) {
         return;
 
     // Map opened successfully, now try to select the targeted event on that map.
-    Event* targetEvent = this->editor->map->getEvent(targetEventGroup, targetEventIdName);
-    if (targetEvent) {
-        this->editor->selectMapEvent(targetEvent);
-    } else {
-        // Can still warp to this map, but can't select the specified event
-        logWarn(QString("%1 '%2' doesn't exist on map '%3'").arg(Event::groupToString(targetEventGroup)).arg(targetEventIdName).arg(targetMapName));
-    }
+    Event *targetEvent = this->editor->map->getEvent(targetEventGroup, targetEventIdName);
+    this->editor->selectMapEvent(targetEvent);
 }
 
 void MainWindow::displayMapProperties() {

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -10,7 +10,7 @@
 #include "customattributesframe.h"
 #include "scripting.h"
 #include "adjustingstackedwidget.h"
-#include "draggablepixmapitem.h"
+#include "eventpixmapitem.h"
 #include "editcommands.h"
 #include "flowlayout.h"
 #include "shortcut.h"

--- a/src/project.cpp
+++ b/src/project.cpp
@@ -162,8 +162,10 @@ void Project::clearTilesetCache() {
 
 Map* Project::loadMap(const QString &mapName) {
     Map* map = this->maps.value(mapName);
-    if (!map)
+    if (!map) {
+        logError(QString("Unknown map name '%1'.").arg(mapName));
         return nullptr;
+    }
 
     if (isMapLoaded(map))
         return map;
@@ -445,7 +447,12 @@ bool Project::loadLayout(Layout *layout) {
 
 Layout *Project::loadLayout(QString layoutId) {
     Layout *layout = this->mapLayouts.value(layoutId);
-    if (!layout || !loadLayout(layout)) {
+    if (!layout) {
+        logError(QString("Unknown layout ID '%1'.").arg(layoutId));
+        return nullptr;
+    }
+
+    if (!loadLayout(layout)) {
         logError(QString("Failed to load layout '%1'").arg(layoutId));
         return nullptr;
     }

--- a/src/project.cpp
+++ b/src/project.cpp
@@ -161,6 +161,11 @@ void Project::clearTilesetCache() {
 }
 
 Map* Project::loadMap(const QString &mapName) {
+    if (mapName == getDynamicMapName()) {
+        // Silently ignored, caller is expected to handle this if they want this to be an error.
+        return nullptr;
+    }
+
     Map* map = this->maps.value(mapName);
     if (!map) {
         logError(QString("Unknown map name '%1'.").arg(mapName));

--- a/src/ui/connectionpixmapitem.cpp
+++ b/src/ui/connectionpixmapitem.cpp
@@ -1,6 +1,7 @@
 #include "connectionpixmapitem.h"
 #include "editcommands.h"
 #include "map.h"
+#include "editor.h"
 
 #include <math.h>
 
@@ -31,7 +32,7 @@ void ConnectionPixmapItem::render(bool ignoreCache) {
         this->basePixmap = this->connection->render();
 
     QPixmap pixmap = this->basePixmap.copy(0, 0, this->basePixmap.width(), this->basePixmap.height());
-    this->setZValue(-1);
+    this->setZValue(Editor::ZValue::MapConnectionActive);
 
     // When editing is inactive the current selection is ignored, all connections should appear normal.
     if (this->getEditable()) {
@@ -43,7 +44,7 @@ void ConnectionPixmapItem::render(bool ignoreCache) {
             painter.end();
         } else {
             // Darken the image
-            this->setZValue(-2);
+            this->setZValue(Editor::ZValue::MapConnectionInactive);
             QPainter painter(&pixmap);
             int alpha = static_cast<int>(255 * 0.25);
             painter.fillRect(0, 0, pixmap.width(), pixmap.height(), QColor(0, 0, 0, alpha));

--- a/src/ui/draggablepixmapitem.cpp
+++ b/src/ui/draggablepixmapitem.cpp
@@ -12,11 +12,6 @@ void DraggablePixmapItem::updatePosition() {
     int y = this->event->getPixelY();
     setX(x);
     setY(y);
-    if (this->editor->selectedEvents.contains(this->event)) {
-        setZValue(event->getY() + 1);
-    } else {
-        setZValue(event->getY());
-    }
     editor->updateWarpEventWarning(event);
 }
 
@@ -26,8 +21,6 @@ void DraggablePixmapItem::emitPositionChanged() {
 }
 
 void DraggablePixmapItem::updatePixmap() {
-    editor->project->loadEventPixmap(event, true);
-    this->updatePosition();
     editor->redrawEventPixmapItem(this);
     emit spriteChanged(event->getPixmap());
 }

--- a/src/ui/draggablepixmapitem.cpp
+++ b/src/ui/draggablepixmapitem.cpp
@@ -23,7 +23,6 @@ void DraggablePixmapItem::updatePosition() {
 void DraggablePixmapItem::emitPositionChanged() {
     emit xChanged(event->getX());
     emit yChanged(event->getY());
-    emit elevationChanged(event->getElevation());
 }
 
 void DraggablePixmapItem::updatePixmap() {

--- a/src/ui/draggablepixmapitem.cpp
+++ b/src/ui/draggablepixmapitem.cpp
@@ -103,31 +103,3 @@ void DraggablePixmapItem::mouseReleaseEvent(QGraphicsSceneMouseEvent *mouse) {
             this->editor->selectMapEvent(this->event);
     }
 }
-
-// Events with properties that specify a map will open that map when double-clicked.
-void DraggablePixmapItem::mouseDoubleClickEvent(QGraphicsSceneMouseEvent *) {
-    Event::Type eventType = this->event->getEventType();
-    if (eventType == Event::Type::Warp) {
-        WarpEvent *warp = dynamic_cast<WarpEvent *>(this->event);
-        QString destMap = warp->getDestinationMap();
-        int warpId = ParseUtil::gameStringToInt(warp->getDestinationWarpID());
-        emit editor->warpEventDoubleClicked(destMap, warpId, Event::Group::Warp);
-    }
-    else if (eventType == Event::Type::CloneObject) {
-        CloneObjectEvent *clone = dynamic_cast<CloneObjectEvent *>(this->event);
-        emit editor->warpEventDoubleClicked(clone->getTargetMap(), clone->getTargetID(), Event::Group::Object);
-    }
-    else if (eventType == Event::Type::SecretBase) {
-        const QString mapPrefix = projectConfig.getIdentifier(ProjectIdentifier::define_map_prefix);
-        SecretBaseEvent *base = dynamic_cast<SecretBaseEvent *>(this->event);
-        QString baseId = base->getBaseID();
-        QString destMap = editor->project->mapConstantsToMapNames.value(mapPrefix + baseId.left(baseId.lastIndexOf("_")));
-        emit editor->warpEventDoubleClicked(destMap, 0, Event::Group::Warp);
-    }
-    else if (eventType == Event::Type::HealLocation && projectConfig.healLocationRespawnDataEnabled) {
-        HealLocationEvent *heal = dynamic_cast<HealLocationEvent *>(this->event);
-        const QString localIdName = heal->getRespawnNPC();
-        int localId = 0; // TODO: Get value from localIdName
-        emit editor->warpEventDoubleClicked(heal->getRespawnMapName(), localId, Event::Group::Object);
-    }
-}

--- a/src/ui/eventframes.cpp
+++ b/src/ui/eventframes.cpp
@@ -453,13 +453,16 @@ void CloneObjectFrame::connectSignals(MainWindow *window) {
     });
 
     // target id
+    // TODO: Replace spinner with combo box populated with local IDs from target map.
     this->spinner_target_id->disconnect();
+    /*
     connect(this->spinner_target_id, QOverload<int>::of(&QSpinBox::valueChanged), [this](int value) {
         this->clone->setTargetID(value);
         this->clone->getPixmapItem()->updatePixmap();
         this->combo_sprite->setCurrentText(this->clone->getGfx());
         this->clone->modify();
     });
+    */
 }
 
 void CloneObjectFrame::initialize() {
@@ -474,7 +477,7 @@ void CloneObjectFrame::initialize() {
     // target id
     this->spinner_target_id->setMinimum(1);
     this->spinner_target_id->setMaximum(126);
-    this->spinner_target_id->setValue(this->clone->getTargetID());
+    //this->spinner_target_id->setValue(this->clone->getTargetID());
 
     // target map
     this->combo_target_map->setTextItem(this->clone->getTargetMap());

--- a/src/ui/eventframes.cpp
+++ b/src/ui/eventframes.cpp
@@ -1,7 +1,7 @@
 #include "eventframes.h"
 #include "customattributesframe.h"
 #include "editcommands.h"
-#include "draggablepixmapitem.h"
+#include "eventpixmapitem.h"
 
 #include <limits>
 using std::numeric_limits;
@@ -114,7 +114,7 @@ void EventFrame::connectSignals(MainWindow *) {
         }
     });
 
-    connect(this->event->getPixmapItem(), &DraggablePixmapItem::xChanged, this->spinner_x, &NoScrollSpinBox::setValue);
+    connect(this->event->getPixmapItem(), &EventPixmapItem::xChanged, this->spinner_x, &NoScrollSpinBox::setValue);
     
     this->spinner_y->disconnect();
     connect(this->spinner_y, QOverload<int>::of(&QSpinBox::valueChanged), [this](int value) {
@@ -123,7 +123,7 @@ void EventFrame::connectSignals(MainWindow *) {
             this->event->getMap()->commit(new EventMove(QList<Event *>() << this->event, 0, delta, this->spinner_y->getActionId()));
         }
     });
-    connect(this->event->getPixmapItem(), &DraggablePixmapItem::yChanged, this->spinner_y, &NoScrollSpinBox::setValue);
+    connect(this->event->getPixmapItem(), &EventPixmapItem::yChanged, this->spinner_y, &NoScrollSpinBox::setValue);
     
     this->spinner_z->disconnect();
     connect(this->spinner_z, QOverload<int>::of(&QSpinBox::valueChanged), [this](int value) {
@@ -297,7 +297,7 @@ void ObjectFrame::connectSignals(MainWindow *window) {
         this->object->getPixmapItem()->updatePixmap();
         this->object->modify();
     });
-    connect(this->object->getPixmapItem(), &DraggablePixmapItem::spriteChanged, this->label_icon, &QLabel::setPixmap);
+    connect(this->object->getPixmapItem(), &EventPixmapItem::spriteChanged, this->label_icon, &QLabel::setPixmap);
 
     // movement
     this->combo_movement->disconnect();
@@ -439,7 +439,7 @@ void CloneObjectFrame::connectSignals(MainWindow *window) {
     EventFrame::connectSignals(window);
 
     // update icon displayed in frame with target
-    connect(this->clone->getPixmapItem(), &DraggablePixmapItem::spriteChanged, this->label_icon, &QLabel::setPixmap);
+    connect(this->clone->getPixmapItem(), &EventPixmapItem::spriteChanged, this->label_icon, &QLabel::setPixmap);
 
     // target map
     this->combo_target_map->disconnect();

--- a/src/ui/eventframes.cpp
+++ b/src/ui/eventframes.cpp
@@ -230,8 +230,9 @@ void ObjectFrame::setup() {
     // local id
     QFormLayout *l_form_local_id = new QFormLayout();
     this->line_edit_local_id = new QLineEdit(this);
-    this->line_edit_local_id->setToolTip("An optional, unique name to use to refer to this object in scripts.\n"
-                                         "If no game is given you can refer to this object using its 'object id' number.");
+    static const QString line_edit_local_id_toolTip = Util::toHtmlParagraph("An optional, unique name to use to refer to this object in scripts. "
+                                                                            "If no name is given you can refer to this object using its 'object id' number.");
+    this->line_edit_local_id->setToolTip(line_edit_local_id_toolTip);
     this->line_edit_local_id->setPlaceholderText("LOCALID_MY_NPC");
     l_form_local_id->addRow("Local ID", this->line_edit_local_id);
     this->layout_contents->addLayout(l_form_local_id);
@@ -455,8 +456,9 @@ void CloneObjectFrame::setup() {
     // local id
     QFormLayout *l_form_local_id = new QFormLayout();
     this->line_edit_local_id = new QLineEdit(this);
-    this->line_edit_local_id->setToolTip("An optional, unique name to use to refer to this object in scripts.\n"
-                                         "If no game is given you can refer to this object using its 'object id' number.");
+    static const QString line_edit_local_id_toolTip = Util::toHtmlParagraph("An optional, unique name to use to refer to this object in scripts. "
+                                                                            "If no name is given you can refer to this object using its 'object id' number.");
+    this->line_edit_local_id->setToolTip(line_edit_local_id_toolTip);
     this->line_edit_local_id->setPlaceholderText("LOCALID_MY_CLONE_NPC");
     l_form_local_id->addRow("Local ID", this->line_edit_local_id);
     this->layout_contents->addLayout(l_form_local_id);
@@ -464,9 +466,10 @@ void CloneObjectFrame::setup() {
     // sprite combo (edits disabled)
     QFormLayout *l_form_sprite = new QFormLayout();
     this->combo_sprite = new NoScrollComboBox(this);
-    this->combo_sprite->setToolTip("The sprite graphics to use for this object. This is updated automatically\n"
-                                    "to match the target object, and so can't be edited. By default the games\n"
-                                    "will get the graphics directly from the target object, so this field is ignored.");
+    static const QString combo_sprite_toolTip = Util::toHtmlParagraph("The sprite graphics to use for this object. This is updated automatically "
+                                                                      "to match the target object, and so can't be edited. By default the games "
+                                                                      "will get the graphics directly from the target object, so this field is ignored.");
+    this->combo_sprite->setToolTip(combo_sprite_toolTip);
     l_form_sprite->addRow("Sprite", this->combo_sprite);
     this->combo_sprite->setEnabled(false);
     this->layout_contents->addLayout(l_form_sprite);
@@ -574,8 +577,9 @@ void WarpFrame::setup() {
     // ID
     QFormLayout *l_form_id = new QFormLayout();
     this->line_edit_id = new QLineEdit(this);
-    this->line_edit_id->setToolTip("An optional, unique name to use to refer to this warp from other warps.\n"
-                                   "If no game is given you can refer to this warp using its 'warp id' number.");
+    static const QString line_edit_id_toolTip = Util::toHtmlParagraph("An optional, unique name to use to refer to this warp from other warps. "
+                                                                      "If no name is given you can refer to this warp using its 'warp id' number.");
+    this->line_edit_id->setToolTip(line_edit_id_toolTip);
     this->line_edit_id->setPlaceholderText("WARP_ID_MY_WARP");
     l_form_id->addRow("ID", this->line_edit_id);
     this->layout_contents->addLayout(l_form_id);

--- a/src/ui/eventframes.cpp
+++ b/src/ui/eventframes.cpp
@@ -320,6 +320,7 @@ void ObjectFrame::connectSignals(MainWindow *window) {
     if (this->connected) return;
 
     EventFrame::connectSignals(window);
+    Project *project = window->editor->project;
 
     // local id
     this->line_edit_local_id->disconnect();
@@ -330,18 +331,18 @@ void ObjectFrame::connectSignals(MainWindow *window) {
 
     // sprite update
     this->combo_sprite->disconnect();
-    connect(this->combo_sprite, &QComboBox::currentTextChanged, [this](const QString &text) {
+    connect(this->combo_sprite, &QComboBox::currentTextChanged, [this, project](const QString &text) {
         this->object->setGfx(text);
-        this->object->getPixmapItem()->updatePixmap();
+        this->object->getPixmapItem()->render(project);
         this->object->modify();
     });
-    connect(this->object->getPixmapItem(), &EventPixmapItem::spriteChanged, this->label_icon, &QLabel::setPixmap);
+    connect(this->object->getPixmapItem(), &EventPixmapItem::rendered, this->label_icon, &QLabel::setPixmap);
 
     // movement
     this->combo_movement->disconnect();
-    connect(this->combo_movement, &QComboBox::currentTextChanged, [this](const QString &text) {
+    connect(this->combo_movement, &QComboBox::currentTextChanged, [this, project](const QString &text) {
         this->object->setMovement(text);
-        this->object->getPixmapItem()->updatePixmap();
+        this->object->getPixmapItem()->render(project);
         this->object->modify();
     });
 
@@ -498,13 +499,13 @@ void CloneObjectFrame::connectSignals(MainWindow *window) {
     });
 
     // update icon displayed in frame with target
-    connect(this->clone->getPixmapItem(), &EventPixmapItem::spriteChanged, this->label_icon, &QLabel::setPixmap);
+    connect(this->clone->getPixmapItem(), &EventPixmapItem::rendered, this->label_icon, &QLabel::setPixmap);
 
     // target map
     this->combo_target_map->disconnect();
     connect(this->combo_target_map, &QComboBox::currentTextChanged, [this, project](const QString &mapName) {
         this->clone->setTargetMap(mapName);
-        this->clone->getPixmapItem()->updatePixmap();
+        this->clone->getPixmapItem()->render(project);
         this->combo_sprite->setCurrentText(this->clone->getGfx());
         this->clone->modify();
         populateIdNameDropdown(this->combo_target_id, project, mapName, Event::Group::Object);
@@ -513,9 +514,9 @@ void CloneObjectFrame::connectSignals(MainWindow *window) {
 
     // target id
     this->combo_target_id->disconnect();
-    connect(this->combo_target_id, &QComboBox::currentTextChanged, [this](const QString &text) {
+    connect(this->combo_target_id, &QComboBox::currentTextChanged, [this, project](const QString &text) {
         this->clone->setTargetID(text);
-        this->clone->getPixmapItem()->updatePixmap();
+        this->clone->getPixmapItem()->render(project);
         this->combo_sprite->setCurrentText(this->clone->getGfx());
         this->clone->modify();
     });

--- a/src/ui/eventframes.cpp
+++ b/src/ui/eventframes.cpp
@@ -74,6 +74,7 @@ void EventFrame::setup() {
     this->label_id = new QLabel("event_type");
     l_vbox_1->addWidget(this->label_id);
     l_vbox_1->addLayout(l_layout_xyz);
+    this->label_id->setText(Event::typeToString(this->event->getEventType()));
 
     // icon / pixmap label
     this->label_icon = new QLabel(this);
@@ -203,8 +204,6 @@ void EventFrame::populateScriptDropdown(NoScrollComboBox * combo, Project * proj
 
 void ObjectFrame::setup() {
     EventFrame::setup();
-
-    this->label_id->setText("Object");
 
     // sprite combo
     QFormLayout *l_form_sprite = new QFormLayout();
@@ -406,8 +405,6 @@ void ObjectFrame::populate(Project *project) {
 void CloneObjectFrame::setup() {
     EventFrame::setup();
 
-    this->label_id->setText("Clone Object");
-
     this->spinner_z->setEnabled(false);
 
     // sprite combo (edits disabled)
@@ -424,11 +421,12 @@ void CloneObjectFrame::setup() {
     l_form_dest_map->addRow("Target Map", this->combo_target_map);
     this->layout_contents->addLayout(l_form_dest_map);
 
-    // clone local id spinbox
+    // clone local id combo
     QFormLayout *l_form_dest_id = new QFormLayout();
-    this->spinner_target_id = new NoScrollSpinBox(this);
-    this->spinner_target_id->setToolTip("event_object ID of the object being cloned.");
-    l_form_dest_id->addRow("Target Local ID", this->spinner_target_id);
+    this->combo_target_id = new NoScrollComboBox(this);
+    // TODO: Once object events have a real local ID input field, this tool tip should be updated to reflect the name of that field
+    this->combo_target_id->setToolTip("event_object ID of the object being cloned.");
+    l_form_dest_id->addRow("Target Local ID", this->combo_target_id);
     this->layout_contents->addLayout(l_form_dest_id);
 
     // custom attributes
@@ -450,19 +448,17 @@ void CloneObjectFrame::connectSignals(MainWindow *window) {
         this->clone->getPixmapItem()->updatePixmap();
         this->combo_sprite->setCurrentText(this->clone->getGfx());
         this->clone->modify();
+        // TODO: If this field changes to the name of a valid map then the available items in the ID combo box should be refreshed.
     });
 
     // target id
-    // TODO: Replace spinner with combo box populated with local IDs from target map.
-    this->spinner_target_id->disconnect();
-    /*
-    connect(this->spinner_target_id, QOverload<int>::of(&QSpinBox::valueChanged), [this](int value) {
-        this->clone->setTargetID(value);
+    this->combo_target_id->disconnect();
+    connect(this->combo_target_id, &QComboBox::currentTextChanged, [this](const QString &text) {
+        this->clone->setTargetID(text);
         this->clone->getPixmapItem()->updatePixmap();
         this->combo_sprite->setCurrentText(this->clone->getGfx());
         this->clone->modify();
     });
-    */
 }
 
 void CloneObjectFrame::initialize() {
@@ -475,9 +471,7 @@ void CloneObjectFrame::initialize() {
     this->combo_sprite->setCurrentText(this->clone->getGfx());
 
     // target id
-    this->spinner_target_id->setMinimum(1);
-    this->spinner_target_id->setMaximum(126);
-    //this->spinner_target_id->setValue(this->clone->getTargetID());
+    this->combo_target_id->setCurrentText(this->clone->getTargetID());
 
     // target map
     this->combo_target_map->setTextItem(this->clone->getTargetMap());
@@ -490,12 +484,11 @@ void CloneObjectFrame::populate(Project *project) {
     EventFrame::populate(project);
 
     this->combo_target_map->addItems(project->mapNames);
+    // TODO: Populate combo_target_id with local IDs from target map.
 }
 
 void WarpFrame::setup() {
     EventFrame::setup();
-
-    this->label_id->setText("Warp");
 
     // desination map combo
     QFormLayout *l_form_dest_map = new QFormLayout();
@@ -537,6 +530,7 @@ void WarpFrame::connectSignals(MainWindow *window) {
     connect(this->combo_dest_map, &QComboBox::currentTextChanged, [this](const QString &text) {
         this->warp->setDestinationMap(text);
         this->warp->modify();
+        // TODO: If this field changes to the name of a valid map then the available items in the ID combo box should be refreshed.
     });
 
     // dest id
@@ -571,14 +565,13 @@ void WarpFrame::populate(Project *project) {
     EventFrame::populate(project);
 
     this->combo_dest_map->addItems(project->mapNames);
+    // TODO: Populate combo_dest_warp with local IDs from target map.
 }
 
 
 
 void TriggerFrame::setup() {
     EventFrame::setup();
-
-    this->label_id->setText("Trigger");
 
     // script combo
     QFormLayout *l_form_script = new QFormLayout();
@@ -666,8 +659,6 @@ void TriggerFrame::populate(Project *project) {
 void WeatherTriggerFrame::setup() {
     EventFrame::setup();
 
-    this->label_id->setText("Weather Trigger");
-
     // weather combo
     QFormLayout *l_form_weather = new QFormLayout();
     this->combo_weather = new NoScrollComboBox(this);
@@ -716,8 +707,6 @@ void WeatherTriggerFrame::populate(Project *project) {
 
 void SignFrame::setup() {
     EventFrame::setup();
-
-    this->label_id->setText("Sign");
 
     // facing dir combo
     QFormLayout *l_form_facing_dir = new QFormLayout();
@@ -787,8 +776,6 @@ void SignFrame::populate(Project *project) {
 
 void HiddenItemFrame::setup() {
     EventFrame::setup();
-
-    this->label_id->setText("Hidden Item");
 
     // item combo
     QFormLayout *l_form_item = new QFormLayout();
@@ -902,8 +889,6 @@ void HiddenItemFrame::populate(Project *project) {
 void SecretBaseFrame::setup() {
     EventFrame::setup();
 
-    this->label_id->setText("Secret Base");
-
     this->spinner_z->setEnabled(false);
 
     // item combo
@@ -955,8 +940,6 @@ void SecretBaseFrame::populate(Project *project) {
 void HealLocationFrame::setup() {
     EventFrame::setup();
 
-    this->label_id->setText("Heal Location");
-
     this->hideable_label_z->setVisible(false);
     this->spinner_z->setVisible(false);
 
@@ -982,6 +965,7 @@ void HealLocationFrame::setup() {
     QFormLayout *l_form_respawn_npc = new QFormLayout(hideable_respawn_npc);
     l_form_respawn_npc->setContentsMargins(0, 0, 0, 0);
     this->combo_respawn_npc = new NoScrollComboBox(hideable_respawn_npc);
+    // TODO: Once object events have a real local ID input field, this tool tip should be updated to reflect the name of that field
     this->combo_respawn_npc->setToolTip("event_object ID of the NPC the player interacts with\n" 
                                           "upon respawning after whiteout.");
     l_form_respawn_npc->addRow("Respawn NPC", this->combo_respawn_npc);
@@ -1006,6 +990,7 @@ void HealLocationFrame::connectSignals(MainWindow *window) {
     connect(this->combo_respawn_map, &QComboBox::currentTextChanged, [this](const QString &text) {
         this->healLocation->setRespawnMapName(text);
         this->healLocation->modify();
+        // TODO: If this field changes to the name of a valid map then the available items in the ID combo box should be refreshed.
     });
 
     this->combo_respawn_npc->disconnect();
@@ -1038,5 +1023,4 @@ void HealLocationFrame::populate(Project *project) {
 
     this->combo_respawn_map->addItems(project->mapNames);
     // TODO: We should dynamically populate combo_respawn_npc with the local IDs of the respawn_map
-    //       Same for warp IDs.
 }

--- a/src/ui/eventpixmapitem.cpp
+++ b/src/ui/eventpixmapitem.cpp
@@ -74,6 +74,7 @@ void EventPixmapItem::mousePressEvent(QGraphicsSceneMouseEvent *mouseEvent) {
     if (selectionToggle || !m_selected) {
         // User is either toggling this selection on/off as part of a group selection,
         // or they're newly selecting just this item.
+        m_selected = (selectionToggle) ? !m_selected : true;
         emit selected(m_event, selectionToggle);
     } else {
         // This item is already selected and the user isn't toggling the selection, so there are 4 possibilities:
@@ -89,7 +90,7 @@ void EventPixmapItem::mousePressEvent(QGraphicsSceneMouseEvent *mouseEvent) {
 }
 
 void EventPixmapItem::mouseMoveEvent(QGraphicsSceneMouseEvent *mouseEvent) {
-    if (!m_active)
+    if (!m_active || !m_selected)
         return;
 
     QPoint pos = Metatile::coordFromPixmapCoord(mouseEvent->scenePos());

--- a/src/ui/eventpixmapitem.cpp
+++ b/src/ui/eventpixmapitem.cpp
@@ -1,4 +1,4 @@
-#include "draggablepixmapitem.h"
+#include "eventpixmapitem.h"
 #include "editor.h"
 #include "editcommands.h"
 #include "mapruler.h"
@@ -7,7 +7,7 @@
 static unsigned currentActionId = 0;
 
 
-void DraggablePixmapItem::updatePosition() {
+void EventPixmapItem::updatePosition() {
     int x = this->event->getPixelX();
     int y = this->event->getPixelY();
     setX(x);
@@ -15,17 +15,17 @@ void DraggablePixmapItem::updatePosition() {
     editor->updateWarpEventWarning(event);
 }
 
-void DraggablePixmapItem::emitPositionChanged() {
+void EventPixmapItem::emitPositionChanged() {
     emit xChanged(event->getX());
     emit yChanged(event->getY());
 }
 
-void DraggablePixmapItem::updatePixmap() {
+void EventPixmapItem::updatePixmap() {
     editor->redrawEventPixmapItem(this);
     emit spriteChanged(event->getPixmap());
 }
 
-void DraggablePixmapItem::mousePressEvent(QGraphicsSceneMouseEvent *mouse) {
+void EventPixmapItem::mousePressEvent(QGraphicsSceneMouseEvent *mouse) {
     if (this->active)
         return;
     this->active = true;
@@ -49,21 +49,21 @@ void DraggablePixmapItem::mousePressEvent(QGraphicsSceneMouseEvent *mouse) {
     this->editor->selectingEvent = true;
 }
 
-void DraggablePixmapItem::move(int dx, int dy) {
+void EventPixmapItem::move(int dx, int dy) {
     event->setX(event->getX() + dx);
     event->setY(event->getY() + dy);
     updatePosition();
     emitPositionChanged();
 }
 
-void DraggablePixmapItem::moveTo(const QPoint &pos) {
+void EventPixmapItem::moveTo(const QPoint &pos) {
     event->setX(pos.x());
     event->setY(pos.y());
     updatePosition();
     emitPositionChanged();
 }
 
-void DraggablePixmapItem::mouseMoveEvent(QGraphicsSceneMouseEvent *mouse) {
+void EventPixmapItem::mouseMoveEvent(QGraphicsSceneMouseEvent *mouse) {
     if (!this->active)
         return;
 
@@ -85,7 +85,7 @@ void DraggablePixmapItem::mouseMoveEvent(QGraphicsSceneMouseEvent *mouse) {
     this->releaseSelectionQueued = false;
 }
 
-void DraggablePixmapItem::mouseReleaseEvent(QGraphicsSceneMouseEvent *mouse) {
+void EventPixmapItem::mouseReleaseEvent(QGraphicsSceneMouseEvent *mouse) {
     if (!this->active)
         return;
     this->active = false;

--- a/src/ui/eventpixmapitem.cpp
+++ b/src/ui/eventpixmapitem.cpp
@@ -4,8 +4,19 @@
 #include "mapruler.h"
 #include "metatile.h"
 
-static unsigned currentActionId = 0;
+void EventPixmapItem::move(int dx, int dy) {
+    event->setX(event->getX() + dx);
+    event->setY(event->getY() + dy);
+    updatePosition();
+    emitPositionChanged();
+}
 
+void EventPixmapItem::moveTo(const QPoint &pos) {
+    event->setX(pos.x());
+    event->setY(pos.y());
+    updatePosition();
+    emitPositionChanged();
+}
 
 void EventPixmapItem::updatePosition() {
     int x = this->event->getPixelX();
@@ -25,17 +36,17 @@ void EventPixmapItem::updatePixmap() {
     emit spriteChanged(event->getPixmap());
 }
 
-void EventPixmapItem::mousePressEvent(QGraphicsSceneMouseEvent *mouse) {
+void EventPixmapItem::mousePressEvent(QGraphicsSceneMouseEvent *mouseEvent) {
     if (this->active)
         return;
     this->active = true;
-    this->lastPos = Metatile::coordFromPixmapCoord(mouse->scenePos());
+    this->lastPos = Metatile::coordFromPixmapCoord(mouseEvent->scenePos());
 
-    bool selectionToggle = mouse->modifiers() & Qt::ControlModifier;
+    bool selectionToggle = mouseEvent->modifiers() & Qt::ControlModifier;
     if (selectionToggle || !this->editor->selectedEvents.contains(this->event)) {
         // User is either toggling this selection on/off as part of a group selection,
         // or they're newly selecting just this item.
-        this->editor->selectMapEvent(this->event, selectionToggle);
+        emit selected(this->event, selectionToggle);
     } else {
         // This item is already selected and the user isn't toggling the selection, so there are 4 possibilities:
         // 1. This is the only selected event, and the selection is pointless.
@@ -46,53 +57,30 @@ void EventPixmapItem::mousePressEvent(QGraphicsSceneMouseEvent *mouse) {
         // To support #4 we set the flag below, and we only call 'selectMapEvent' on mouse release if no move occurred.
         this->releaseSelectionQueued = true;
     }
-    this->editor->selectingEvent = true;
+    mouseEvent->accept();
 }
 
-void EventPixmapItem::move(int dx, int dy) {
-    event->setX(event->getX() + dx);
-    event->setY(event->getY() + dy);
-    updatePosition();
-    emitPositionChanged();
-}
-
-void EventPixmapItem::moveTo(const QPoint &pos) {
-    event->setX(pos.x());
-    event->setY(pos.y());
-    updatePosition();
-    emitPositionChanged();
-}
-
-void EventPixmapItem::mouseMoveEvent(QGraphicsSceneMouseEvent *mouse) {
+void EventPixmapItem::mouseMoveEvent(QGraphicsSceneMouseEvent *mouseEvent) {
     if (!this->active)
         return;
 
-    QPoint pos = Metatile::coordFromPixmapCoord(mouse->scenePos());
+    QPoint pos = Metatile::coordFromPixmapCoord(mouseEvent->scenePos());
     if (pos == this->lastPos)
         return;
 
-    QPoint moveDistance = pos - this->lastPos;
-    this->lastPos = pos;
-    emit this->editor->map_item->hoveredMapMetatileChanged(pos);
-
-    QList <Event *> selectedEvents;
-    if (this->editor->selectedEvents.contains(this->event)) {
-        selectedEvents = this->editor->selectedEvents;
-    } else {
-        selectedEvents.append(this->event);
-    }
-    editor->map->commit(new EventMove(selectedEvents, moveDistance.x(), moveDistance.y(), currentActionId));
     this->releaseSelectionQueued = false;
+    emit dragged(this->event, this->lastPos, pos);
+    this->lastPos = pos;
 }
 
-void EventPixmapItem::mouseReleaseEvent(QGraphicsSceneMouseEvent *mouse) {
+void EventPixmapItem::mouseReleaseEvent(QGraphicsSceneMouseEvent *mouseEvent) {
     if (!this->active)
         return;
     this->active = false;
-    currentActionId++;
     if (this->releaseSelectionQueued) {
         this->releaseSelectionQueued = false;
-        if (Metatile::coordFromPixmapCoord(mouse->scenePos()) == this->lastPos)
-            this->editor->selectMapEvent(this->event);
+        if (Metatile::coordFromPixmapCoord(mouseEvent->scenePos()) == this->lastPos)
+            emit selected(this->event, false);
     }
+    emit released(this->event, this->lastPos);
 }

--- a/src/ui/graphicsview.cpp
+++ b/src/ui/graphicsview.cpp
@@ -2,22 +2,7 @@
 #include "mapview.h"
 #include "editor.h"
 
-void GraphicsView::mousePressEvent(QMouseEvent *event) {
-    QGraphicsView::mousePressEvent(event);
-    if (editor) {
-        editor->eventsView_onMousePress(event);
-    }
-}
-
-void GraphicsView::mouseMoveEvent(QMouseEvent *event) {
-    QGraphicsView::mouseMoveEvent(event);
-}
-
-void GraphicsView::mouseReleaseEvent(QMouseEvent *event) {
-    QGraphicsView::mouseReleaseEvent(event);
-}
-
-void GraphicsView::moveEvent(QMoveEvent *event) {
+void MapView::moveEvent(QMoveEvent *event) {
     QGraphicsView::moveEvent(event);
     QLabel *label_MapRulerStatus = findChild<QLabel *>("label_MapRulerStatus", Qt::FindDirectChildrenOnly);
     if (label_MapRulerStatus && label_MapRulerStatus->isVisible())

--- a/src/ui/layoutpixmapitem.cpp
+++ b/src/ui/layoutpixmapitem.cpp
@@ -714,19 +714,20 @@ void LayoutPixmapItem::hoverLeaveEvent(QGraphicsSceneHoverEvent *) {
 }
 
 void LayoutPixmapItem::mousePressEvent(QGraphicsSceneMouseEvent *event) {
-    QPoint pos = Metatile::coordFromPixmapCoord(event->pos());
-    this->paint_tile_initial_x = this->straight_path_initial_x = pos.x();
-    this->paint_tile_initial_y = this->straight_path_initial_y = pos.y();
+    this->metatilePos = Metatile::coordFromPixmapCoord(event->pos());
+    this->paint_tile_initial_x = this->straight_path_initial_x = this->metatilePos.x();
+    this->paint_tile_initial_y = this->straight_path_initial_y = this->metatilePos.y();
     emit startPaint(event, this);
     emit mouseEvent(event, this);
 }
 
 void LayoutPixmapItem::mouseMoveEvent(QGraphicsSceneMouseEvent *event) {
     QPoint pos = Metatile::coordFromPixmapCoord(event->pos());
-    if (pos != this->metatilePos) {
-        this->metatilePos = pos;
-        emit this->hoveredMapMetatileChanged(pos);
-    }
+    if (pos == this->metatilePos)
+        return;
+
+    this->metatilePos = pos;
+    emit hoveredMapMetatileChanged(pos);
     emit mouseEvent(event, this);
 }
 

--- a/src/ui/mapimageexporter.cpp
+++ b/src/ui/mapimageexporter.cpp
@@ -113,8 +113,7 @@ void MapImageExporter::setModeSpecificUi() {
     }
 
     if (m_mode == ImageExporterMode::Timelapse) {
-        // TODO: At the moment edit history for events (and the EventPixmapItem class)
-        // explicitly depend on the editor and assume their map is currently open.
+        // TODO: At the moment edit history for events explicitly depend on the editor and assume their map is currently open.
         // Other edit commands rely on this more subtly, like triggering API callbacks or
         // spending time rendering their layout (which can make creating timelapses very slow).
         // Until this is resolved, the selected map/layout must remain the same as in the editor.

--- a/src/ui/mapimageexporter.cpp
+++ b/src/ui/mapimageexporter.cpp
@@ -96,7 +96,7 @@ void MapImageExporter::setModeSpecificUi() {
     }
 
     if (m_mode == ImageExporterMode::Timelapse) {
-        // TODO: At the moment edit history for events (and the DraggablePixmapItem class)
+        // TODO: At the moment edit history for events (and the EventPixmapItem class)
         // explicitly depend on the editor and assume their map is currently open.
         // Other edit commands rely on this more subtly, like triggering API callbacks or
         // spending time rendering their layout (which can make creating timelapses very slow).

--- a/src/ui/movablerect.cpp
+++ b/src/ui/movablerect.cpp
@@ -27,7 +27,6 @@ ResizableRect::ResizableRect(QObject *parent, bool *enabled, int width, int heig
   : QObject(parent),
     MovableRect(enabled, width * 16, height * 16, color)
 {
-        setZValue(0xFFFFFFFF); // ensure on top of view
         setAcceptHoverEvents(true);
         setFlags(this->flags() | QGraphicsItem::ItemIsMovable);
 }

--- a/src/ui/resizelayoutpopup.cpp
+++ b/src/ui/resizelayoutpopup.cpp
@@ -139,6 +139,7 @@ void ResizeLayoutPopup::setupLayoutView() {
     static bool layoutSizeRectVisible = true;
 
     this->outline = new ResizableRect(this, &layoutSizeRectVisible, this->editor->layout->getWidth(), this->editor->layout->getHeight(), qRgb(255, 0, 255));
+    this->outline->setZValue(Editor::ZValue::ResizeLayoutPopup); // Ensure on top of view
     this->outline->setLimit(cover->rect().toAlignedRect());
     connect(outline, &ResizableRect::rectUpdated, [=](QRect rect){
         // Note: this extra limit check needs access to the project values, so it is done here and not ResizableRect::mouseMoveEvent


### PR DESCRIPTION
Closes #623 
- Add input fields for event ID strings to object events, clone object events, and warps
- Fix improper handling of local IDs for events that open maps when double-clicked
- Fix #710 
- Fix deselecting an event still allowing you to drag the event around
- Fix events rendering on top of the ruler at very high y values
- Fix new map names not appearing in event drop downs that have already been populated
- Separate the `DraggablePixmapItem` class from the Editor