### PR TITLE
Fix some issues with config loading

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -29,11 +29,21 @@ class KeyValueConfigBase
 {
 public:
     bool save();
-    void load();
-    virtual ~KeyValueConfigBase();
+    bool load(const QString &dir = QString());
+
+    void setRoot(const QString &dir);
+    QString root() const { return m_root; }
+    QString filepath() const { return m_filepath; }
+    QString filename() const { return m_filename; }
+
+    explicit KeyValueConfigBase(const QString &filename)
+        : m_root(QString()),
+          m_filename(filename),
+          m_filepath(filename)
+    { };
+    virtual ~KeyValueConfigBase() {};
     virtual void reset() = 0;
 protected:
-    virtual QString getConfigFilepath() = 0;
     virtual void parseConfigKeyValue(QString key, QString value) = 0;
     virtual QMap<QString, QString> getKeyValueMap() = 0;
     virtual void init() = 0;
@@ -43,14 +53,16 @@ protected:
     static int getConfigInteger(const QString &key, const QString &value, int min = INT_MIN, int max = INT_MAX, int defaultValue = 0);
     static uint32_t getConfigUint32(const QString &key, const QString &value, uint32_t min = 0, uint32_t max = UINT_MAX, uint32_t defaultValue = 0);
     static QColor getConfigColor(const QString &key, const QString &value, const QColor &defaultValue = Qt::black);
+
+    QString m_root;
+    QString m_filename;
+    QString m_filepath;
 };
 
 class PorymapConfig: public KeyValueConfigBase
 {
 public:
-    PorymapConfig() {
-        reset();
-    }
+    PorymapConfig();
     virtual void reset() override {
         this->recentProjects.clear();
         this->projectManuallyClosed = false;
@@ -167,7 +179,6 @@ public:
     std::set<LogType> statusBarLogTypes;
 
 protected:
-    virtual QString getConfigFilepath() override;
     virtual void parseConfigKeyValue(QString key, QString value) override;
     virtual QMap<QString, QString> getKeyValueMap() override;
     virtual void init() override {};
@@ -318,9 +329,7 @@ enum ProjectFilePath {
 class ProjectConfig: public KeyValueConfigBase
 {
 public:
-    ProjectConfig() {
-        reset();
-    }
+    ProjectConfig();
     virtual void reset() override {
         this->baseGameVersion = BaseGameVersion::pokeemerald;
         // Reset non-version-specific settings
@@ -365,6 +374,7 @@ public:
     static QString getPlayerIconPath(BaseGameVersion baseGameVersion, int character);
     static QIcon getPlayerIcon(BaseGameVersion baseGameVersion, int character);
 
+    QString projectDir() const { return m_root; } // Alias for root()
     void reset(BaseGameVersion baseGameVersion);
     void setFilePath(ProjectFilePath pathId, const QString &path);
     void setFilePath(const QString &pathId, const QString &path);
@@ -387,7 +397,6 @@ public:
     QMap<QString, QString> getPokemonIconPaths();
 
     BaseGameVersion baseGameVersion;
-    QString projectDir;
     bool usePoryScript;
     bool useCustomBorderSize;
     bool eventWeatherTriggerEnabled;
@@ -435,7 +444,6 @@ public:
     QMap<QString,QString> globalConstants;
 
 protected:
-    virtual QString getConfigFilepath() override;
     virtual void parseConfigKeyValue(QString key, QString value) override;
     virtual QMap<QString, QString> getKeyValueMap() override;
     virtual void init() override;
@@ -454,27 +462,25 @@ extern ProjectConfig projectConfig;
 class UserConfig: public KeyValueConfigBase
 {
 public:
-    UserConfig() {
-        reset();
-    }
+    UserConfig();
     virtual void reset() override {
         this->recentMapOrLayout = QString();
         this->useEncounterJson = true;
         this->customScripts.clear();
         this->readKeys.clear();
     }
+
+    QString projectDir() const { return m_root; } // Alias for root()
     void parseCustomScripts(QString input);
     QString outputCustomScripts();
     void setCustomScripts(QStringList scripts, QList<bool> enabled);
     QStringList getCustomScriptPaths();
     QList<bool> getCustomScriptsEnabled();
 
-    QString projectDir;
     QString recentMapOrLayout;
     bool useEncounterJson;
 
 protected:
-    virtual QString getConfigFilepath() override;
     virtual void parseConfigKeyValue(QString key, QString value) override;
     virtual QMap<QString, QString> getKeyValueMap() override;
     virtual void init() override;
@@ -496,10 +502,7 @@ class Shortcut;
 class ShortcutsConfig : public KeyValueConfigBase
 {
 public:
-    ShortcutsConfig() :
-        user_shortcuts({ }),
-        default_shortcuts({ })
-    { }
+    ShortcutsConfig();
 
     virtual void reset() override { user_shortcuts.clear(); }
 
@@ -512,7 +515,6 @@ public:
     QList<QKeySequence> userShortcuts(const QObject *object) const;
 
 protected:
-    virtual QString getConfigFilepath() override;
     virtual void parseConfigKeyValue(QString key, QString value) override;
     virtual QMap<QString, QString> getKeyValueMap() override;
     virtual void init() override { };

--- a/include/mainwindow.h
+++ b/include/mainwindow.h
@@ -385,7 +385,6 @@ private:
     void scrollMapListToCurrentLayout(MapTree *list);
     void resetMapListFilters();
     void showFileWatcherWarning();
-    QString getExistingDirectory(QString);
     bool openProject(QString dir, bool initial = false);
     bool closeProject();
     void showRecentError(const QString &baseMessage);

--- a/src/core/map.cpp
+++ b/src/core/map.cpp
@@ -176,7 +176,7 @@ QStringList Map::getScriptLabels(Event::Group group) {
 QString Map::getScriptsFilepath() const {
     const bool usePoryscript = projectConfig.usePoryScript;
     auto path = QDir::cleanPath(QString("%1/%2/%3/scripts")
-                                        .arg(projectConfig.projectDir)
+                                        .arg(projectConfig.projectDir())
                                         .arg(projectConfig.getFilePath(ProjectFilePath::data_map_folders))
                                         .arg(!m_sharedScriptsMap.isEmpty() ? m_sharedScriptsMap : m_name));
     auto extension = Project::getScriptFileExtension(usePoryscript);
@@ -188,7 +188,7 @@ QString Map::getScriptsFilepath() const {
 
 QString Map::getJsonFilepath(const QString &mapName) {
     return QDir::cleanPath(QString("%1/%2/%3/map.json")
-                                        .arg(projectConfig.projectDir)
+                                        .arg(projectConfig.projectDir())
                                         .arg(projectConfig.getFilePath(ProjectFilePath::data_map_folders))
                                         .arg(mapName));
 }

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -2330,7 +2330,7 @@ void Editor::openMapJson(const QString &mapName) const {
 }
 
 void Editor::openLayoutJson(const QString &layoutId) const {
-    QString path = QDir::cleanPath(QString("%1/%2").arg(projectConfig.projectDir).arg(projectConfig.getFilePath(ProjectFilePath::json_layouts)));
+    QString path = QDir::cleanPath(QString("%1/%2").arg(projectConfig.projectDir()).arg(projectConfig.getFilePath(ProjectFilePath::json_layouts)));
     QString idField = QString("\"id\": \"%1\",").arg(layoutId);
     openInTextEditor(path, ParseUtil::getJsonLineNumber(path, idField));
 }

--- a/src/project.cpp
+++ b/src/project.cpp
@@ -3375,7 +3375,7 @@ QString Project::getExistingFilepath(QString filepath) {
     if (filepath.isEmpty() || QFile::exists(filepath))
         return filepath;
 
-    filepath = QDir::cleanPath(projectConfig.projectDir + QDir::separator() + filepath);
+    filepath = QDir::cleanPath(projectConfig.projectDir() + QDir::separator() + filepath);
     if (QFile::exists(filepath))
         return filepath;
 

--- a/src/ui/customscriptseditor.cpp
+++ b/src/ui/customscriptseditor.cpp
@@ -11,7 +11,7 @@
 CustomScriptsEditor::CustomScriptsEditor(QWidget *parent) :
     QMainWindow(parent),
     ui(new Ui::CustomScriptsEditor),
-    baseDir(userConfig.projectDir + "/")
+    baseDir(userConfig.projectDir() + "/")
 {
     ui->setupUi(this);
     setAttribute(Qt::WA_DeleteOnClose);

--- a/src/ui/prefab.cpp
+++ b/src/ui/prefab.cpp
@@ -94,7 +94,7 @@ void Prefab::savePrefabs() {
 
     QFileInfo info(filepath);
     if (info.isRelative()) {
-        filepath = QDir::cleanPath(projectConfig.projectDir + QDir::separator() + filepath);
+        filepath = QDir::cleanPath(projectConfig.projectDir() + QDir::separator() + filepath);
     }
     QFile prefabsFile(filepath);
     if (!prefabsFile.open(QIODevice::WriteOnly)) {
@@ -287,7 +287,7 @@ bool Prefab::tryImportDefaultPrefabs(QWidget * parent, BaseGameVersion version, 
     if (fileInfo.suffix().isEmpty())
         filepath += ".json";
     if (fileInfo.isRelative()) {
-        absFilepath = QDir::cleanPath(projectConfig.projectDir + QDir::separator() + filepath);
+        absFilepath = QDir::cleanPath(projectConfig.projectDir() + QDir::separator() + filepath);
     } else {
         absFilepath = filepath;
     }

--- a/src/ui/projectsettingseditor.cpp
+++ b/src/ui/projectsettingseditor.cpp
@@ -21,7 +21,7 @@ ProjectSettingsEditor::ProjectSettingsEditor(QWidget *parent, Project *project) 
     QMainWindow(parent),
     ui(new Ui::ProjectSettingsEditor),
     project(project),
-    baseDir(projectConfig.projectDir + "/")
+    baseDir(projectConfig.projectDir() + "/")
 {
     ui->setupUi(this);
     setAttribute(Qt::WA_DeleteOnClose);


### PR DESCRIPTION
- Fix handling of empty config files. Previously, an empty project config would be initialized with Emerald's default settings. Now it will be treated the same as if the file didn't exist (i.e., it will get the base game version, then initialize settings based on that version).
- Opening a project is now aborted if a user/project config exists but fails to open. Previously it would open the project anyway and initialize settings with the defaults, which could potentially overwrite the existing settings.
- `getConfigFilepath` was recreating the config filepath every time it was called, which included (for some configs) checking the file system to see if the root directory exists. Now the config filepath is only created once.

Closes #649 