### PR TITLE
Allow compiling without the qml or network modules

### DIFF
--- a/docsrc/manual/scripting-capabilities.rst
+++ b/docsrc/manual/scripting-capabilities.rst
@@ -11,6 +11,9 @@ Porymap is extensible via scripting capabilities. This allows the user to write 
 - Procedurally Generated Maps
 - Randomize Grass Patterns
 
+.. note::
+    If you are compiling Porymap yourself, these features will only be available if Qt's ``qml`` module is installed.
+
 
 Custom Scripts Editor
 ---------------------

--- a/include/core/network.h
+++ b/include/core/network.h
@@ -26,10 +26,14 @@
     });
 */
 
+#if __has_include(<QNetworkAccessManager>)
 #include <QNetworkAccessManager>
 #include <QNetworkRequest>
 #include <QNetworkReply>
 #include <QDateTime>
+#endif
+
+#ifdef QT_NETWORK_LIB
 
 class NetworkReplyData : public QObject
 {
@@ -83,5 +87,7 @@ private:
     void processReply(QNetworkReply * reply, NetworkReplyData * data);
     const QNetworkRequest getRequest(const QUrl &url);
 };
+
+#endif // QT_NETWORK_LIB
 
 #endif // NETWORK_H

--- a/include/mainwindow.h
+++ b/include/mainwindow.h
@@ -11,7 +11,6 @@
 #include <QGraphicsSceneMouseEvent>
 #include <QCloseEvent>
 #include <QAbstractItemModel>
-#include <QJSValue>
 #include "project.h"
 #include "orderedjson.h"
 #include "config.h"
@@ -36,6 +35,10 @@
 #include "message.h"
 #include "resizelayoutpopup.h"
 
+#if __has_include(<QJSValue>)
+#include <QJSValue>
+#endif
+
 
 
 namespace Ui {
@@ -56,7 +59,11 @@ public:
 
     void initialize();
 
+    Q_INVOKABLE void setPrimaryTileset(const QString &tileset);
+    Q_INVOKABLE void setSecondaryTileset(const QString &tileset);
+
     // Scripting API
+#ifdef QT_QML_LIB
     Q_INVOKABLE QJSValue getBlock(int x, int y);
     void tryRedrawMapArea(bool forceRedraw);
     void redrawResizedMapArea();
@@ -119,8 +126,6 @@ public:
     Q_INVOKABLE int getNumSecondaryTilesetTiles();
     Q_INVOKABLE QString getPrimaryTileset();
     Q_INVOKABLE QString getSecondaryTileset();
-    Q_INVOKABLE void setPrimaryTileset(const QString &tileset);
-    Q_INVOKABLE void setSecondaryTileset(const QString &tileset);
     void saveMetatilesByMetatileId(int metatileId);
     void saveMetatileAttributesByMetatileId(int metatileId);
     Metatile * getMetatile(int metatileId);
@@ -172,6 +177,7 @@ public:
     Q_INVOKABLE void setAllowEscaping(bool allow);
     Q_INVOKABLE int getFloorNumber();
     Q_INVOKABLE void setFloorNumber(int floorNumber);
+#endif // QT_QML_LIB
 
 public slots:
     void on_mainTabBar_tabBarClicked(int index);

--- a/include/mainwindow.h
+++ b/include/mainwindow.h
@@ -331,8 +331,11 @@ private:
     QPointer<FilterChildrenProxyModel> layoutListProxyModel = nullptr;
     QPointer<LayoutTreeModel> layoutTreeModel = nullptr;
 
+#ifdef QT_NETWORK_LIB
     QPointer<UpdatePromoter> updatePromoter = nullptr;
     QPointer<NetworkAccessManager> networkAccessManager = nullptr;
+#endif
+
     QPointer<AboutPorymap> aboutWindow = nullptr;
     QPointer<WildMonChart> wildMonChart = nullptr;
     QPointer<WildMonSearch> wildMonSearch = nullptr;

--- a/include/scripting.h
+++ b/include/scripting.h
@@ -2,12 +2,19 @@
 #ifndef SCRIPTING_H
 #define SCRIPTING_H
 
-#include "mainwindow.h"
-#include "block.h"
+#include <QStringList>
 #include "scriptutility.h"
 
-#include <QStringList>
+class Block;
+class Tile;
+class MainWindow;
+
+#if __has_include(<QJSEngine>)
 #include <QJSEngine>
+#endif
+
+
+#ifdef QT_QML_LIB
 
 // !! New callback functions or changes to existing callback function names/arguments
 //    should be synced to resources/text/script_template.txt and docsrc/manual/scripting-capabilities.rst
@@ -77,5 +84,35 @@ private:
     void loadModules(QStringList moduleFiles);
     void invokeCallback(CallbackType type, QJSValueList args);
 };
+
+#else
+
+class Scripting
+{
+public:
+    Scripting(MainWindow *) {}
+    ~Scripting() {}
+    static void init(MainWindow *) {}
+    static void stop() {}
+    static void populateGlobalObject(MainWindow *) {}
+
+    static void cb_ProjectOpened(QString) {};
+    static void cb_ProjectClosed(QString) {};
+    static void cb_MetatileChanged(int, int, Block, Block) {};
+    static void cb_BorderMetatileChanged(int, int, uint16_t, uint16_t) {};
+    static void cb_BlockHoverChanged(int, int) {};
+    static void cb_BlockHoverCleared() {};
+    static void cb_MapOpened(QString) {};
+    static void cb_LayoutOpened(QString) {};
+    static void cb_MapResized(int, int, const QMargins &) {};
+    static void cb_BorderResized(int, int, int, int) {};
+    static void cb_MapShifted(int, int) {};
+    static void cb_TilesetUpdated(const QString &) {};
+    static void cb_MainTabChanged(int, int) {};
+    static void cb_MapViewTabChanged(int, int) {};
+    static void cb_BorderVisibilityToggled(bool) {};
+};
+
+#endif // QT_QML_LIB
 
 #endif // SCRIPTING_H

--- a/include/scriptutility.h
+++ b/include/scriptutility.h
@@ -2,14 +2,24 @@
 #ifndef SCRIPTUTILITY_H
 #define SCRIPTUTILITY_H
 
-#include "mainwindow.h"
+#if __has_include(<QJSValue>)
+#include <QJSValue>
+#endif
+
+#ifdef QT_QML_LIB
+
+#include <QAction>
+#include <QMessageBox>
+#include <QSet>
+#include <QTimer>
+
+class MainWindow;
 
 class ScriptUtility : public QObject
 {
     Q_OBJECT
-
 public:
-    ScriptUtility(MainWindow *mainWindow);
+    ScriptUtility(MainWindow *mainWindow) : window(mainWindow) {}
     ~ScriptUtility();
 
     QString getActionFunctionName(int actionIndex);
@@ -68,5 +78,7 @@ private:
     QSet<QTimer *> activeTimers;
     QHash<int, QString> actionMap;
 };
+
+#endif // QT_QML_LIB
 
 #endif // SCRIPTUTILITY_H

--- a/include/ui/mapview.h
+++ b/include/ui/mapview.h
@@ -1,7 +1,10 @@
 #ifndef MAPVIEW_H
 #define MAPVIEW_H
 
+#if __has_include(<QJSValue>)
 #include <QJSValue>
+#endif
+
 #include "graphicsview.h"
 #include "overlay.h"
 #include "tile.h"
@@ -22,6 +25,7 @@ public:
     void clearOverlayMap();
 
     // Overlay scripting API
+#ifdef QT_QML_LIB
     Q_INVOKABLE void clear(int layer);
     Q_INVOKABLE void clear();
     Q_INVOKABLE void hide(int layer);
@@ -74,6 +78,7 @@ public:
     Q_INVOKABLE void addTileImage(int x, int y, int tileId, bool xflip, bool yflip, int paletteId, bool setTransparency = false, int layer = 0);
     Q_INVOKABLE void addTileImage(int x, int y, QJSValue tileObj, bool setTransparency = false, int layer = 0);
     Q_INVOKABLE void addMetatileImage(int x, int y, int metatileId, bool setTransparency = false, int layer = 0);
+#endif // QT_QML_LIB
 
 protected:
     virtual void drawForeground(QPainter *painter, const QRectF &rect) override;

--- a/include/ui/overlay.h
+++ b/include/ui/overlay.h
@@ -8,6 +8,8 @@
 #include <QStaticText>
 #include <QPainterPath>
 
+#ifdef QT_QML_LIB
+
 class OverlayItem {
 public:
     OverlayItem() {}
@@ -122,5 +124,18 @@ private:
     qreal opacity;
     QRectF *clippingRect;
 };
+
+#else
+
+class Overlay
+{
+public:
+    Overlay() {}
+    ~Overlay() {}
+
+    void renderItems(QPainter *) {}
+};
+
+#endif // QT_QML_LIB
 
 #endif // OVERLAY_H

--- a/include/ui/updatepromoter.h
+++ b/include/ui/updatepromoter.h
@@ -1,6 +1,8 @@
 #ifndef UPDATEPROMOTER_H
 #define UPDATEPROMOTER_H
 
+#ifdef QT_NETWORK_LIB
+
 #include "network.h"
 
 #include <QDialog>
@@ -46,5 +48,7 @@ private slots:
 signals:
     void changedPreferences();
 };
+
+#endif // QT_NETWORK_LIB
 
 #endif // UPDATEPROMOTER_H

--- a/porymap.pro
+++ b/porymap.pro
@@ -4,7 +4,7 @@
 #
 #-------------------------------------------------
 
-QT       += core gui network
+QT       += core gui
 
 qtHaveModule(charts) {
     QT += charts
@@ -15,6 +15,11 @@ qtHaveModule(qml) {
     QT += qml
 } else {
     warning("Qt module 'qml' not found, disabling plug-in features.")
+}
+qtHaveModule(network) {
+    QT += network
+} else {
+    warning("Qt module 'network' not found, disabling network features.")
 }
 
 greaterThan(QT_MAJOR_VERSION, 4): QT += widgets

--- a/porymap.pro
+++ b/porymap.pro
@@ -4,12 +4,17 @@
 #
 #-------------------------------------------------
 
-QT       += core gui qml network
+QT       += core gui network
 
 qtHaveModule(charts) {
     QT += charts
 } else {
     warning("Qt module 'charts' not found, disabling chart features.")
+}
+qtHaveModule(qml) {
+    QT += qml
+} else {
+    warning("Qt module 'qml' not found, disabling plug-in features.")
 }
 
 greaterThan(QT_MAJOR_VERSION, 4): QT += widgets

--- a/src/core/map.cpp
+++ b/src/core/map.cpp
@@ -4,6 +4,7 @@
 #include "scripting.h"
 #include "utility.h"
 #include "editcommands.h"
+#include "project.h"
 
 #include <QTime>
 #include <QPainter>

--- a/src/core/maplayout.cpp
+++ b/src/core/maplayout.cpp
@@ -5,6 +5,8 @@
 #include "scripting.h"
 #include "imageproviders.h"
 #include "utility.h"
+#include "project.h"
+#include "layoutpixmapitem.h"
 
 QList<int> Layout::s_globalMetatileLayerOrder;
 QList<float> Layout::s_globalMetatileLayerOpacity;

--- a/src/core/network.cpp
+++ b/src/core/network.cpp
@@ -1,3 +1,4 @@
+#ifdef QT_NETWORK_LIB
 #include "network.h"
 #include "config.h"
 
@@ -148,3 +149,5 @@ void NetworkAccessManager::processReply(QNetworkReply * reply, NetworkReplyData 
 
     cacheEntry->data = data->m_body = reply->readAll();
 }
+
+#endif // QT_NETWORK_LIB

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -51,8 +51,10 @@
 
 // We only publish release binaries for Windows and macOS.
 // This is relevant for the update promoter, which alerts users of a new release.
+#ifdef QT_NETWORK_LIB
 #if defined(Q_OS_WIN) || defined(Q_OS_MACOS)
 #define RELEASE_PLATFORM
+#endif
 #endif
 
 
@@ -155,11 +157,14 @@ void MainWindow::initWindow() {
     this->initMapList();
     this->initShortcuts();
 
+    QStringList missingModules;
+
 #ifndef RELEASE_PLATFORM
     ui->actionCheck_for_Updates->setVisible(false);
 #endif
-
-    QStringList missingModules;
+#ifndef QT_NETWORK_LIB
+    missingModules.append(" 'network'");
+#endif
 
 #ifndef QT_CHARTS_LIB
     ui->pushButton_SummaryChart->setVisible(false);
@@ -2970,8 +2975,10 @@ void MainWindow::on_actionPreferences_triggered() {
 void MainWindow::togglePreferenceSpecificUi() {
     ui->actionOpen_Project_in_Text_Editor->setEnabled(!porymapConfig.textEditorOpenFolder.isEmpty());
 
+#ifdef QT_NETWORK_LIB
     if (this->updatePromoter)
         this->updatePromoter->updatePreferences();
+#endif
 }
 
 void MainWindow::openProjectSettingsEditor(int tab) {

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -74,7 +74,8 @@ MainWindow::MainWindow(QWidget *parent) :
     ui->setupUi(this);
 
     logInit();
-    logInfo(QString("Launching Porymap v%1").arg(QCoreApplication::applicationVersion()));
+    logInfo(QString("Launching Porymap v%1 (%2)").arg(QCoreApplication::applicationVersion()).arg(QStringLiteral(PORYMAP_LATEST_COMMIT)));
+    logInfo(QString("Using Qt v%2 (%3)").arg(QStringLiteral(QT_VERSION_STR)).arg(QSysInfo::buildCpuArchitecture()));
 }
 
 void MainWindow::initialize() {

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -159,9 +159,23 @@ void MainWindow::initWindow() {
     ui->actionCheck_for_Updates->setVisible(false);
 #endif
 
+    QStringList missingModules;
+
 #ifndef QT_CHARTS_LIB
     ui->pushButton_SummaryChart->setVisible(false);
+    missingModules.append(" 'charts'");
 #endif
+
+#ifndef QT_QML_LIB
+    ui->actionCustom_Scripts->setVisible(false);
+    missingModules.append(" 'qml'");
+#endif
+
+    if (!missingModules.isEmpty()) {
+        logWarn(QString("Qt module%1%2 not found. Some features will be disabled.")
+                            .arg(missingModules.length() > 1 ? "s" : "")
+                            .arg(missingModules.join(",")));
+    }
 
     setWindowDisabled(true);
 }
@@ -2285,21 +2299,29 @@ void MainWindow::initShortcutsEditor() {
 void MainWindow::connectSubEditorsToShortcutsEditor() {
     /* Initialize sub-editors so that their children are added to MainWindow's object tree and will
      * be returned by shortcutableObjects() to be passed to ShortcutsEditor. */
-    if (!tilesetEditor)
+    if (!this->tilesetEditor) {
         initTilesetEditor();
-    connect(shortcutsEditor, &ShortcutsEditor::shortcutsSaved,
-            tilesetEditor, &TilesetEditor::applyUserShortcuts);
+    }
+    if (this->tilesetEditor) {
+        connect(this->shortcutsEditor, &ShortcutsEditor::shortcutsSaved,
+                this->tilesetEditor, &TilesetEditor::applyUserShortcuts);
+    }
 
-    if (!regionMapEditor)
+    if (!this->regionMapEditor){
         initRegionMapEditor(true);
-    if (regionMapEditor)
-        connect(shortcutsEditor, &ShortcutsEditor::shortcutsSaved,
-                regionMapEditor, &RegionMapEditor::applyUserShortcuts);
+    }
+    if (this->regionMapEditor) {
+        connect(this->shortcutsEditor, &ShortcutsEditor::shortcutsSaved,
+                this->regionMapEditor, &RegionMapEditor::applyUserShortcuts);
+    }
 
-    if (!customScriptsEditor)
+    if (!this->customScriptsEditor) {
         initCustomScriptsEditor();
-    connect(shortcutsEditor, &ShortcutsEditor::shortcutsSaved,
-            customScriptsEditor, &CustomScriptsEditor::applyUserShortcuts);
+    }
+    if (this->customScriptsEditor) {
+        connect(this->shortcutsEditor, &ShortcutsEditor::shortcutsSaved,
+                this->customScriptsEditor, &CustomScriptsEditor::applyUserShortcuts);
+    }
 }
 
 void MainWindow::resetMapViewScale() {
@@ -2994,16 +3016,20 @@ void MainWindow::onWarpBehaviorWarningClicked() {
 }
 
 void MainWindow::on_actionCustom_Scripts_triggered() {
-    if (!this->customScriptsEditor)
+    if (!this->customScriptsEditor) {
         initCustomScriptsEditor();
-
-    Util::show(this->customScriptsEditor);
+    }
+    if (this->customScriptsEditor) {
+        Util::show(this->customScriptsEditor);
+    }
 }
 
 void MainWindow::initCustomScriptsEditor() {
+#ifdef QT_QML_LIB
     this->customScriptsEditor = new CustomScriptsEditor(this);
     connect(this->customScriptsEditor, &CustomScriptsEditor::reloadScriptEngine,
             this, &MainWindow::reloadScriptEngine);
+#endif
 }
 
 void MainWindow::reloadScriptEngine() {

--- a/src/scriptapi/apimap.cpp
+++ b/src/scriptapi/apimap.cpp
@@ -1,3 +1,4 @@
+#ifdef QT_QML_LIB
 #include "mainwindow.h"
 #include "ui_mainwindow.h"
 #include "scripting.h"
@@ -963,3 +964,5 @@ void MainWindow::setFloorNumber(int floorNumber) {
     this->editor->map->header()->setFloorNumber(floorNumber);
 }
 
+
+#endif // QT_QML_LIB

--- a/src/scriptapi/apioverlay.cpp
+++ b/src/scriptapi/apioverlay.cpp
@@ -1,6 +1,8 @@
+#ifdef QT_QML_LIB
 #include "mapview.h"
 #include "scripting.h"
 #include "imageproviders.h"
+#include "editor.h"
 
 void MapView::updateScene() {
     if (this->scene()) {
@@ -300,3 +302,5 @@ void MapView::addMetatileImage(int x, int y, int metatileId, bool setTransparenc
     if (this->getOverlay(layer)->addImage(x, y, image))
         this->updateScene();
 }
+
+#endif // QT_QML_LIB

--- a/src/scriptapi/apiutility.cpp
+++ b/src/scriptapi/apiutility.cpp
@@ -1,11 +1,9 @@
+#ifdef QT_QML_LIB
+#include "scriptutility.h"
 #include "mainwindow.h"
 #include "ui_mainwindow.h"
 #include "scripting.h"
 #include "config.h"
-
-ScriptUtility::ScriptUtility(MainWindow *mainWindow) {
-    this->window = mainWindow;
-}
 
 ScriptUtility::~ScriptUtility() {
     if (window && window->ui && window->ui->menuTools) {
@@ -318,3 +316,5 @@ bool ScriptUtility::isPrimaryTileset(QString tilesetName) {
 bool ScriptUtility::isSecondaryTileset(QString tilesetName) {
     return getSecondaryTilesetNames().contains(tilesetName);
 }
+
+#endif // QT_QML_LIB

--- a/src/scriptapi/scripting.cpp
+++ b/src/scriptapi/scripting.cpp
@@ -1,8 +1,10 @@
+#if __has_include(<QQmlEngine>)
 #include <QQmlEngine>
 
 #include "scripting.h"
 #include "log.h"
 #include "config.h"
+#include "mainwindow.h"
 
 const QMap<CallbackType, QString> callbackFunctions = {
     {OnProjectOpened, "onProjectOpened"},
@@ -422,3 +424,6 @@ const QImage * Scripting::getImage(const QString &inputFilepath, bool useCache) 
     instance->imageCache.insert(inputFilepath, image);
     return image;
 }
+
+
+#endif // __has_include(<QQmlEngine>)

--- a/src/ui/overlay.cpp
+++ b/src/ui/overlay.cpp
@@ -1,3 +1,4 @@
+#ifdef QT_QML_LIB
 #include "overlay.h"
 #include "scripting.h"
 #include "log.h"
@@ -256,3 +257,6 @@ bool Overlay::addImage(int x, int y, QImage image) {
     this->items.append(new OverlayPixmap(x, y, QPixmap::fromImage(image)));
     return true;
 }
+
+
+#endif // QT_QML_LIB

--- a/src/ui/updatepromoter.cpp
+++ b/src/ui/updatepromoter.cpp
@@ -1,3 +1,4 @@
+#ifdef QT_NETWORK_LIB
 #include "updatepromoter.h"
 #include "ui_updatepromoter.h"
 #include "log.h"
@@ -188,3 +189,5 @@ void UpdatePromoter::dialogButtonClicked(QAbstractButton *button) {
         QDesktopServices::openUrl(this->downloadUrl);
     }
 }
+
+#endif // QT_NETWORK_LIB

--- a/src/ui/wildmonchart.cpp
+++ b/src/ui/wildmonchart.cpp
@@ -1,4 +1,4 @@
-#if __has_include(<QtCharts>)
+#ifdef QT_CHARTS_LIB
 #include "wildmonchart.h"
 #include "ui_wildmonchart.h"
 #include "config.h"
@@ -466,4 +466,4 @@ void WildMonChart::closeEvent(QCloseEvent *event) {
     QWidget::closeEvent(event);
 }
 
-#endif // __has_include(<QtCharts>)
+#endif // QT_CHARTS_LIB


### PR DESCRIPTION
Adds support for building Porymap without either the qml or network modules (we already do this for the charts module). 

Without the qml module, the plug-in / API features are disabled, and without the network module the 'check for updates' feature is disabled (this is already disabled on Linux). Both of these features are not critical (and for the majority of users go unused) so we'd rather have users be able to build and use Porymap without needing to sort out their Qt installation. This has come up a few times already, especially for users that have multiple installations of Qt in their environment.

There's a slight maintenance burden here in that the stubbed `Scripting` class will need to be updated alongside the actual definition when e.g. a new scripting callback is added.