### PR TITLE
Fix image export colors, add color space settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project somewhat adheres to [Semantic Versioning](https://semver.org/sp
 
 ### Fixed
 - Fix rare crash while quitting Porymap.
+- Fix exported images on macOS using a different color space than in Porymap.
 
 ## [6.2.0] - 2025-08-08
 ### Added

--- a/forms/preferenceeditor.ui
+++ b/forms/preferenceeditor.ui
@@ -48,52 +48,74 @@
              <x>0</x>
              <y>0</y>
              <width>493</width>
-             <height>374</height>
+             <height>408</height>
             </rect>
            </property>
            <layout class="QVBoxLayout" name="verticalLayout_6">
             <item>
-             <widget class="QCheckBox" name="checkBox_MonitorProjectFiles">
-              <property name="toolTip">
-               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If checked, a prompt to reload your project will appear if relevant project files are edited&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-              </property>
-              <property name="text">
-               <string>Monitor project files</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QCheckBox" name="checkBox_OpenRecentProject">
-              <property name="toolTip">
-               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If checked, Porymap will automatically open your most recently opened project on startup&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-              </property>
-              <property name="text">
-               <string>Open recent project on launch</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QCheckBox" name="checkBox_CheckForUpdates">
-              <property name="toolTip">
-               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If checked, Porymap will automatically alert you on startup if a new release is available&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-              </property>
-              <property name="text">
-               <string>Automatically check for updates</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QGroupBox" name="groupBox_Themes">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="title">
-               <string>Application Theme</string>
-              </property>
-             </widget>
+             <layout class="QFormLayout" name="formLayout">
+              <item row="2" column="0" colspan="2">
+               <widget class="QCheckBox" name="checkBox_CheckForUpdates">
+                <property name="toolTip">
+                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If checked, Porymap will automatically alert you on startup if a new release is available&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                </property>
+                <property name="text">
+                 <string>Automatically check for updates</string>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="0" colspan="2">
+               <widget class="QCheckBox" name="checkBox_OpenRecentProject">
+                <property name="toolTip">
+                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If checked, Porymap will automatically open your most recently opened project on startup&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                </property>
+                <property name="text">
+                 <string>Open recent project on launch</string>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="0" colspan="2">
+               <widget class="QCheckBox" name="checkBox_MonitorProjectFiles">
+                <property name="toolTip">
+                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If checked, a prompt to reload your project will appear if relevant project files are edited&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                </property>
+                <property name="text">
+                 <string>Monitor project files</string>
+                </property>
+               </widget>
+              </item>
+              <item row="3" column="0">
+               <widget class="QLabel" name="label_ApplicationTheme">
+                <property name="text">
+                 <string>Application Theme</string>
+                </property>
+               </widget>
+              </item>
+              <item row="3" column="1">
+               <widget class="NoScrollComboBox" name="comboBox_ApplicationTheme">
+                <property name="editable">
+                 <bool>false</bool>
+                </property>
+               </widget>
+              </item>
+              <item row="4" column="0">
+               <widget class="QLabel" name="label_ColorSpace">
+                <property name="text">
+                 <string>Image Export Color Space</string>
+                </property>
+               </widget>
+              </item>
+              <item row="4" column="1">
+               <widget class="NoScrollComboBox" name="comboBox_ColorSpace">
+                <property name="toolTip">
+                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The color space to use for exported images. If &amp;quot;---&amp;quot; is set, no color space will be used for the exported image. For details on each color space, see Qt's manual page for QColorSpace.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                </property>
+                <property name="editable">
+                 <bool>false</bool>
+                </property>
+               </widget>
+              </item>
+             </layout>
             </item>
             <item>
              <widget class="QGroupBox" name="groupBox_Fonts">
@@ -483,6 +505,13 @@
    </layout>
   </widget>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>NoScrollComboBox</class>
+   <extends>QComboBox</extends>
+   <header>noscrollcombobox.h</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/include/config.h
+++ b/include/config.h
@@ -14,6 +14,7 @@
 #include <QGraphicsPixmapItem>
 #include <QFontDatabase>
 #include <QStandardPaths>
+#include <QColorSpace>
 #include <set>
 
 #include "events.h"
@@ -145,6 +146,7 @@ public:
     std::set<LogType> statusBarLogTypes;
     QFont applicationFont;
     QFont mapListFont;
+    int imageExportColorSpaceId;
 
 protected:
     virtual void parseConfigKeyValue(QString key, QString value) override;

--- a/include/core/mapconnection.h
+++ b/include/core/mapconnection.h
@@ -42,6 +42,7 @@ public:
     MapConnection* createMirror();
 
     QPixmap render() const;
+    QImage renderImage() const;
     QPoint relativePixelPos(bool clipped = false) const;
 
     static QPointer<Project> project;

--- a/include/core/utility.h
+++ b/include/core/utility.h
@@ -4,6 +4,7 @@
 
 #include <QString>
 #include <QLineEdit>
+#include <QColorSpace>
 
 namespace Util {
     void numericalModeSort(QStringList &list);
@@ -17,6 +18,7 @@ namespace Util {
     void setErrorStylesheet(QLineEdit *lineEdit, bool isError);
     QString toStylesheetString(const QFont &font);
     void show(QWidget *w);
+    QColorSpace toColorSpace(int colorSpaceInt);
 }
 
 #endif // UTILITY_H

--- a/include/ui/mapimageexporter.h
+++ b/include/ui/mapimageexporter.h
@@ -58,6 +58,7 @@ private:
     QBuffer *m_timelapseBuffer = nullptr;
     QMovie *m_timelapseMovie = nullptr;
     QGraphicsPixmapItem *m_preview = nullptr;
+    QImage m_previewImage;
 
     ImageExporterSettings m_settings;
     ImageExporterMode m_mode = ImageExporterMode::Normal;
@@ -77,15 +78,15 @@ private:
     void setConnectionDirectionEnabled(const QString &dir, bool enable);
     void saveImage();
     QGifImage* createTimelapseGifImage(QProgressDialog *progress);
-    QPixmap getStitchedImage(QProgressDialog *progress);
-    QPixmap getFormattedMapPixmap();
+    QImage getStitchedImage(QProgressDialog *progress);
+    QImage getFormattedMapImage();
     void paintBorder(QPainter *painter, Layout *layout);
     void paintCollision(QPainter *painter, Layout *layout);
     void paintConnections(QPainter *painter, const Map *map);
     void paintEvents(QPainter *painter, const Map *map);
     void paintGrid(QPainter *painter, const Layout *layout = nullptr);
     QMargins getMargins(const Map *map);
-    QPixmap getExpandedPixmap(const QPixmap &pixmap, const QSize &targetSize, const QColor &fillColor);
+    QImage getExpandedImage(const QImage &image, const QSize &targetSize, const QColor &fillColor);
     bool currentHistoryAppliesToFrame(QUndoStack *historyStack);
 
 protected:

--- a/include/ui/metatileimageexporter.h
+++ b/include/ui/metatileimageexporter.h
@@ -81,6 +81,7 @@ private:
 
     CheckeredBgScene *m_scene = nullptr;
     QGraphicsPixmapItem *m_preview = nullptr;
+    QImage m_previewImage;
     bool m_previewUpdateQueued = false;
     QList<int> m_layerOrder;
     ProjectConfig m_savedConfig;

--- a/include/ui/preferenceeditor.h
+++ b/include/ui/preferenceeditor.h
@@ -29,7 +29,6 @@ signals:
 
 private:
     Ui::PreferenceEditor *ui;
-    NoScrollComboBox *themeSelector;
     QFont applicationFont;
     QFont mapListFont;
 

--- a/src/core/mapconnection.cpp
+++ b/src/core/mapconnection.cpp
@@ -68,6 +68,12 @@ QPixmap MapConnection::render() const {
     return map->renderConnection(m_direction, m_parentMap ? m_parentMap->layout() : nullptr);
 }
 
+QImage MapConnection::renderImage() const {
+    render();
+    auto map = targetMap();
+    return (map && map->layout()) ? map->layout()->image : QImage();
+}
+
 // Get the position of the target map relative to its parent map.
 // For right/down connections this is offset by the dimensions of the parent map.
 // For left/up connections this is offset by the dimensions of the target map.

--- a/src/core/utility.cpp
+++ b/src/core/utility.cpp
@@ -125,3 +125,23 @@ void Util::show(QWidget *w) {
         w->activateWindow();
     }
 }
+
+// Safe conversion from an int representing a QColorSpace::NamedColorSpace to a QColorSpace.
+// This lets us use 0 to mean "no color space".
+QColorSpace Util::toColorSpace(int colorSpaceInt) {
+    QColorSpace colorSpace;
+
+    int min = static_cast<int>(QColorSpace::SRgb);
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 8, 0))
+    // Qt 6.8.0 introduced additional color spaces
+    int max = static_cast<int>(QColorSpace::Bt2100Hlg);
+#else
+    int max = static_cast<int>(QColorSpace::ProPhotoRgb);
+#endif
+
+    if (colorSpaceInt >= min && colorSpaceInt <= max) {
+        return QColorSpace(static_cast<QColorSpace::NamedColorSpace>(colorSpaceInt));
+    } else {
+        return QColorSpace();
+    }
+}

--- a/src/ui/metatileimageexporter.cpp
+++ b/src/ui/metatileimageexporter.cpp
@@ -185,7 +185,7 @@ void MetatileImageExporter::reset() {
 
 QImage MetatileImageExporter::getImage() {
     tryUpdatePreview();
-    return m_preview->pixmap().toImage();
+    return m_previewImage;
 }
 
 bool MetatileImageExporter::saveImage(QString filepath) {
@@ -197,7 +197,7 @@ bool MetatileImageExporter::saveImage(QString filepath) {
             return false;
         }
     }
-    return m_preview->pixmap().save(filepath);
+    return m_previewImage.save(filepath);
 }
 
 QString MetatileImageExporter::getDefaultFileName() const {
@@ -244,7 +244,7 @@ void MetatileImageExporter::queuePreviewUpdate() {
 // For updating only when a change has been recorded.
 // Useful for something that might happen often, like an input widget losing focus.
 void MetatileImageExporter::tryUpdatePreview() {
-    if (m_preview->pixmap().isNull() || m_previewUpdateQueued) {
+    if (m_previewImage.isNull() || m_previewUpdateQueued) {
         updatePreview();
     }
 }
@@ -261,15 +261,14 @@ void MetatileImageExporter::updatePreview() {
         }
     }
 
-    QImage previewImage;
     if (ui->checkBox_PrimaryTileset->isChecked() && ui->checkBox_SecondaryTileset->isChecked()) {
         // Special behavior to combine the two tilesets while skipping the unused region between tilesets.
-        previewImage = getMetatileSheetImage(m_primaryTileset,
+        m_previewImage = getMetatileSheetImage(m_primaryTileset,
                                              m_secondaryTileset,
                                              ui->spinBox_WidthMetatiles->value(),
                                              m_layerOrder);
     } else {
-        previewImage = getMetatileSheetImage(m_primaryTileset,
+        m_previewImage = getMetatileSheetImage(m_primaryTileset,
                                              m_secondaryTileset,
                                              ui->spinBox_MetatileStart->value(),
                                              ui->spinBox_MetatileEnd->value(),
@@ -277,7 +276,8 @@ void MetatileImageExporter::updatePreview() {
                                              m_layerOrder);
     }
 
-    m_preview->setPixmap(QPixmap::fromImage(previewImage));
+    m_previewImage.setColorSpace(Util::toColorSpace(porymapConfig.imageExportColorSpaceId));
+    m_preview->setPixmap(QPixmap::fromImage(m_previewImage));
     m_scene->setSceneRect(m_scene->itemsBoundingRect());
     m_previewUpdateQueued = false;
 


### PR DESCRIPTION
Closes #525 

Adds a setting under Preferences to set the color space for exported images. For macOS users this defaults to Display P3 (this difference in color space is why the exported image in the issue appeared different than in Porymap). For non-macOS users it defaults to no color space (same as the previous behavior).

