### PR TITLE
Fix exported metatile image scaling, remove hardcoded cell sizes

### DIFF
--- a/forms/tileseteditor.ui
+++ b/forms/tileseteditor.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>733</width>
+    <width>748</width>
     <height>784</height>
    </rect>
   </property>
@@ -267,16 +267,10 @@
                   <verstretch>0</verstretch>
                  </sizepolicy>
                 </property>
-                <property name="minimumSize">
-                 <size>
-                  <width>66</width>
-                  <height>34</height>
-                 </size>
-                </property>
                 <property name="maximumSize">
                  <size>
-                  <width>96</width>
-                  <height>34</height>
+                  <width>1</width>
+                  <height>1</height>
                  </size>
                 </property>
                 <property name="verticalScrollBarPolicy">
@@ -561,8 +555,8 @@
             <rect>
              <x>0</x>
              <y>0</y>
-             <width>445</width>
-             <height>237</height>
+             <width>499</width>
+             <height>241</height>
             </rect>
            </property>
            <layout class="QGridLayout" name="gridLayout_2">
@@ -623,7 +617,7 @@
     <rect>
      <x>0</x>
      <y>0</y>
-     <width>733</width>
+     <width>748</width>
      <height>37</height>
     </rect>
    </property>

--- a/include/config.h
+++ b/include/config.h
@@ -82,7 +82,7 @@ public:
         this->collisionOpacity = 50;
         this->collisionZoom = 30;
         this->metatilesZoom = 30;
-        this->tilesetEditorMetatilesZoom = 30;
+        this->tilesetEditorMetatilesZoom = 45;
         this->tilesetEditorTilesZoom = 30;
         this->showPlayerView = false;
         this->showCursorTile = true;

--- a/include/ui/metatilelayersitem.h
+++ b/include/ui/metatilelayersitem.h
@@ -9,14 +9,7 @@
 class MetatileLayersItem: public SelectablePixmapItem {
     Q_OBJECT
 public:
-    MetatileLayersItem(Metatile *metatile, Tileset *primaryTileset, Tileset *secondaryTileset): SelectablePixmapItem(16, 16, 6, 2) {
-        this->metatile = metatile;
-        this->primaryTileset = primaryTileset;
-        this->secondaryTileset = secondaryTileset;
-        this->clearLastModifiedCoords();
-        this->clearLastHoveredCoords();
-        setAcceptHoverEvents(true);
-    }
+    MetatileLayersItem(Metatile *metatile, Tileset *primaryTileset, Tileset *secondaryTileset);
     void draw();
     void setTilesets(Tileset*, Tileset*);
     void setMetatile(Metatile*);

--- a/include/ui/tilemaptileselector.h
+++ b/include/ui/tilemaptileselector.h
@@ -136,7 +136,7 @@ public:
             this->palette = PaletteUtil::parse(palFilepath, &err);
         }
         this->setPixmap(QPixmap::fromImage(this->tileset));
-        this->numTilesWide = this->tileset.width() / 8;
+        this->numTilesWide = this->tileset.width() / this->cellWidth;
         this->selectedTile = 0x00;
         setAcceptHoverEvents(true);
     }

--- a/src/ui/metatileselector.cpp
+++ b/src/ui/metatileselector.cpp
@@ -21,7 +21,7 @@ void MetatileSelector::updateBasePixmap() {
     if (length_ % this->numMetatilesWide != 0) {
         height_++;
     }
-    QImage image(this->numMetatilesWide * 16, height_ * 16, QImage::Format_RGBA8888);
+    QImage image(this->numMetatilesWide * this->cellWidth, height_ * this->cellHeight, QImage::Format_RGBA8888);
     image.fill(Qt::magenta);
     QPainter painter(&image);
     for (int i = 0; i < length_; i++) {
@@ -32,7 +32,7 @@ void MetatileSelector::updateBasePixmap() {
         QImage metatile_image = getMetatileImage(tile, this->primaryTileset, this->secondaryTileset, layout->metatileLayerOrder, layout->metatileLayerOpacity);
         int map_y = i / this->numMetatilesWide;
         int map_x = i % this->numMetatilesWide;
-        QPoint metatile_origin = QPoint(map_x * 16, map_y * 16);
+        QPoint metatile_origin = QPoint(map_x * this->cellWidth, map_y * this->cellHeight);
         painter.drawImage(metatile_origin, metatile_image);
     }
     painter.end();

--- a/src/ui/regionmapentriespixmapitem.cpp
+++ b/src/ui/regionmapentriespixmapitem.cpp
@@ -17,12 +17,12 @@ void RegionMapEntriesPixmapItem::draw() {
         entry_w = entry.width, entry_h = entry.height;
     }
 
-    QImage image(region_map->tilemapWidth() * 8, region_map->tilemapHeight() * 8, QImage::Format_RGBA8888);
+    QImage image(region_map->tilemapWidth() * this->cellWidth, region_map->tilemapHeight() * this->cellHeight, QImage::Format_RGBA8888);
 
     QPainter painter(&image);
     for (int i = 0; i < region_map->tilemapSize(); i++) {
         QImage bottom_img = this->tile_selector->tileImg(region_map->getTile(i));
-        QImage top_img(8, 8, QImage::Format_RGBA8888);
+        QImage top_img(this->cellWidth, this->cellHeight, QImage::Format_RGBA8888);
         int x = i % region_map->tilemapWidth();
         int y = i / region_map->tilemapWidth();
         bool insideEntry = false;
@@ -40,7 +40,7 @@ void RegionMapEntriesPixmapItem::draw() {
         } else {
             top_img.fill(Qt::black);
         }
-        QPoint pos = QPoint(x * 8, y * 8);
+        QPoint pos = QPoint(x * this->cellWidth, y * this->cellHeight);
         painter.setOpacity(1);
         painter.drawImage(pos, bottom_img);
         painter.save();

--- a/src/ui/regionmaplayoutpixmapitem.cpp
+++ b/src/ui/regionmaplayoutpixmapitem.cpp
@@ -8,7 +8,7 @@ void RegionMapLayoutPixmapItem::draw() {
     QPainter painter(&image);
     for (int i = 0; i < region_map->tilemapSize(); i++) {
         QImage bottom_img = this->tile_selector->tileImg(region_map->getTile(i));
-        QImage top_img(8, 8, QImage::Format_RGBA8888);
+        QImage top_img(this->cellWidth, this->cellHeight, QImage::Format_RGBA8888);
         if (region_map->squareHasMap(i)) {
             top_img.fill(Qt::gray);
         } else {
@@ -16,7 +16,7 @@ void RegionMapLayoutPixmapItem::draw() {
         }
         int x = i % region_map->tilemapWidth();
         int y = i / region_map->tilemapWidth();
-        QPoint pos = QPoint(x * 8, y * 8);
+        QPoint pos = QPoint(x * this->cellWidth, y * this->cellHeight);
         painter.setOpacity(1);
         painter.drawImage(pos, bottom_img);
         painter.save();

--- a/src/ui/tilemaptileselector.cpp
+++ b/src/ui/tilemaptileselector.cpp
@@ -7,9 +7,9 @@ void TilemapTileSelector::draw() {
     this->pixelWidth = width_;
     size_t height_ = this->tileset.height();
     this->pixelHeight = height_;
-    size_t ntiles_ = (width_/8) * (height_/8);
+    size_t ntiles_ = (width_/this->cellWidth) * (height_/this->cellHeight);
 
-    this->numTilesWide = width_ / 8;
+    this->numTilesWide = width_ / this->cellWidth;
     this->numTiles     = ntiles_;
 
     this->setPixmap(QPixmap::fromImage(this->setPalette(this->tile_palette)));
@@ -92,7 +92,7 @@ QImage TilemapTileSelector::tileImg(shared_ptr<TilemapTile> tile) {
     QImage tilesetImage = setPalette(tile->palette());
 
     // take a tile from the tileset
-    QImage img = tilesetImage.copy(pos.x() * 8, pos.y() * 8, 8, 8);
+    QImage img = tilesetImage.copy(pos.x() * this->cellWidth, pos.y() * this->cellHeight, this->cellWidth, this->cellHeight);
 
     // QImage::flip was introduced in 6.9.0 to replace QImage::mirrored.
 #if (QT_VERSION >= QT_VERSION_CHECK(6, 9, 0))

--- a/src/ui/tileseteditormetatileselector.cpp
+++ b/src/ui/tileseteditormetatileselector.cpp
@@ -4,7 +4,7 @@
 #include <QPainter>
 
 TilesetEditorMetatileSelector::TilesetEditorMetatileSelector(Tileset *primaryTileset, Tileset *secondaryTileset, Layout *layout)
-  : SelectablePixmapItem(32, 32, 1, 1) {
+  : SelectablePixmapItem(16, 16, 1, 1) {
     this->primaryTileset = primaryTileset;
     this->secondaryTileset = secondaryTileset;
     this->numMetatilesWide = 8;

--- a/src/ui/tileseteditortileselector.cpp
+++ b/src/ui/tileseteditortileselector.cpp
@@ -22,27 +22,27 @@ void TilesetEditorTileSelector::draw() {
     int secondaryLength = this->secondaryTileset->tiles.length();
     int height = totalTiles / this->numTilesWide;
     QList<QRgb> palette = Tileset::getPalette(this->paletteId, this->primaryTileset, this->secondaryTileset, true);
-    QImage image(this->numTilesWide * 16, height * 16, QImage::Format_RGBA8888);
+    QImage image(this->numTilesWide * this->cellWidth, height * this->cellHeight, QImage::Format_RGBA8888);
 
     QPainter painter(&image);
     for (uint16_t tile = 0; tile < totalTiles; tile++) {
         QImage tileImage;
         if (tile < primaryLength) {
-            tileImage = getPalettedTileImage(tile, this->primaryTileset, this->secondaryTileset, this->paletteId, true).scaled(16, 16);
+            tileImage = getPalettedTileImage(tile, this->primaryTileset, this->secondaryTileset, this->paletteId, true).scaled(this->cellWidth, this->cellHeight);
         } else if (tile < Project::getNumTilesPrimary()) {
-            tileImage = QImage(16, 16, QImage::Format_RGBA8888);
+            tileImage = QImage(this->cellWidth, this->cellHeight, QImage::Format_RGBA8888);
             tileImage.fill(palette.at(0));
         } else if (tile < Project::getNumTilesPrimary() + secondaryLength) {
-            tileImage = getPalettedTileImage(tile, this->primaryTileset, this->secondaryTileset, this->paletteId, true).scaled(16, 16);
+            tileImage = getPalettedTileImage(tile, this->primaryTileset, this->secondaryTileset, this->paletteId, true).scaled(this->cellWidth, this->cellHeight);
         } else {
-            tileImage = QImage(16, 16, QImage::Format_RGBA8888);
+            tileImage = QImage(this->cellWidth, this->cellHeight, QImage::Format_RGBA8888);
             QPainter painter(&tileImage);
-            painter.fillRect(0, 0, 16, 16, palette.at(0));
+            painter.fillRect(0, 0, this->cellWidth, this->cellHeight, palette.at(0));
         }
 
         int y = tile / this->numTilesWide;
         int x = tile % this->numTilesWide;
-        QPoint origin = QPoint(x * 16, y * 16);
+        QPoint origin = QPoint(x * this->cellWidth, y * this->cellHeight);
         painter.drawImage(origin, tileImage);
     }
 
@@ -52,9 +52,9 @@ void TilesetEditorTileSelector::draw() {
             // Round up height for incomplete last row
             row++;
         }
-        const int y = row * 16;
+        const int y = row * this->cellHeight;
         painter.setPen(Qt::white);
-        painter.drawLine(0, y, this->numTilesWide * 16, y);
+        painter.drawLine(0, y, this->numTilesWide * this->cellWidth, y);
     }
 
     painter.end();
@@ -244,8 +244,10 @@ QImage TilesetEditorTileSelector::buildSecondaryTilesIndexedImage() {
 }
 
 QImage TilesetEditorTileSelector::buildImage(int tileIdStart, int numTiles) {
+    const int tileWidth = 8;
+    const int tileHeight = 8;
     int height = qCeil(numTiles / static_cast<double>(this->numTilesWide));
-    QImage image(this->numTilesWide * 8, height * 8, QImage::Format_RGBA8888);
+    QImage image(this->numTilesWide * tileWidth, height * tileHeight, QImage::Format_RGBA8888);
     image.fill(0);
 
     QPainter painter(&image);
@@ -253,7 +255,7 @@ QImage TilesetEditorTileSelector::buildImage(int tileIdStart, int numTiles) {
         QImage tileImage = getGreyscaleTileImage(tileIdStart + i, this->primaryTileset, this->secondaryTileset);
         int y = i / this->numTilesWide;
         int x = i % this->numTilesWide;
-        QPoint origin = QPoint(x * 8, y * 8);
+        QPoint origin = QPoint(x * tileWidth, y * tileHeight);
         painter.drawImage(origin, tileImage);
     }
     painter.end();
@@ -305,7 +307,7 @@ void TilesetEditorTileSelector::drawUnused() {
 
     for (int tile = 0; tile < this->usedTiles.size(); tile++) {
         if (!this->usedTiles[tile]) {
-            unusedPainter.drawPixmap((tile % 16) * 16, (tile / 16) * 16, redX);
+            unusedPainter.drawPixmap((tile % this->cellWidth) * this->cellWidth, (tile / this->cellWidth) * this->cellHeight, redX);
         }
     }
 


### PR DESCRIPTION
- Fix `Export Primary/Secondary Metatiles Image...` exporting metatiles at 32x32 instead of 16x16. This was because it used the same image drawing functions as the selector (which was 32x32), so rather than handle two separate scales in the image drawing we scale down the selector, and increase its default zoom setting.
- Fix a bunch of hard-coded sizes for the various subclasses of `SelectablePixmapItem`. This should make rescaling them easier in the future (the metatile layers item in particular might want to be rescaled at some point, it's a little small to be the painting focus of the Tileset Editor).