### PR TITLE
Condense file watcher warning, reduce resource usage

### DIFF
--- a/include/project.h
+++ b/include/project.h
@@ -61,7 +61,6 @@ public:
     QMap<QString, uint32_t> metatileBehaviorMap;
     QMap<uint32_t, QString> metatileBehaviorMapInverse;
     ParseUtil parser;
-    QFileSystemWatcher fileWatcher;
     QSet<QString> modifiedFiles;
     bool usingAsmTilesets;
     QSet<QString> disabledSettingsNames;
@@ -263,6 +262,7 @@ public:
     static QString getMapGroupPrefix();
 
 private:
+    QPointer<QFileSystemWatcher> fileWatcher;
     QMap<QString, qint64> modifiedFileTimestamps;
     QMap<QString, QString> facingDirections;
     QHash<QString, QString> speciesToIconPath;
@@ -332,6 +332,8 @@ private:
     void ignoreWatchedFilesTemporarily(const QStringList &filepaths);
     void recordFileChange(const QString &filepath);
     void resetFileCache();
+    void resetFileWatcher();
+    void logFileWatchStatus();
 
     bool saveMapLayouts();
     bool saveMapGroups();

--- a/include/ui/preferenceeditor.h
+++ b/include/ui/preferenceeditor.h
@@ -24,6 +24,7 @@ signals:
     void preferencesSaved();
     void themeChanged(const QString &theme);
     void scriptSettingsChanged(bool on);
+    void reloadProjectRequested();
 
 private:
     Ui::PreferenceEditor *ui;

--- a/src/core/map.cpp
+++ b/src/core/map.cpp
@@ -163,17 +163,19 @@ QStringList Map::getScriptLabels(Event::Group group) {
             m_loggedScriptsFileError = true;
         }
 
-        if (!m_scriptFileWatcher) {
-            // Only create the file watcher when it's first needed (even an empty QFileSystemWatcher will consume system resources).
-            // The other option would be for Porymap to have a single global QFileSystemWatcher, but that has complications of its own.
-            m_scriptFileWatcher = new QFileSystemWatcher(this);
-            connect(m_scriptFileWatcher, &QFileSystemWatcher::fileChanged, this, &Map::invalidateScripts);
-        }
-        if (!m_scriptFileWatcher->files().contains(scriptsFilepath) && !m_scriptFileWatcher->addPath(scriptsFilepath) && !m_loggedScriptsFileError) {
-            logWarn(QString("Failed to add scripts file '%1' to file watcher for %2.")
-                            .arg(Util::stripPrefix(scriptsFilepath, projectConfig.projectDir() + "/"))
-                            .arg(m_name));
-            m_loggedScriptsFileError = true;
+        if (porymapConfig.monitorFiles) {
+            if (!m_scriptFileWatcher) {
+                // Only create the file watcher when it's first needed (even an empty QFileSystemWatcher will consume system resources).
+                // The other option would be for Porymap to have a single global QFileSystemWatcher, but that has complications of its own.
+                m_scriptFileWatcher = new QFileSystemWatcher(this);
+                connect(m_scriptFileWatcher, &QFileSystemWatcher::fileChanged, this, &Map::invalidateScripts);
+            }
+            if (!m_scriptFileWatcher->files().contains(scriptsFilepath) && !m_scriptFileWatcher->addPath(scriptsFilepath) && !m_loggedScriptsFileError) {
+                logWarn(QString("Failed to add scripts file '%1' to file watcher for %2.")
+                                .arg(Util::stripPrefix(scriptsFilepath, projectConfig.projectDir() + "/"))
+                                .arg(m_name));
+                m_loggedScriptsFileError = true;
+            }
         }
 
         m_scriptsLoaded = true;

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -2938,6 +2938,7 @@ void MainWindow::on_actionPreferences_triggered() {
         // require us to repopulate the EventFrames and redraw event pixmaps, respectively.
         connect(preferenceEditor, &PreferenceEditor::preferencesSaved, editor, &Editor::updateEvents);
         connect(preferenceEditor, &PreferenceEditor::scriptSettingsChanged, editor->project, &Project::readEventScriptLabels);
+        connect(preferenceEditor, &PreferenceEditor::reloadProjectRequested, this, &MainWindow::on_action_Reload_Project_triggered);
     }
 
     openSubWindow(preferenceEditor);


### PR DESCRIPTION
- The last release added some warnings to the file watcher because I suspected it was quietly breaking for some environments (after getting some logs back, it is, but I don't think there's anything Porymap can do about it). If the file watcher fails to monitor any files it will now log a single warning, rather than one warning for each file.
- `QFileSystemWatcher` uses system resources even if no files are being watched. `Map`'s file watcher was updated so that it's only created when the first file watch is requested. Now `Project`'s file watcher does this too.
- If `Monitor project files` was disabled Porymap would still quietly use all the same resources to watch project files, it just wouldn't tell the user. Now Porymap won't use any of these resources if the setting is disabled (consequently the project must be reloaded for changes to this setting to take effect; a prompt for this was added).
