### PR TITLE
Add global define settings

### DIFF
--- a/forms/newdefinedialog.ui
+++ b/forms/newdefinedialog.ui
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>NewDefineDialog</class>
+ <widget class="QDialog" name="NewDefineDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>252</width>
+    <height>124</height>
+   </rect>
+  </property>
+  <property name="modal">
+   <bool>true</bool>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QFrame" name="form">
+     <layout class="QFormLayout" name="formLayout">
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <item row="0" column="0">
+       <widget class="QLabel" name="label_Name">
+        <property name="text">
+         <string>Name</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QLineEdit" name="lineEdit_Name">
+        <property name="clearButtonEnabled">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QLabel" name="label_NameError">
+        <property name="visible">
+         <bool>false</bool>
+        </property>
+        <property name="styleSheet">
+         <string notr="true">color: rgb(255, 0, 0)</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="QLineEdit" name="lineEdit_Value"/>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="label_Value">
+        <property name="text">
+         <string>Value</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Orientation::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::StandardButton::Cancel|QDialogButtonBox::StandardButton::Ok</set>
+     </property>
+     <property name="centerButtons">
+      <bool>false</bool>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/forms/projectsettingseditor.ui
+++ b/forms/projectsettingseditor.ui
@@ -21,7 +21,7 @@
     <item>
      <widget class="QTabWidget" name="mainTabs">
       <property name="currentIndex">
-       <number>4</number>
+       <number>0</number>
       </property>
       <widget class="QWidget" name="tab_General">
        <attribute name="title">

--- a/forms/projectsettingseditor.ui
+++ b/forms/projectsettingseditor.ui
@@ -21,7 +21,7 @@
     <item>
      <widget class="QTabWidget" name="mainTabs">
       <property name="currentIndex">
-       <number>0</number>
+       <number>4</number>
       </property>
       <widget class="QWidget" name="tab_General">
        <attribute name="title">
@@ -1582,19 +1582,21 @@
              <height>499</height>
             </rect>
            </property>
-           <layout class="QVBoxLayout" name="verticalLayout_10">
-            <item>
-             <widget class="QToolButton" name="button_HelpFiles">
-              <property name="text">
-               <string>...</string>
+           <layout class="QGridLayout" name="gridLayout_10" rowstretch="1,2,8">
+            <item row="0" column="1">
+             <spacer name="horizontalSpacer_5">
+              <property name="orientation">
+               <enum>Qt::Orientation::Horizontal</enum>
               </property>
-              <property name="icon">
-               <iconset resource="../resources/images.qrc">
-                <normaloff>:/icons/help.ico</normaloff>:/icons/help.ico</iconset>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
               </property>
-             </widget>
+             </spacer>
             </item>
-            <item>
+            <item row="2" column="0" colspan="3">
              <widget class="QWidget" name="widget_ProjectPaths" native="true">
               <layout class="QVBoxLayout" name="verticalLayout_6">
                <property name="spacing">
@@ -1626,7 +1628,7 @@
                     <x>0</x>
                     <y>0</y>
                     <width>544</width>
-                    <height>437</height>
+                    <height>338</height>
                    </rect>
                   </property>
                   <layout class="QFormLayout" name="layout_ProjectPaths">
@@ -1645,6 +1647,34 @@
                </item>
               </layout>
              </widget>
+            </item>
+            <item row="0" column="2">
+             <widget class="QPushButton" name="button_AddGlobalConstantsFile">
+              <property name="toolTip">
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Add additional C files containing #defines or enums. These will be used to resolve unknown symbols during project launch.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+              </property>
+              <property name="text">
+               <string>Add Global Constants File...</string>
+              </property>
+              <property name="icon">
+               <iconset resource="../resources/images.qrc">
+                <normaloff>:/icons/add.ico</normaloff>:/icons/add.ico</iconset>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="0">
+             <widget class="QToolButton" name="button_HelpFiles">
+              <property name="text">
+               <string>...</string>
+              </property>
+              <property name="icon">
+               <iconset resource="../resources/images.qrc">
+                <normaloff>:/icons/help.ico</normaloff>:/icons/help.ico</iconset>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="0" colspan="3">
+             <layout class="QGridLayout" name="gridLayout_GlobalConstantsFiles"/>
             </item>
            </layout>
           </widget>
@@ -1671,8 +1701,8 @@
              <height>499</height>
             </rect>
            </property>
-           <layout class="QVBoxLayout" name="verticalLayout_19">
-            <item>
+           <layout class="QGridLayout" name="gridLayout_11">
+            <item row="0" column="0">
              <widget class="QToolButton" name="button_HelpIdentifiers">
               <property name="text">
                <string>...</string>
@@ -1683,7 +1713,7 @@
               </property>
              </widget>
             </item>
-            <item>
+            <item row="2" column="0" colspan="3">
              <widget class="QWidget" name="widget_Identifiers" native="true">
               <layout class="QVBoxLayout" name="verticalLayout_20">
                <property name="spacing">
@@ -1715,7 +1745,7 @@
                     <x>0</x>
                     <y>0</y>
                     <width>544</width>
-                    <height>437</height>
+                    <height>421</height>
                    </rect>
                   </property>
                   <layout class="QFormLayout" name="layout_Identifiers">
@@ -1734,6 +1764,36 @@
                </item>
               </layout>
              </widget>
+            </item>
+            <item row="0" column="2">
+             <widget class="QPushButton" name="button_AddGlobalConstant">
+              <property name="toolTip">
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Add an additional #define name and expression. This may be used to evaluate other #defines during project launch.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+              </property>
+              <property name="text">
+               <string>Add Global Constant...</string>
+              </property>
+              <property name="icon">
+               <iconset resource="../resources/images.qrc">
+                <normaloff>:/icons/add.ico</normaloff>:/icons/add.ico</iconset>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="1">
+             <spacer name="horizontalSpacer_7">
+              <property name="orientation">
+               <enum>Qt::Orientation::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+            <item row="1" column="0" colspan="3">
+             <layout class="QGridLayout" name="gridLayout_GlobalConstants"/>
             </item>
            </layout>
           </widget>

--- a/include/config.h
+++ b/include/config.h
@@ -346,6 +346,7 @@ public:
         this->unusedTileSplit = 0x0000;
         this->maxEventsPerGroup = 255;
         this->globalConstantsFilepaths.clear();
+        this->globalConstants.clear();
         this->identifiers.clear();
         this->readKeys.clear();
     }
@@ -419,6 +420,7 @@ public:
     QList<uint32_t> warpBehaviors;
     int maxEventsPerGroup;
     QStringList globalConstantsFilepaths;
+    QMap<QString,QString> globalConstants;
 
 protected:
     virtual QString getConfigFilepath() override;

--- a/include/config.h
+++ b/include/config.h
@@ -345,6 +345,7 @@ public:
         this->unusedTileCovered = 0x0000;
         this->unusedTileSplit = 0x0000;
         this->maxEventsPerGroup = 255;
+        this->globalConstantsFilepaths.clear();
         this->identifiers.clear();
         this->readKeys.clear();
     }
@@ -417,6 +418,7 @@ public:
     QMargins playerViewDistance;
     QList<uint32_t> warpBehaviors;
     int maxEventsPerGroup;
+    QStringList globalConstantsFilepaths;
 
 protected:
     virtual QString getConfigFilepath() override;

--- a/include/core/parseutil.h
+++ b/include/core/parseutil.h
@@ -60,7 +60,7 @@ public:
     QStringList readCDefineNames(const QString &filename, const QSet<QString> &regexList, QString *error = nullptr);
     void loadGlobalCDefinesFromFile(const QString &filename, QString *error = nullptr);
     void loadGlobalCDefines(const QMap<QString,QString> &defines);
-    void resetGlobalCDefines();
+    void resetCDefines();
     OrderedMap<QString, QHash<QString, QString>> readCStructs(const QString &, const QString & = "", const QHash<int, QString>& = {});
     QList<QStringList> getLabelMacros(const QList<QStringList>&, const QString&);
     QStringList getLabelValues(const QList<QStringList>&, const QString&);
@@ -93,10 +93,20 @@ private:
     QString curDefine;
     QHash<QString, QString> fileCache;
     QHash<QString, QStringList> errorMap;
+
+    // The maps of define names to values/expressions that are available while parsing C defines.
+    // As the parser reads and evaluates more defines it will update these maps accordingly.
+    QMap<QString, int> knownDefineValues;
+    QMap<QString, QString> knownDefineExpressions;
+
+    // Maps of special define names to values/expressions that take precedence over defines encountered while parsing.
+    // Some (like 'TRUE'/'FALSE') are always present in these maps, others may be specified by the user with 'loadGlobalCDefines' / 'loadGlobalCDefinesFromFile'.
     QMap<QString, int> globalDefineValues;
     QMap<QString, QString> globalDefineExpressions;
-    int evaluateDefine(const QString&, const QString &, QMap<QString, int>*, QMap<QString, QString>*);
-    QList<Token> tokenizeExpression(QString, QMap<QString, int>*, QMap<QString, QString>*);
+
+    int evaluateDefine(const QString &identifier, bool *ok = nullptr);
+    int evaluateExpression(const QString &expression);
+    QList<Token> tokenizeExpression(QString expression);
     QList<Token> generatePostfix(const QList<Token> &tokens);
     int evaluatePostfix(const QList<Token> &postfix);
     void recordError(const QString &message);

--- a/include/core/parseutil.h
+++ b/include/core/parseutil.h
@@ -55,11 +55,12 @@ public:
     QString readCIncbin(const QString &text, const QString &label);
     QMap<QString, QString> readCIncbinMulti(const QString &filepath);
     QStringList readCIncbinArray(const QString &filename, const QString &label);
-    QMap<QString, int> readCDefinesByRegex(const QString &filename, const QSet<QString> &regexList, QString *error = nullptr);
-    QMap<QString, int> readCDefinesByName(const QString &filename, const QSet<QString> &names, QString *error = nullptr);
+    QHash<QString, int> readCDefinesByRegex(const QString &filename, const QSet<QString> &regexList, QString *error = nullptr);
+    QHash<QString, int> readCDefinesByName(const QString &filename, const QSet<QString> &names, QString *error = nullptr);
     QStringList readCDefineNames(const QString &filename, const QSet<QString> &regexList, QString *error = nullptr);
     void loadGlobalCDefinesFromFile(const QString &filename, QString *error = nullptr);
     void loadGlobalCDefines(const QMap<QString,QString> &defines);
+    void loadGlobalCDefines(const QHash<QString,QString> &defines);
     void resetCDefines();
     OrderedMap<QString, QHash<QString, QString>> readCStructs(const QString &, const QString & = "", const QHash<int, QString>& = {});
     QList<QStringList> getLabelMacros(const QList<QStringList>&, const QString&);
@@ -96,13 +97,13 @@ private:
 
     // The maps of define names to values/expressions that are available while parsing C defines.
     // As the parser reads and evaluates more defines it will update these maps accordingly.
-    QMap<QString, int> knownDefineValues;
-    QMap<QString, QString> knownDefineExpressions;
+    QHash<QString, int> knownDefineValues;
+    QHash<QString, QString> knownDefineExpressions;
 
     // Maps of special define names to values/expressions that take precedence over defines encountered while parsing.
     // Some (like 'TRUE'/'FALSE') are always present in these maps, others may be specified by the user with 'loadGlobalCDefines' / 'loadGlobalCDefinesFromFile'.
-    QMap<QString, int> globalDefineValues;
-    QMap<QString, QString> globalDefineExpressions;
+    QHash<QString, int> globalDefineValues;
+    QHash<QString, QString> globalDefineExpressions;
 
     int evaluateDefine(const QString &identifier, bool *ok = nullptr);
     int evaluateExpression(const QString &expression);
@@ -115,11 +116,11 @@ private:
     QString createErrorMessage(const QString &message, const QString &expression);
 
     struct ParsedDefines {
-        QMap<QString,QString> expressions; // Map of all define names encountered to their expressions
+        QHash<QString,QString> expressions; // Map of all define names encountered to their expressions
         QStringList filteredNames; // List of define names that matched the search text, in the order that they were encountered
     };
     ParsedDefines readCDefines(const QString &filename, const QSet<QString> &filterList, bool useRegex, QString *error);
-    QMap<QString, int> evaluateCDefines(const QString &filename, const QSet<QString> &filterList, bool useRegex, QString *error);
+    QHash<QString, int> evaluateCDefines(const QString &filename, const QSet<QString> &filterList, bool useRegex, QString *error);
     bool defineNameMatchesFilter(const QString &name, const QSet<QString> &filterList) const;
     bool defineNameMatchesFilter(const QString &name, const QSet<QRegularExpression> &filterList) const;
     QString loadTextFile(const QString &path, QString *error = nullptr);

--- a/include/core/parseutil.h
+++ b/include/core/parseutil.h
@@ -58,7 +58,8 @@ public:
     QMap<QString, int> readCDefinesByRegex(const QString &filename, const QSet<QString> &regexList, QString *error = nullptr);
     QMap<QString, int> readCDefinesByName(const QString &filename, const QSet<QString> &names, QString *error = nullptr);
     QStringList readCDefineNames(const QString &filename, const QSet<QString> &regexList, QString *error = nullptr);
-    void loadGlobalCDefines(const QString &filename, QString *error = nullptr);
+    void loadGlobalCDefinesFromFile(const QString &filename, QString *error = nullptr);
+    void loadGlobalCDefines(const QMap<QString,QString> &defines);
     void resetGlobalCDefines();
     OrderedMap<QString, QHash<QString, QString>> readCStructs(const QString &, const QString & = "", const QHash<int, QString>& = {});
     QList<QStringList> getLabelMacros(const QList<QStringList>&, const QString&);

--- a/include/core/parseutil.h
+++ b/include/core/parseutil.h
@@ -43,7 +43,7 @@ class ParseUtil
 {
 public:
     ParseUtil();
-    void set_root(const QString &dir);
+    void setRoot(const QString &dir) { this->root = dir; }
     static QString readTextFile(const QString &path, QString *error = nullptr);
     bool cacheFile(const QString &path, QString *error = nullptr);
     void clearFileCache() { this->fileCache.clear(); }
@@ -58,6 +58,8 @@ public:
     QMap<QString, int> readCDefinesByRegex(const QString &filename, const QSet<QString> &regexList, QString *error = nullptr);
     QMap<QString, int> readCDefinesByName(const QString &filename, const QSet<QString> &names, QString *error = nullptr);
     QStringList readCDefineNames(const QString &filename, const QSet<QString> &regexList, QString *error = nullptr);
+    void loadGlobalCDefines(const QString &filename, QString *error = nullptr);
+    void resetGlobalCDefines();
     OrderedMap<QString, QHash<QString, QString>> readCStructs(const QString &, const QString & = "", const QHash<int, QString>& = {});
     QList<QStringList> getLabelMacros(const QList<QStringList>&, const QString&);
     QStringList getLabelValues(const QList<QStringList>&, const QString&);
@@ -90,6 +92,8 @@ private:
     QString curDefine;
     QHash<QString, QString> fileCache;
     QHash<QString, QStringList> errorMap;
+    QMap<QString, int> globalDefineValues;
+    QMap<QString, QString> globalDefineExpressions;
     int evaluateDefine(const QString&, const QString &, QMap<QString, int>*, QMap<QString, QString>*);
     QList<Token> tokenizeExpression(QString, QMap<QString, int>*, QMap<QString, QString>*);
     QList<Token> generatePostfix(const QList<Token> &tokens);

--- a/include/project.h
+++ b/include/project.h
@@ -76,7 +76,7 @@ public:
     int maxEncounterRate;
     bool wildEncountersLoaded;
 
-    void set_root(QString);
+    void setRoot(const QString&);
 
     void clearMaps();
     void clearTilesetCache();
@@ -203,6 +203,7 @@ public:
     bool readEventGraphics();
     bool readFieldmapProperties();
     bool readFieldmapMasks();
+    bool readGlobalConstants();
     QMap<QString, QMap<QString, QString>> readObjEventGfxInfo();
 
     QPixmap getEventPixmap(const QString &gfxName, const QString &movementName);

--- a/include/ui/newdefinedialog.h
+++ b/include/ui/newdefinedialog.h
@@ -1,0 +1,32 @@
+#ifndef NEWDEFINEDIALOG_H
+#define NEWDEFINEDIALOG_H
+
+#include <QDialog>
+#include <QAbstractButton>
+
+namespace Ui {
+class NewDefineDialog;
+}
+
+class NewDefineDialog : public QDialog
+{
+    Q_OBJECT
+
+public:
+    explicit NewDefineDialog(QWidget *parent = nullptr);
+    ~NewDefineDialog();
+
+    virtual void accept() override;
+
+signals:
+    void createdDefine(const QString &name, const QString &expression);
+
+private:
+    Ui::NewDefineDialog *ui;
+
+    bool validateName(bool allowEmpty = false);
+    void onNameChanged(const QString &name);
+    void dialogButtonClicked(QAbstractButton *button);
+};
+
+#endif // NEWDEFINEDIALOG_H

--- a/include/ui/projectsettingseditor.h
+++ b/include/ui/projectsettingseditor.h
@@ -67,6 +67,12 @@ private:
     void setWarpBehaviorsList(QStringList list);
     void openFilesHelp();
     void openIdentifiersHelp();
+    void addNewGlobalConstantsFilepath();
+    void addGlobalConstantsFilepath(const QString &filepath);
+    QStringList getGlobalConstantsFilepaths();
+    void addNewGlobalConstant();
+    void addGlobalConstant(const QString &name, const QString &expression);
+    QMap<QString,QString> getGlobalConstants();
 
 private slots:
     void dialogButtonClicked(QAbstractButton *button);

--- a/porymap.pro
+++ b/porymap.pro
@@ -104,6 +104,7 @@ SOURCES += src/core/advancemapparser.cpp \
     src/ui/metatileselector.cpp \
     src/ui/movablerect.cpp \
     src/ui/movementpermissionsselector.cpp \
+    src/ui/newdefinedialog.cpp \
     src/ui/neweventtoolbutton.cpp \
     src/ui/newlayoutdialog.cpp \
     src/ui/newlayoutform.cpp \
@@ -216,6 +217,7 @@ HEADERS  += include/core/advancemapparser.h \
     include/ui/metatileselector.h \
     include/ui/movablerect.h \
     include/ui/movementpermissionsselector.h \
+    include/ui/newdefinedialog.h \
     include/ui/neweventtoolbutton.h \
     include/ui/newlayoutdialog.h \
     include/ui/newlayoutform.h \
@@ -269,6 +271,7 @@ FORMS    += forms/mainwindow.ui \
     forms/gridsettingsdialog.ui \
     forms/mapheaderform.ui \
     forms/maplisttoolbar.ui \
+    forms/newdefinedialog.ui \
     forms/newlayoutdialog.ui \
     forms/newlayoutform.ui \
     forms/newlocationdialog.ui \

--- a/src/core/parseutil.cpp
+++ b/src/core/parseutil.cpp
@@ -488,11 +488,11 @@ ParseUtil::ParsedDefines ParseUtil::readCDefines(const QString &filename, const 
 }
 
 // Read all the define names and their expressions in the specified file, then evaluate the ones matching the search text (and any they depend on).
-QMap<QString, int> ParseUtil::evaluateCDefines(const QString &filename, const QSet<QString> &filterList, bool useRegex, QString *error) {
+QHash<QString, int> ParseUtil::evaluateCDefines(const QString &filename, const QSet<QString> &filterList, bool useRegex, QString *error) {
     ParsedDefines defines = readCDefines(filename, filterList, useRegex, error);
 
     // Evaluate defines
-    QMap<QString, int> filteredValues;
+    QHash<QString, int> filteredValues;
     this->errorMap.clear();
     while (!defines.filteredNames.isEmpty()) {
         this->curDefine = defines.filteredNames.takeFirst();
@@ -504,12 +504,12 @@ QMap<QString, int> ParseUtil::evaluateCDefines(const QString &filename, const QS
 }
 
 // Find and evaluate a specific set of defines with known names.
-QMap<QString, int> ParseUtil::readCDefinesByName(const QString &filename, const QSet<QString> &names, QString *error) {
+QHash<QString, int> ParseUtil::readCDefinesByName(const QString &filename, const QSet<QString> &names, QString *error) {
     return evaluateCDefines(filename, names, false, error);
 }
 
 // Find and evaluate an unknown list of defines with a known name pattern.
-QMap<QString, int> ParseUtil::readCDefinesByRegex(const QString &filename, const QSet<QString> &regexList, QString *error) {
+QHash<QString, int> ParseUtil::readCDefinesByRegex(const QString &filename, const QSet<QString> &regexList, QString *error) {
     return evaluateCDefines(filename, regexList, true, error);
 }
 
@@ -526,12 +526,17 @@ void ParseUtil::loadGlobalCDefinesFromFile(const QString &filename, QString *err
     loadGlobalCDefines(readCDefines(filename, {}, false, error).expressions);
 }
 
-void ParseUtil::loadGlobalCDefines(const QMap<QString,QString> &defines) {
+void ParseUtil::loadGlobalCDefines(const QHash<QString,QString> &defines) {
     this->globalDefineExpressions.insert(defines);
 }
 
+void ParseUtil::loadGlobalCDefines(const QMap<QString,QString> &defines) {
+    for (auto it = defines.constBegin(); it != defines.constEnd(); it++)
+        this->globalDefineExpressions.insert(it.key(), it.value());
+}
+
 void ParseUtil::resetCDefines() {
-    static const QMap<QString, int> defaultDefineValues = {
+    static const QHash<QString, int> defaultDefineValues = {
         {"FALSE", 0},
         {"TRUE", 1},
         {"SCHAR_MIN", SCHAR_MIN},

--- a/src/core/parseutil.cpp
+++ b/src/core/parseutil.cpp
@@ -483,7 +483,7 @@ QMap<QString, int> ParseUtil::evaluateCDefines(const QString &filename, const QS
         const QString expression = defines.expressions.take(name);
         if (expression == " ") continue;
         this->curDefine = name;
-        filteredValues.insert(name, evaluateDefine(name, expression, &allValues, &defines.expressions));
+        filteredValues.insert(name, evaluateDefine(name, expression, &allValues, &defines.expressions)); // TODO: Unite map with global expressions? Allows users to overwrite project defines
         logRecordedErrors(); // Only log errors for defines that Porymap is looking for
     }
 
@@ -509,8 +509,12 @@ QStringList ParseUtil::readCDefineNames(const QString &filename, const QSet<QStr
 
 // Find any defines in the specified file and save their expressions.
 // If any of these defines are encountered later by other define parsing functions then they'll be recognized and evaluated.
-void ParseUtil::loadGlobalCDefines(const QString &filename, QString *error) {
-    this->globalDefineExpressions.insert(readCDefines(filename, {}, false, error).expressions);
+void ParseUtil::loadGlobalCDefinesFromFile(const QString &filename, QString *error) {
+    loadGlobalCDefines(readCDefines(filename, {}, false, error).expressions);
+}
+
+void ParseUtil::loadGlobalCDefines(const QMap<QString,QString> &defines) {
+    this->globalDefineExpressions.insert(defines);
 }
 
 void ParseUtil::resetGlobalCDefines() {

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -660,7 +660,7 @@ bool MainWindow::openProject(QString dir, bool initial) {
 
     // Create the project
     auto project = new Project(editor);
-    project->set_root(dir);
+    project->setRoot(dir);
     connect(project, &Project::fileChanged, this, &MainWindow::showFileWatcherWarning);
     connect(project, &Project::mapLoaded, this, &MainWindow::onMapLoaded);
     connect(project, &Project::mapCreated, this, &MainWindow::onNewMapCreated);

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1665,6 +1665,13 @@ void MainWindow::duplicate() {
 void MainWindow::copy() {
     auto focused = QApplication::focusWidget();
     if (focused) {
+        // Allow copying text from selectable QLabels.
+        auto label = dynamic_cast<QLabel*>(focused);
+        if (label && !label->selectedText().isEmpty()) {
+            setClipboardData(label->selectedText());
+            return;
+        }
+
         QString objectName = focused->objectName();
         if (objectName == "graphicsView_currentMetatileSelection") {
             // copy the current metatile selection as json data

--- a/src/project.cpp
+++ b/src/project.cpp
@@ -2747,11 +2747,12 @@ bool Project::readGlobalConstants() {
     this->parser.resetGlobalCDefines();
     for (const auto &path : projectConfig.globalConstantsFilepaths) {
         QString error;
-        this->parser.loadGlobalCDefines(path, &error);
+        this->parser.loadGlobalCDefinesFromFile(path, &error);
         if (!error.isEmpty()) {
             logWarn(QString("Failed to read global constants file '%1': %2").arg(path).arg(error));
         }
     }
+    this->parser.loadGlobalCDefines(projectConfig.globalConstants);
     return true;
 }
 

--- a/src/project.cpp
+++ b/src/project.cpp
@@ -2744,7 +2744,7 @@ bool Project::readMiscellaneousConstants() {
 }
 
 bool Project::readGlobalConstants() {
-    this->parser.resetGlobalCDefines();
+    this->parser.resetCDefines();
     for (const auto &path : projectConfig.globalConstantsFilepaths) {
         QString error;
         this->parser.loadGlobalCDefinesFromFile(path, &error);

--- a/src/project.cpp
+++ b/src/project.cpp
@@ -48,10 +48,10 @@ Project::~Project()
     QPixmapCache::clear();
 }
 
-void Project::set_root(QString dir) {
+void Project::setRoot(const QString &dir) {
     this->root = dir;
     FileDialog::setDirectory(dir);
-    this->parser.set_root(dir);
+    this->parser.setRoot(dir);
 }
 
 // Before attempting the initial project load we should check for a few notable files.
@@ -78,7 +78,8 @@ bool Project::sanityCheck() {
 bool Project::load() {
     resetFileCache();
     this->disabledSettingsNames.clear();
-    bool success = readMapLayouts()
+    bool success = readGlobalConstants()
+                && readMapLayouts()
                 && readRegionMapSections()
                 && readItemNames()
                 && readFlagNames()
@@ -2739,6 +2740,18 @@ bool Project::readMiscellaneousConstants() {
                 .arg(this->maxObjectEvents));
     }
 
+    return true;
+}
+
+bool Project::readGlobalConstants() {
+    this->parser.resetGlobalCDefines();
+    for (const auto &path : projectConfig.globalConstantsFilepaths) {
+        QString error;
+        this->parser.loadGlobalCDefines(path, &error);
+        if (!error.isEmpty()) {
+            logWarn(QString("Failed to read global constants file '%1': %2").arg(path).arg(error));
+        }
+    }
     return true;
 }
 

--- a/src/ui/newdefinedialog.cpp
+++ b/src/ui/newdefinedialog.cpp
@@ -1,0 +1,60 @@
+#include "newdefinedialog.h"
+#include "ui_newdefinedialog.h"
+#include "validator.h"
+
+const QString lineEdit_ErrorStylesheet = "QLineEdit { background-color: rgba(255, 0, 0, 25%) }";
+
+NewDefineDialog::NewDefineDialog(QWidget *parent) :
+    QDialog(parent),
+    ui(new Ui::NewDefineDialog)
+{
+    setAttribute(Qt::WA_DeleteOnClose);
+    ui->setupUi(this);
+
+    ui->lineEdit_Name->setValidator(new IdentifierValidator(this));
+
+    connect(ui->lineEdit_Name, &QLineEdit::textChanged, this, &NewDefineDialog::onNameChanged);
+    connect(ui->buttonBox, &QDialogButtonBox::clicked, this, &NewDefineDialog::dialogButtonClicked);
+
+    adjustSize();
+}
+
+NewDefineDialog::~NewDefineDialog()
+{
+    delete ui;
+}
+
+void NewDefineDialog::onNameChanged(const QString &) {
+    validateName(true);
+}
+
+bool NewDefineDialog::validateName(bool allowEmpty) {
+    const QString name = ui->lineEdit_Name->text();
+
+    QString errorText;
+    if (name.isEmpty() && !allowEmpty) {
+        errorText = QString("%1 cannot be empty.").arg(ui->label_Name->text());
+    }
+
+    bool isValid = errorText.isEmpty();
+    ui->label_NameError->setText(errorText);
+    ui->label_NameError->setVisible(!isValid);
+    ui->lineEdit_Name->setStyleSheet(!isValid ? lineEdit_ErrorStylesheet : "");
+    return isValid;
+}
+
+void NewDefineDialog::dialogButtonClicked(QAbstractButton *button) {
+    auto role = ui->buttonBox->buttonRole(button);
+    if (role == QDialogButtonBox::RejectRole){
+        reject();
+    } else if (role == QDialogButtonBox::AcceptRole) {
+        accept();
+    }
+}
+
+void NewDefineDialog::accept() {
+    if (!validateName())
+        return;
+    emit createdDefine(ui->lineEdit_Name->text(), ui->lineEdit_Value->text());
+    QDialog::accept();
+}

--- a/src/ui/projectsettingseditor.cpp
+++ b/src/ui/projectsettingseditor.cpp
@@ -3,6 +3,7 @@
 #include "noscrollcombobox.h"
 #include "prefab.h"
 #include "filedialog.h"
+#include "newdefinedialog.h"
 #include "utility.h"
 
 #include <QAbstractButton>
@@ -53,6 +54,9 @@ void ProjectSettingsEditor::connectSignals() {
     });
     connect(ui->button_AddWarpBehavior,    &QAbstractButton::clicked, [this](bool) { this->updateWarpBehaviorsList(true); });
     connect(ui->button_RemoveWarpBehavior, &QAbstractButton::clicked, [this](bool) { this->updateWarpBehaviorsList(false); });
+
+    connect(ui->button_AddGlobalConstantsFile, &QAbstractButton::clicked, this, &ProjectSettingsEditor::addNewGlobalConstantsFilepath);
+    connect(ui->button_AddGlobalConstant,      &QAbstractButton::clicked, this, &ProjectSettingsEditor::addNewGlobalConstant);
 
     // Connect file selection buttons
     connect(ui->button_ChoosePrefabs,     &QAbstractButton::clicked, [this](bool) { this->choosePrefabsFile(); });
@@ -501,6 +505,12 @@ void ProjectSettingsEditor::refresh() {
         lineEdit->setText(projectConfig.getCustomFilePath(lineEdit->objectName()));
     for (auto lineEdit : ui->scrollAreaContents_Identifiers->findChildren<QLineEdit*>())
         lineEdit->setText(projectConfig.getCustomIdentifier(lineEdit->objectName()));
+    for (const auto &path : projectConfig.globalConstantsFilepaths) {
+        addGlobalConstantsFilepath(path);
+    }
+    for (auto it = projectConfig.globalConstants.constBegin(); it != projectConfig.globalConstants.constEnd(); it++) {
+        addGlobalConstant(it.key(), it.value());
+    }
 
     // Set warp behaviors
     QStringList behaviorNames;
@@ -578,6 +588,10 @@ void ProjectSettingsEditor::save() {
     for (auto lineEdit : ui->scrollAreaContents_Identifiers->findChildren<QLineEdit*>())
         projectConfig.setIdentifier(lineEdit->objectName(), lineEdit->text());
 
+    // Save global constants
+    projectConfig.globalConstantsFilepaths = getGlobalConstantsFilepaths();
+    projectConfig.globalConstants = getGlobalConstants();
+
     // Save warp behaviors
     projectConfig.warpBehaviors.clear();
     const QStringList behaviorNames = this->getWarpBehaviorsList();
@@ -622,6 +636,100 @@ void ProjectSettingsEditor::chooseFile(QLineEdit * filepathEdit, const QString &
     if (filepathEdit)
         filepathEdit->setText(this->stripProjectDir(filepath));
     this->hasUnsavedChanges = true;
+}
+
+void ProjectSettingsEditor::addNewGlobalConstantsFilepath() {
+    QString filepath = stripProjectDir(FileDialog::getOpenFileName(this, "Choose Global Constants File"));
+    if (filepath.isEmpty() || getGlobalConstantsFilepaths().contains(filepath))
+        return;
+
+    addGlobalConstantsFilepath(filepath);
+    this->hasUnsavedChanges = true;
+}
+
+void ProjectSettingsEditor::addGlobalConstantsFilepath(const QString &filepath) {
+    auto filepathLabel = new QLabel(filepath, this);
+    filepathLabel->setFrameStyle(QFrame::Panel | QFrame::Raised);
+    filepathLabel->setTextInteractionFlags(Qt::TextSelectableByMouse); // TODO: This doesn't allow Copy shortcut from the keyboard to work
+
+    // TODO: Tool tips
+
+    int newRow = ui->gridLayout_GlobalConstantsFiles->rowCount();
+    ui->gridLayout_GlobalConstantsFiles->addWidget(filepathLabel, newRow, 0);
+
+    auto deleteButton = new QToolButton();
+    deleteButton->setIcon(QIcon(":/icons/delete.ico"));
+    connect(deleteButton, &QAbstractButton::clicked, [this, filepathLabel, deleteButton](bool) {
+        ui->gridLayout_GlobalConstantsFiles->removeWidget(filepathLabel);
+        ui->gridLayout_GlobalConstantsFiles->removeWidget(deleteButton);
+        delete filepathLabel;
+        delete deleteButton;
+        this->hasUnsavedChanges = true;
+    });
+    ui->gridLayout_GlobalConstantsFiles->addWidget(deleteButton, newRow, 1);
+}
+
+QStringList ProjectSettingsEditor::getGlobalConstantsFilepaths() {
+    QStringList paths;
+    for (int row = 1; row < ui->gridLayout_GlobalConstantsFiles->rowCount(); row++) {
+        auto item = ui->gridLayout_GlobalConstantsFiles->itemAtPosition(row, 0);
+        if (!item) continue;
+        auto pathLabel = dynamic_cast<QLabel*>(item->widget());
+        if (!pathLabel) continue;
+        paths.append(pathLabel->text());
+    }
+    return paths;
+}
+
+void ProjectSettingsEditor::addNewGlobalConstant() {
+    auto dialog = new NewDefineDialog(this);
+    connect(dialog, &NewDefineDialog::createdDefine, [this](const QString &name, const QString &expression) {
+        if (!getGlobalConstants().contains(name)) {
+            addGlobalConstant(name, expression);
+            this->hasUnsavedChanges = true;
+        }
+    });
+    dialog->open();
+}
+
+void ProjectSettingsEditor::addGlobalConstant(const QString &name, const QString &expression) {
+    // TODO: Tool tips
+    auto nameLabel = new QLabel(name, this);
+    nameLabel->setFrameStyle(QFrame::Panel | QFrame::Raised);
+    nameLabel->setTextInteractionFlags(Qt::TextSelectableByMouse); // TODO: This doesn't allow Copy shortcut from the keyboard to work
+
+    auto expressionLineEdit = new QLineEdit(expression, this);
+
+    int newRow = ui->gridLayout_GlobalConstants->rowCount();
+    ui->gridLayout_GlobalConstants->addWidget(nameLabel, newRow, 0);
+    ui->gridLayout_GlobalConstants->addWidget(expressionLineEdit, newRow, 1);
+
+    auto deleteButton = new QToolButton();
+    deleteButton->setIcon(QIcon(":/icons/delete.ico"));
+    connect(deleteButton, &QAbstractButton::clicked, [this, nameLabel, expressionLineEdit, deleteButton](bool) {
+        ui->gridLayout_GlobalConstants->removeWidget(nameLabel);
+        ui->gridLayout_GlobalConstants->removeWidget(expressionLineEdit);
+        ui->gridLayout_GlobalConstants->removeWidget(deleteButton);
+        delete nameLabel;
+        delete expressionLineEdit;
+        delete deleteButton;
+        this->hasUnsavedChanges = true;
+    });
+    ui->gridLayout_GlobalConstants->addWidget(deleteButton, newRow, 2);
+}
+
+QMap<QString,QString> ProjectSettingsEditor::getGlobalConstants() {
+    QMap<QString,QString> constants;
+    for (int row = 1; row < ui->gridLayout_GlobalConstants->rowCount(); row++) {
+        auto nameItem = ui->gridLayout_GlobalConstants->itemAtPosition(row, 0);
+        auto expressionItem = ui->gridLayout_GlobalConstants->itemAtPosition(row, 1);
+        if (!nameItem || !expressionItem) continue;
+        auto nameLabel = dynamic_cast<QLabel*>(nameItem->widget());
+        auto expressionLineEdit = dynamic_cast<QLineEdit*>(expressionItem->widget());
+        if (!nameLabel || !expressionLineEdit) continue;
+        constants.insert(nameLabel->text(), expressionLineEdit->text());
+    }
+    return constants;
 }
 
 // Display relative path if this file is in the project folder

--- a/src/ui/projectsettingseditor.cpp
+++ b/src/ui/projectsettingseditor.cpp
@@ -650,9 +650,7 @@ void ProjectSettingsEditor::addNewGlobalConstantsFilepath() {
 void ProjectSettingsEditor::addGlobalConstantsFilepath(const QString &filepath) {
     auto filepathLabel = new QLabel(filepath, this);
     filepathLabel->setFrameStyle(QFrame::Panel | QFrame::Raised);
-    filepathLabel->setTextInteractionFlags(Qt::TextSelectableByMouse); // TODO: This doesn't allow Copy shortcut from the keyboard to work
-
-    // TODO: Tool tips
+    filepathLabel->setTextInteractionFlags(Qt::TextSelectableByMouse);
 
     int newRow = ui->gridLayout_GlobalConstantsFiles->rowCount();
     ui->gridLayout_GlobalConstantsFiles->addWidget(filepathLabel, newRow, 0);
@@ -693,10 +691,9 @@ void ProjectSettingsEditor::addNewGlobalConstant() {
 }
 
 void ProjectSettingsEditor::addGlobalConstant(const QString &name, const QString &expression) {
-    // TODO: Tool tips
     auto nameLabel = new QLabel(name, this);
     nameLabel->setFrameStyle(QFrame::Panel | QFrame::Raised);
-    nameLabel->setTextInteractionFlags(Qt::TextSelectableByMouse); // TODO: This doesn't allow Copy shortcut from the keyboard to work
+    nameLabel->setTextInteractionFlags(Qt::TextSelectableByMouse);
 
     auto expressionLineEdit = new QLineEdit(expression, this);
 


### PR DESCRIPTION
Adds 2 new settings that allow users to tell Porymap about any `#define`s it might not otherwise know about it. Porymap will then use this information to evaluate any defines it needs. One setting lets users specify a name and expression for a define, the other lets users specify a file path (and Porymap will parse and record any defines in that file).

Additionally, Porymap will now remember defines while it parses project files so that it can use information from one file to evaluate defines in another file.