### PR TITLE
Cursor refactoring

### DIFF
--- a/include/core/maplayout.h
+++ b/include/core/maplayout.h
@@ -100,6 +100,7 @@ public:
     QRect getVisibleRect() const;
 
     bool isWithinBounds(int x, int y) const;
+    bool isWithinBounds(const QPoint &pos) const;
     bool isWithinBounds(const QRect &rect) const;
     bool isWithinBorderBounds(int x, int y) const;
 

--- a/include/editor.h
+++ b/include/editor.h
@@ -172,7 +172,7 @@ public:
     void setEditMode(EditMode editMode);
     EditMode getEditMode() const { return this->editMode; }
 
-    bool getEditingLayout();
+    bool getEditingLayout() const;
 
     void setMapEditingButtonsEnabled(bool enabled);
 
@@ -256,10 +256,11 @@ private:
     static bool startDetachedProcess(const QString &command,
                                     const QString &workingDirectory = QString(),
                                     qint64 *pid = nullptr);
-
-private slots:
+    bool canPaintMetatiles() const;
     void onMapStartPaint(QGraphicsSceneMouseEvent *event, LayoutPixmapItem *item);
     void onMapEndPaint(QGraphicsSceneMouseEvent *event, LayoutPixmapItem *item);
+
+private slots:
     void setSmartPathCursorMode(QGraphicsSceneMouseEvent *event);
     void mouseEvent_map(QGraphicsSceneMouseEvent *event, LayoutPixmapItem *item);
     void mouseEvent_collision(QGraphicsSceneMouseEvent *event, CollisionPixmapItem *item);

--- a/include/editor.h
+++ b/include/editor.h
@@ -122,9 +122,10 @@ public:
     void updateEventPixmapItemZValue(EventPixmapItem *item);
     qreal getEventOpacity(const Event *event) const;
 
+    bool isMouseInMap() const;
     void setPlayerViewRect(const QRectF &rect);
-    void updateCursorRectPos(int x, int y);
-    void setCursorRectVisible(bool visible);
+    void setCursorRectPos(const QPoint &pos);
+    void updateCursorRectVisibility();
 
     void onEventDragged(Event *event, const QPoint &oldPosition, const QPoint &newPosition);
     void onEventReleased(Event *event, const QPoint &position);
@@ -251,6 +252,7 @@ private:
     QString getMovementPermissionText(uint16_t collision, uint16_t elevation);
     QString getMetatileDisplayMessage(uint16_t metatileId);
     void setCollisionTabSpinBoxes(uint16_t collision, uint16_t elevation);
+    void adjustStraightPathPos(QGraphicsSceneMouseEvent *event, LayoutPixmapItem *item, QPoint *pos) const;
     static bool startDetachedProcess(const QString &command,
                                     const QString &workingDirectory = QString(),
                                     qint64 *pid = nullptr);
@@ -259,7 +261,6 @@ private slots:
     void onMapStartPaint(QGraphicsSceneMouseEvent *event, LayoutPixmapItem *item);
     void onMapEndPaint(QGraphicsSceneMouseEvent *event, LayoutPixmapItem *item);
     void setSmartPathCursorMode(QGraphicsSceneMouseEvent *event);
-    void setStraightPathCursorMode(QGraphicsSceneMouseEvent *event);
     void mouseEvent_map(QGraphicsSceneMouseEvent *event, LayoutPixmapItem *item);
     void mouseEvent_collision(QGraphicsSceneMouseEvent *event, CollisionPixmapItem *item);
     void setSelectedConnectionItem(ConnectionPixmapItem *connectionItem);
@@ -267,10 +268,9 @@ private slots:
     void onHoveredMovementPermissionCleared();
     void onHoveredMetatileSelectionChanged(uint16_t);
     void onHoveredMetatileSelectionCleared();
-    void onHoveredMapMetatileChanged(const QPoint &pos);
-    void onHoveredMapMetatileCleared();
-    void onHoveredMapMovementPermissionChanged(int, int);
-    void onHoveredMapMovementPermissionCleared();
+    void onMapHoverEntered(const QPoint &pos);
+    void onMapHoverChanged(const QPoint &pos);
+    void onMapHoverCleared();
     void onSelectedMetatilesChanged();
     void onWheelZoom(int);
 

--- a/include/settings.h
+++ b/include/settings.h
@@ -10,7 +10,6 @@ public:
     Settings();
     bool smartPathsEnabled;
     bool betterCursors;
-    QCursor mapCursor;
     bool playerViewRectEnabled;
     bool cursorTileRectEnabled;
 };

--- a/include/ui/collisionpixmapitem.h
+++ b/include/ui/collisionpixmapitem.h
@@ -23,11 +23,11 @@ public:
     QSpinBox * selectedElevation;
     qreal *opacity;
     void updateMovementPermissionSelection(QGraphicsSceneMouseEvent *event);
-    virtual void paint(QGraphicsSceneMouseEvent*);
-    virtual void floodFill(QGraphicsSceneMouseEvent*);
-    virtual void magicFill(QGraphicsSceneMouseEvent*);
-    virtual void pick(QGraphicsSceneMouseEvent*);
-    void draw(bool ignoreCache = false);
+    virtual void paint(QGraphicsSceneMouseEvent*) override;
+    virtual void floodFill(QGraphicsSceneMouseEvent*) override;
+    virtual void magicFill(QGraphicsSceneMouseEvent*) override;
+    virtual void pick(QGraphicsSceneMouseEvent*) override;
+    void draw(bool ignoreCache = false) override;
 
 private:
     unsigned actionId_ = 0;
@@ -36,16 +36,17 @@ private:
 
 signals:
     void mouseEvent(QGraphicsSceneMouseEvent *, CollisionPixmapItem *);
-    void hoveredMapMovementPermissionChanged(int, int);
-    void hoveredMapMovementPermissionCleared();
+    void hoverEntered(const QPoint &pos);
+    void hoverChanged(const QPoint &pos);
+    void hoverCleared();
 
 protected:
-    void hoverMoveEvent(QGraphicsSceneHoverEvent*);
-    void hoverEnterEvent(QGraphicsSceneHoverEvent*);
-    void hoverLeaveEvent(QGraphicsSceneHoverEvent*);
-    void mousePressEvent(QGraphicsSceneMouseEvent*);
-    void mouseMoveEvent(QGraphicsSceneMouseEvent*);
-    void mouseReleaseEvent(QGraphicsSceneMouseEvent*);
+    virtual void hoverMoveEvent(QGraphicsSceneHoverEvent*) override;
+    virtual void hoverEnterEvent(QGraphicsSceneHoverEvent*) override;
+    virtual void hoverLeaveEvent(QGraphicsSceneHoverEvent*) override;
+    virtual void mousePressEvent(QGraphicsSceneMouseEvent*) override;
+    virtual void mouseMoveEvent(QGraphicsSceneMouseEvent*) override;
+    virtual void mouseReleaseEvent(QGraphicsSceneMouseEvent*) override;
 };
 
 #endif // COLLISIONPIXMAPITEM_H

--- a/include/ui/cursortilerect.h
+++ b/include/ui/cursortilerect.h
@@ -8,78 +8,55 @@
 class CursorTileRect : public QGraphicsItem
 {
 public:
-    CursorTileRect(bool *enabled, QRgb color);
-    QRectF boundingRect() const override
-    {
-        int width = this->width;
-        int height = this->height;
-        if (this->singleTileMode) {
-            width = 16;
-            height = 16;
-        } else if (!this->rightClickSelectionAnchored && this->smartPathMode && this->selectionHeight == 3 && this->selectionWidth == 3) {
-            width = 32;
-            height = 32;
-        }
+    CursorTileRect(const QSize &tileSize, const QRgb &color, QGraphicsItem *parent = nullptr);
+    
+    QSize size() const;
+
+    QRectF boundingRect() const override {
+        auto s = size();
         qreal penWidth = 4;
         return QRectF(-penWidth,
                       -penWidth,
-                      width + penWidth * 2,
-                      height + penWidth * 2);
+                      s.width() + penWidth * 2,
+                      s.height() + penWidth * 2);
     }
 
-    void paint(QPainter *painter, const QStyleOptionGraphicsItem *, QWidget *) override
-    {
-        if (!(*enabled)) return;
-        int width = this->width;
-        int height = this->height;
-        if (this->singleTileMode) {
-            width = 16;
-            height = 16;
-        } else if (this->smartPathInEffect()) {
-            width = 32;
-            height = 32;
-        }
-
-        painter->setPen(this->color);
-        painter->drawRect(x() - 1, y() - 1, width + 2, height + 2);
+    void paint(QPainter *painter, const QStyleOptionGraphicsItem *, QWidget *) override {
+        if (!isVisible()) return;
+        auto rect = QRectF(pos(), size());
+        painter->setPen(m_color);
+        painter->drawRect(rect + QMargins(1,1,1,1)); // Fill
         painter->setPen(QColor(0, 0, 0));
-        painter->drawRect(x() - 2, y() - 2, width + 4, height + 4);
-        painter->drawRect(x(), y(), width, height);
+        painter->drawRect(rect + QMargins(2,2,2,2)); // Outer border
+        painter->drawRect(rect); // Inner border
     }
+
     void initAnchor(int coordX, int coordY);
     void stopAnchor();
     void initRightClickSelectionAnchor(int coordX, int coordY);
     void stopRightClickSelectionAnchor();
 
-    void setSmartPathMode(bool enable) { this->smartPathMode = enable; }
-    bool getSmartPathMode() const { return this->smartPathMode; }
+    void setSmartPathMode(bool enable) { m_smartPathMode = enable; }
+    bool getSmartPathMode() const { return m_smartPathMode; }
 
-    void setStraightPathMode(bool enable) { this->straightPathMode = enable; }
-    bool getStraightPathMode() const { return this->straightPathMode; }
-
-    void setSingleTileMode(bool enable) { this->singleTileMode = enable; }
-    bool getSingleTileMode() const { return this->singleTileMode; }
+    void setSingleTileMode(bool enable) { m_singleTileMode = enable; }
+    bool getSingleTileMode() const { return m_singleTileMode; }
 
     void updateLocation(int x, int y);
     void updateSelectionSize(int width, int height);
-    void setActive(bool active);
-    bool getActive();
-    bool *enabled;
+
 private:
-    bool active;
-    int width;
-    int height;
-    bool anchored;
-    bool rightClickSelectionAnchored;
-    bool smartPathMode;
-    bool straightPathMode;
-    bool singleTileMode;
-    int anchorCoordX;
-    int anchorCoordY;
-    int selectionWidth;
-    int selectionHeight;
-    QRgb color;
-    bool smartPathInEffect();
+    const QSize m_tileSize;
+    QSize m_selectionSize;
+    QPoint m_anchorCoord;
+    QRgb m_color;
+
+    bool m_anchored = false;
+    bool m_rightClickSelectionAnchored = false;
+    bool m_smartPathMode = false;
+    bool m_singleTileMode = false;
+
+    bool smartPathInEffect() const;
 };
 
 

--- a/include/ui/layoutpixmapitem.h
+++ b/include/ui/layoutpixmapitem.h
@@ -86,17 +86,12 @@ public:
     void lockNondominantAxis(QGraphicsSceneMouseEvent *event);
     QPoint adjustCoords(QPoint pos);
 
-    void setEditsEnabled(bool enabled) { this->editsEnabled = enabled; }
-    bool getEditsEnabled() { return this->editsEnabled; }
-
 private:
     void paintSmartPath(int x, int y, bool fromScriptCall = false);
     static QList<int> smartPathTable;
     QPoint lastMetatileSelectionPos = QPoint(-1,-1);
 
     unsigned actionId_ = 0;
-
-    bool editsEnabled = true;
 
 signals:
     void startPaint(QGraphicsSceneMouseEvent *, LayoutPixmapItem *);

--- a/include/ui/layoutpixmapitem.h
+++ b/include/ui/layoutpixmapitem.h
@@ -102,16 +102,17 @@ signals:
     void startPaint(QGraphicsSceneMouseEvent *, LayoutPixmapItem *);
     void endPaint(QGraphicsSceneMouseEvent *, LayoutPixmapItem *);
     void mouseEvent(QGraphicsSceneMouseEvent *, LayoutPixmapItem *);
-    void hoveredMapMetatileChanged(const QPoint &pos);
-    void hoveredMapMetatileCleared();
+    void hoverEntered(const QPoint &pos);
+    void hoverChanged(const QPoint &pos);
+    void hoverCleared();
 
 protected:
-    void hoverMoveEvent(QGraphicsSceneHoverEvent*);
-    void hoverEnterEvent(QGraphicsSceneHoverEvent*);
-    void hoverLeaveEvent(QGraphicsSceneHoverEvent*);
-    void mousePressEvent(QGraphicsSceneMouseEvent*);
-    void mouseMoveEvent(QGraphicsSceneMouseEvent*);
-    void mouseReleaseEvent(QGraphicsSceneMouseEvent*);
+    virtual void hoverMoveEvent(QGraphicsSceneHoverEvent*) override;
+    virtual void hoverEnterEvent(QGraphicsSceneHoverEvent*) override;
+    virtual void hoverLeaveEvent(QGraphicsSceneHoverEvent*) override;
+    virtual void mousePressEvent(QGraphicsSceneMouseEvent*) override;
+    virtual void mouseMoveEvent(QGraphicsSceneMouseEvent*) override;
+    virtual void mouseReleaseEvent(QGraphicsSceneMouseEvent*) override;
 };
 
 #endif // MAPPIXMAPITEM_H

--- a/include/ui/movablerect.h
+++ b/include/ui/movablerect.h
@@ -10,7 +10,7 @@
 class MovableRect : public QGraphicsRectItem
 {
 public:
-    MovableRect(bool *enabled, const QRectF &rect, const QRgb &color);
+    MovableRect(const QRectF &rect, const QRgb &color);
     QRectF boundingRect() const override {
         qreal penWidth = 4;
         return QRectF(-penWidth,
@@ -29,12 +29,7 @@ public:
     }
     void updateLocation(int x, int y);
 
-    void setActive(bool active);
-    bool getActive() const { return this->active; }
-
 protected:
-    bool *enabled = nullptr;
-    bool active = true;
     QRectF baseRect;
     QRgb color;
 
@@ -48,7 +43,7 @@ class ResizableRect : public QObject, public MovableRect
 {
     Q_OBJECT
 public:
-    ResizableRect(QObject *parent, bool *enabled, int width, int height, QRgb color);
+    ResizableRect(QObject *parent, int width, int height, QRgb color);
 
     QRectF boundingRect() const override {
         return QRectF(this->rect() + QMargins(lineWidth, lineWidth, lineWidth, lineWidth));

--- a/src/core/maplayout.cpp
+++ b/src/core/maplayout.cpp
@@ -55,6 +55,10 @@ bool Layout::isWithinBounds(int x, int y) const {
     return (x >= 0 && x < this->getWidth() && y >= 0 && y < this->getHeight());
 }
 
+bool Layout::isWithinBounds(const QPoint &pos) const {
+    return isWithinBounds(pos.x(), pos.y());
+}
+
 bool Layout::isWithinBounds(const QRect &rect) const {
     return rect.left() >= 0 && rect.right() < this->getWidth() && rect.top() >= 0 && rect.bottom() < this->getHeight();
 }

--- a/src/core/metatile.cpp
+++ b/src/core/metatile.cpp
@@ -38,6 +38,8 @@ int Metatile::getIndexInTileset(int metatileId) {
 QPoint Metatile::coordFromPixmapCoord(const QPointF &pixelCoord) {
     int x = static_cast<int>(pixelCoord.x()) / 16;
     int y = static_cast<int>(pixelCoord.y()) / 16;
+    if (pixelCoord.x() < 0) x--;
+    if (pixelCoord.y() < 0) y--;
     return QPoint(x, y);
 }
 

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -1196,7 +1196,6 @@ void Editor::updateCursorRectVisibility() {
         auto editAction = getEditAction();
         bool visible = this->settings->cursorTileRectEnabled
                         && mouseInMap
-                        && getEditingLayout()
                         // Only show the tile cursor for tools that apply at a specific tile
                         && editAction != EditAction::Select
                         && editAction != EditAction::Move;
@@ -2224,7 +2223,7 @@ bool Editor::canAddEvents(const QList<Event*> &events) {
 }
 
 void Editor::duplicateSelectedEvents() {
-    if (this->selectedEvents.isEmpty() || !project || !map || !current_view || this->getEditingLayout())
+    if (this->selectedEvents.isEmpty() || !project || !map || !current_view || this->editMode != EditMode::Events)
         return;
 
     QList<Event *> duplicatedEvents;

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -169,7 +169,6 @@ void Editor::setEditMode(EditMode editMode) {
         editStack = &this->layout->editHistory;
     }
 
-    this->cursorMapTileRect->setActive(editingLayout);
     this->playerViewRect->setActive(editingLayout);
     this->editGroup.setActiveStack(editStack);
     this->ui->toolButton_Fill->setEnabled(editingLayout);
@@ -204,6 +203,10 @@ void Editor::setEditAction(EditAction editAction) {
         this->map_ruler->setEnabled(false);
     }
 
+    // Only show the tile cursor for tools that apply at a specific tile
+    this->cursorMapTileRect->setActive(getEditingLayout() && editAction != EditAction::Select && editAction != EditAction::Move);
+
+    // The tile cursor can only grow while painting metatiles
     this->cursorMapTileRect->setSingleTileMode(!(editAction == EditAction::Paint && this->editMode == EditMode::Metatiles));
 
     // Update cursor

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -125,7 +125,7 @@ void Editor::closeProject() {
     delete this->project;
 }
 
-bool Editor::getEditingLayout() {
+bool Editor::getEditingLayout() const {
     return this->editMode == EditMode::Metatiles || this->editMode == EditMode::Collision;
 }
 
@@ -1366,8 +1366,12 @@ bool Editor::setLayout(QString layoutId) {
     return true;
 }
 
+bool Editor::canPaintMetatiles() const {
+    return this->editMode == EditMode::Metatiles && this->mapEditAction != EditAction::Select && this->mapEditAction != EditAction::Move;
+}
+
 void Editor::onMapStartPaint(QGraphicsSceneMouseEvent *event, LayoutPixmapItem *) {
-    if (!this->getEditingLayout()) {
+    if (!canPaintMetatiles()) {
         return;
     }
 
@@ -1380,7 +1384,7 @@ void Editor::onMapStartPaint(QGraphicsSceneMouseEvent *event, LayoutPixmapItem *
 }
 
 void Editor::onMapEndPaint(QGraphicsSceneMouseEvent *, LayoutPixmapItem *) {
-    if (!this->getEditingLayout()) {
+    if (!canPaintMetatiles()) {
         return;
     }
     this->cursorMapTileRect->stopRightClickSelectionAnchor();

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -2176,7 +2176,6 @@ void MainWindow::on_mapViewTab_tabBarClicked(int index)
                 prefab.updatePrefabUi(this->editor->layout);
         }
     }
-    editor->setCursorRectVisible(false);
 }
 
 void MainWindow::on_mainTabBar_tabBarClicked(int index)
@@ -2240,11 +2239,7 @@ void MainWindow::on_actionPlayer_View_Rectangle_triggered()
     bool enabled = ui->actionPlayer_View_Rectangle->isChecked();
     porymapConfig.showPlayerView = enabled;
     this->editor->settings->playerViewRectEnabled = enabled;
-    if ((this->editor->map_item && this->editor->map_item->has_mouse)
-     || (this->editor->collision_item && this->editor->collision_item->has_mouse)) {
-        this->editor->playerViewRect->setVisible(enabled && this->editor->playerViewRect->getActive());
-        ui->graphicsView_Map->scene()->update();
-    }
+    this->editor->updateCursorRectVisibility();
 }
 
 void MainWindow::on_actionCursor_Tile_Outline_triggered()
@@ -2252,11 +2247,7 @@ void MainWindow::on_actionCursor_Tile_Outline_triggered()
     bool enabled = ui->actionCursor_Tile_Outline->isChecked();
     porymapConfig.showCursorTile = enabled;
     this->editor->settings->cursorTileRectEnabled = enabled;
-    if ((this->editor->map_item && this->editor->map_item->has_mouse)
-     || (this->editor->collision_item && this->editor->collision_item->has_mouse)) {
-        this->editor->cursorMapTileRect->setVisible(enabled && this->editor->cursorMapTileRect->getActive());
-        ui->graphicsView_Map->scene()->update();
-    }
+    this->editor->updateCursorRectVisibility();
 }
 
 void MainWindow::on_actionShow_Events_In_Map_View_triggered() {

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -2579,12 +2579,6 @@ void MainWindow::on_toolButton_Move_clicked()    { editor->setEditAction(Editor:
 void MainWindow::on_toolButton_Shift_clicked()   { editor->setEditAction(Editor::EditAction::Shift); }
 
 void MainWindow::setEditActionUi(Editor::EditAction editAction) {
-    // TODO: Viewport's hand cursor is not reliably cleared when changing to QGraphicsView::NoDrag.
-    auto dragMode = (editAction == Editor::EditAction::Move) ? QGraphicsView::ScrollHandDrag : QGraphicsView::NoDrag;
-    ui->graphicsView_Connections->setDragMode(dragMode);
-    ui->graphicsView_Map->setDragMode(dragMode);
-    ui->graphicsView_Map->setFocus();
-
     ui->toolButton_Paint->setChecked(editAction == Editor::EditAction::Paint);
     ui->toolButton_Select->setChecked(editAction == Editor::EditAction::Select);
     ui->toolButton_Fill->setChecked(editAction == Editor::EditAction::Fill);

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -2579,17 +2579,10 @@ void MainWindow::on_toolButton_Move_clicked()    { editor->setEditAction(Editor:
 void MainWindow::on_toolButton_Shift_clicked()   { editor->setEditAction(Editor::EditAction::Shift); }
 
 void MainWindow::setEditActionUi(Editor::EditAction editAction) {
-    if (editAction == Editor::EditAction::Move) {
-        ui->graphicsView_Map->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
-        ui->graphicsView_Map->setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
-        QScroller::grabGesture(ui->graphicsView_Map, QScroller::LeftMouseButtonGesture);
-        ui->graphicsView_Map->setViewportUpdateMode(QGraphicsView::ViewportUpdateMode::FullViewportUpdate);
-    } else {
-        ui->graphicsView_Map->setHorizontalScrollBarPolicy(Qt::ScrollBarAsNeeded);
-        ui->graphicsView_Map->setVerticalScrollBarPolicy(Qt::ScrollBarAsNeeded);
-        QScroller::ungrabGesture(ui->graphicsView_Map);
-        ui->graphicsView_Map->setViewportUpdateMode(QGraphicsView::ViewportUpdateMode::MinimalViewportUpdate);
-    }
+    // TODO: Viewport's hand cursor is not reliably cleared when changing to QGraphicsView::NoDrag.
+    auto dragMode = (editAction == Editor::EditAction::Move) ? QGraphicsView::ScrollHandDrag : QGraphicsView::NoDrag;
+    ui->graphicsView_Connections->setDragMode(dragMode);
+    ui->graphicsView_Map->setDragMode(dragMode);
     ui->graphicsView_Map->setFocus();
 
     ui->toolButton_Paint->setChecked(editAction == Editor::EditAction::Paint);

--- a/src/ui/collisionpixmapitem.cpp
+++ b/src/ui/collisionpixmapitem.cpp
@@ -8,9 +8,6 @@ void CollisionPixmapItem::hoverMoveEvent(QGraphicsSceneHoverEvent *event) {
         this->previousPos = pos;
         emit this->hoverChanged(pos);
     }
-    if (this->settings->betterCursors && this->getEditsEnabled()) {
-        setCursor(this->settings->mapCursor);
-    }
 }
 
 void CollisionPixmapItem::hoverEnterEvent(QGraphicsSceneHoverEvent * event) {
@@ -20,9 +17,6 @@ void CollisionPixmapItem::hoverEnterEvent(QGraphicsSceneHoverEvent * event) {
 }
 
 void CollisionPixmapItem::hoverLeaveEvent(QGraphicsSceneHoverEvent *) {
-    if (this->settings->betterCursors && this->getEditsEnabled()){
-        unsetCursor();
-    }
     this->has_mouse = false;
     emit this->hoverCleared();
 }

--- a/src/ui/collisionpixmapitem.cpp
+++ b/src/ui/collisionpixmapitem.cpp
@@ -6,7 +6,7 @@ void CollisionPixmapItem::hoverMoveEvent(QGraphicsSceneHoverEvent *event) {
     QPoint pos = Metatile::coordFromPixmapCoord(event->pos());
     if (pos != this->previousPos) {
         this->previousPos = pos;
-        emit this->hoveredMapMovementPermissionChanged(pos.x(), pos.y());
+        emit this->hoverChanged(pos);
     }
     if (this->settings->betterCursors && this->getEditsEnabled()) {
         setCursor(this->settings->mapCursor);
@@ -15,16 +15,16 @@ void CollisionPixmapItem::hoverMoveEvent(QGraphicsSceneHoverEvent *event) {
 
 void CollisionPixmapItem::hoverEnterEvent(QGraphicsSceneHoverEvent * event) {
     this->has_mouse = true;
-    QPoint pos = Metatile::coordFromPixmapCoord(event->pos());
-    emit this->hoveredMapMovementPermissionChanged(pos.x(), pos.y());
+    this->previousPos = Metatile::coordFromPixmapCoord(event->pos());
+    emit this->hoverEntered(this->previousPos);
 }
 
 void CollisionPixmapItem::hoverLeaveEvent(QGraphicsSceneHoverEvent *) {
-    emit this->hoveredMapMovementPermissionCleared();
     if (this->settings->betterCursors && this->getEditsEnabled()){
         unsetCursor();
     }
     this->has_mouse = false;
+    emit this->hoverCleared();
 }
 
 void CollisionPixmapItem::mousePressEvent(QGraphicsSceneMouseEvent *event) {
@@ -38,7 +38,7 @@ void CollisionPixmapItem::mouseMoveEvent(QGraphicsSceneMouseEvent *event) {
     QPoint pos = Metatile::coordFromPixmapCoord(event->pos());
     if (pos != this->previousPos) {
         this->previousPos = pos;
-        emit this->hoveredMapMovementPermissionChanged(pos.x(), pos.y());
+        emit this->hoverChanged(pos);
     }
     emit mouseEvent(event, this);
 }

--- a/src/ui/connectionpixmapitem.cpp
+++ b/src/ui/connectionpixmapitem.cpp
@@ -126,7 +126,11 @@ void ConnectionPixmapItem::setSelected(bool selected) {
     emit selectionChanged(selected);
 }
 
-void ConnectionPixmapItem::mousePressEvent(QGraphicsSceneMouseEvent *) {
+void ConnectionPixmapItem::mousePressEvent(QGraphicsSceneMouseEvent *event) {
+    if (!this->getEditable()) {
+        event->ignore();
+        return;
+    }
     this->setSelected(true);
 }
 

--- a/src/ui/cursortilerect.cpp
+++ b/src/ui/cursortilerect.cpp
@@ -1,94 +1,70 @@
 #include "cursortilerect.h"
 #include "log.h"
 
-CursorTileRect::CursorTileRect(bool *enabled, QRgb color)
-{
-    this->enabled = enabled;
-    this->active = true;
-    this->color = color;
-    this->width = 16;
-    this->height = 16;
-    this->smartPathMode = false;
-    this->straightPathMode = false;
-    this->singleTileMode = false;
-    this->anchored = false;
-    this->rightClickSelectionAnchored = false;
-    this->anchorCoordX = 0;
-    this->anchorCoordY = 0;
-    this->selectionWidth = 1;
-    this->selectionHeight = 1;
+CursorTileRect::CursorTileRect(const QSize &tileSize, const QRgb &color, QGraphicsItem *parent)
+    : QGraphicsItem(parent),
+      m_tileSize(tileSize),
+      m_selectionSize(QSize(1,1)),
+      m_anchorCoord(QPoint(0,0)),
+      m_color(color)
+{ }
+
+// Size of the cursor may be explicitly enforced depending on settings.
+QSize CursorTileRect::size() const {
+    if (m_singleTileMode)
+        return m_tileSize;
+
+    if (smartPathInEffect())
+        return m_tileSize * 2;
+
+    return QSize(m_tileSize.width() * m_selectionSize.width(),
+                 m_tileSize.height() * m_selectionSize.height());
 }
 
-void CursorTileRect::setActive(bool active)
-{
-    this->active = active;
+void CursorTileRect::initAnchor(int coordX, int coordY) {
+    m_anchorCoord = QPoint(coordX, coordY);
+    m_anchored = true;
 }
 
-bool CursorTileRect::getActive()
-{
-    return active;
+void CursorTileRect::stopAnchor() {
+    m_anchored = false;
 }
 
-void CursorTileRect::initAnchor(int coordX, int coordY)
-{
-    this->anchorCoordX = coordX;
-    this->anchorCoordY = coordY;
-    this->anchored = true;
+void CursorTileRect::initRightClickSelectionAnchor(int coordX, int coordY) {
+    m_anchorCoord = QPoint(coordX, coordY);
+    m_rightClickSelectionAnchored = true;
 }
 
-void CursorTileRect::stopAnchor()
-{
-    this->anchored = false;
+void CursorTileRect::stopRightClickSelectionAnchor() {
+    m_rightClickSelectionAnchored = false;
 }
 
-void CursorTileRect::initRightClickSelectionAnchor(int coordX, int coordY)
-{
-    this->anchorCoordX = coordX;
-    this->anchorCoordY = coordY;
-    this->rightClickSelectionAnchored = true;
+void CursorTileRect::updateSelectionSize(int width, int height) {
+    m_selectionSize = QSize(width, height).expandedTo(QSize(1,1));
+    prepareGeometryChange();
+    update();
 }
 
-void CursorTileRect::stopRightClickSelectionAnchor()
-{
-    this->rightClickSelectionAnchored = false;
+bool CursorTileRect::smartPathInEffect() const {
+    return !m_rightClickSelectionAnchored && m_smartPathMode && m_selectionSize == QSize(3,3);
 }
 
-void CursorTileRect::updateSelectionSize(int width, int height)
-{
-    this->selectionWidth = width;
-    this->selectionHeight = height;
-    this->width = width * 16;
-    this->height = height * 16;
-    this->prepareGeometryChange();
-    this->update();
-}
+void CursorTileRect::updateLocation(int coordX, int coordY) {
+    if (!m_singleTileMode) {
+        if (m_rightClickSelectionAnchored) {
+            coordX = qMin(coordX, m_anchorCoord.x());
+            coordY = qMin(coordY, m_anchorCoord.y());
+        } else if (m_anchored && !smartPathInEffect()) {
+            int xDiff = coordX - m_anchorCoord.x();
+            int yDiff = coordY - m_anchorCoord.y();
+            if (xDiff < 0 && xDiff % m_selectionSize.width() != 0) xDiff -= m_selectionSize.width();
+            if (yDiff < 0 && yDiff % m_selectionSize.height() != 0) yDiff -= m_selectionSize.height();
 
-bool CursorTileRect::smartPathInEffect()
-{
-    return !this->rightClickSelectionAnchored && this->smartPathMode && this->selectionHeight == 3 && this->selectionWidth == 3;
-}
-
-void CursorTileRect::updateLocation(int coordX, int coordY)
-{
-    if (!this->singleTileMode) {
-        if (this->rightClickSelectionAnchored) {
-            coordX = qMin(coordX, this->anchorCoordX);
-            coordY = qMin(coordY, this->anchorCoordY);
-        }
-        else if (this->anchored && !this->smartPathInEffect()) {
-            int xDiff = coordX - this->anchorCoordX;
-            int yDiff = coordY - this->anchorCoordY;
-            if (xDiff < 0 && xDiff % this->selectionWidth != 0) xDiff -= this->selectionWidth;
-            if (yDiff < 0 && yDiff % this->selectionHeight != 0) yDiff -= this->selectionHeight;
-
-            coordX = this->anchorCoordX + (xDiff / this->selectionWidth) * this->selectionWidth;
-            coordY = this->anchorCoordY + (yDiff / this->selectionHeight) * this->selectionHeight;
+            coordX = m_anchorCoord.x() + (xDiff / m_selectionSize.width()) * m_selectionSize.width();
+            coordY = m_anchorCoord.y() + (yDiff / m_selectionSize.height()) * m_selectionSize.height();
         }
     }
 
-    coordX = qMax(coordX, 0);
-    coordY = qMax(coordY, 0);
     this->setX(coordX * 16);
     this->setY(coordY * 16);
-    this->setVisible(*this->enabled && this->active);
 }

--- a/src/ui/layoutpixmapitem.cpp
+++ b/src/ui/layoutpixmapitem.cpp
@@ -695,7 +695,7 @@ void LayoutPixmapItem::hoverMoveEvent(QGraphicsSceneHoverEvent *event) {
     QPoint pos = Metatile::coordFromPixmapCoord(event->pos());
     if (pos != this->metatilePos) {
         this->metatilePos = pos;
-        emit this->hoveredMapMetatileChanged(pos);
+        emit this->hoverChanged(pos);
     }
     if (this->settings->betterCursors && this->editsEnabled) {
         setCursor(this->settings->mapCursor);
@@ -704,16 +704,16 @@ void LayoutPixmapItem::hoverMoveEvent(QGraphicsSceneHoverEvent *event) {
 
 void LayoutPixmapItem::hoverEnterEvent(QGraphicsSceneHoverEvent * event) {
     this->has_mouse = true;
-    QPoint pos = Metatile::coordFromPixmapCoord(event->pos());
-    emit this->hoveredMapMetatileChanged(pos);
+    this->metatilePos = Metatile::coordFromPixmapCoord(event->pos());
+    emit this->hoverEntered(this->metatilePos);
 }
 
 void LayoutPixmapItem::hoverLeaveEvent(QGraphicsSceneHoverEvent *) {
-    emit this->hoveredMapMetatileCleared();
     if (this->settings->betterCursors && this->editsEnabled) {
         unsetCursor();
     }
     this->has_mouse = false;
+    emit this->hoverCleared();
 }
 
 void LayoutPixmapItem::mousePressEvent(QGraphicsSceneMouseEvent *event) {
@@ -730,7 +730,7 @@ void LayoutPixmapItem::mouseMoveEvent(QGraphicsSceneMouseEvent *event) {
         return;
 
     this->metatilePos = pos;
-    emit hoveredMapMetatileChanged(pos);
+    emit hoverChanged(pos);
     emit mouseEvent(event, this);
 }
 

--- a/src/ui/layoutpixmapitem.cpp
+++ b/src/ui/layoutpixmapitem.cpp
@@ -697,21 +697,15 @@ void LayoutPixmapItem::hoverMoveEvent(QGraphicsSceneHoverEvent *event) {
         this->metatilePos = pos;
         emit this->hoverChanged(pos);
     }
-    if (this->settings->betterCursors && this->editsEnabled) {
-        setCursor(this->settings->mapCursor);
-    }
 }
 
-void LayoutPixmapItem::hoverEnterEvent(QGraphicsSceneHoverEvent * event) {
+void LayoutPixmapItem::hoverEnterEvent(QGraphicsSceneHoverEvent *event) {
     this->has_mouse = true;
     this->metatilePos = Metatile::coordFromPixmapCoord(event->pos());
     emit this->hoverEntered(this->metatilePos);
 }
 
 void LayoutPixmapItem::hoverLeaveEvent(QGraphicsSceneHoverEvent *) {
-    if (this->settings->betterCursors && this->editsEnabled) {
-        unsetCursor();
-    }
     this->has_mouse = false;
     emit this->hoverCleared();
 }

--- a/src/ui/movablerect.cpp
+++ b/src/ui/movablerect.cpp
@@ -5,14 +5,11 @@
 #include "movablerect.h"
 #include "utility.h"
 
-MovableRect::MovableRect(bool *enabled, const QRectF &rect, const QRgb &color)
+MovableRect::MovableRect(const QRectF &rect, const QRgb &color)
   : QGraphicsRectItem(rect),
-    enabled(enabled),
     baseRect(rect),
     color(color)
-{
-    updateVisibility();
-}
+{ }
 
 /// Center rect on grid position (x, y)
 void MovableRect::updateLocation(int x, int y) {
@@ -20,28 +17,19 @@ void MovableRect::updateLocation(int x, int y) {
             this->baseRect.y() + (y * 16),
             this->baseRect.width(),
             this->baseRect.height());
-    updateVisibility();
 }
 
-void MovableRect::setActive(bool active) {
-    this->active = active;
-    updateVisibility();
-}
-
-void MovableRect::updateVisibility() {
-    setVisible(*this->enabled && this->active);
-}
 
 /******************************************************************************
     ************************************************************************
  ******************************************************************************/
 
-ResizableRect::ResizableRect(QObject *parent, bool *enabled, int width, int height, QRgb color)
+ResizableRect::ResizableRect(QObject *parent, int width, int height, QRgb color)
   : QObject(parent),
-    MovableRect(enabled, QRect(0, 0, width * 16, height * 16), color)
+    MovableRect(QRect(0, 0, width * 16, height * 16), color)
 {
-        setAcceptHoverEvents(true);
-        setFlags(this->flags() | QGraphicsItem::ItemIsMovable);
+    setAcceptHoverEvents(true);
+    setFlags(this->flags() | QGraphicsItem::ItemIsMovable);
 }
 
 ResizableRect::Edge ResizableRect::detectEdge(int x, int y) {

--- a/src/ui/resizelayoutpopup.cpp
+++ b/src/ui/resizelayoutpopup.cpp
@@ -136,9 +136,7 @@ void ResizeLayoutPopup::setupLayoutView() {
     this->ui->spinBox_height->setMinimum(1);
     this->ui->spinBox_height->setMaximum(maxHeight);
 
-    static bool layoutSizeRectVisible = true;
-
-    this->outline = new ResizableRect(this, &layoutSizeRectVisible, this->layout->getWidth(), this->layout->getHeight(), qRgb(255, 0, 255));
+    this->outline = new ResizableRect(this, this->layout->getWidth(), this->layout->getHeight(), qRgb(255, 0, 255));
     this->outline->setZValue(Editor::ZValue::ResizeLayoutPopup); // Ensure on top of view
     this->outline->setLimit(cover->rect().toAlignedRect());
     connect(outline, &ResizableRect::rectUpdated, [=](QRect rect){


### PR DESCRIPTION
- Removes the momentum from the Move tool
- Closes #749
- Closes #711
- Closes #639
- Closes #629
- Fix `Ctrl+D` allowing events to be duplicated from the Connections tab