### PR TITLE
Add sorting options to the Locations and Layouts list

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -97,6 +97,8 @@ public:
     int mapListTab;
     bool mapListEditGroupsEnabled;
     QMap<int, bool> mapListHideEmptyEnabled;
+    bool mapListLayoutsSorted;
+    bool mapListLocationsSorted;
     bool prettyCursors;
     bool mirrorConnectingMaps;
     bool showDiveEmergeMaps;

--- a/include/mainwindow.h
+++ b/include/mainwindow.h
@@ -393,10 +393,10 @@ private:
     void openDuplicateMapOrLayoutDialog();
     void openNewMapGroupDialog();
     void openNewLocationDialog();
-    void scrollMapList(MapTree *list, const QString &itemName);
+    void scrollMapList(MapTree *list, const QString &itemName, bool expandItem = true);
     void scrollMapListToCurrentMap(MapTree *list);
     void scrollMapListToCurrentLayout(MapTree *list);
-    void scrollCurrentMapListToItem(const QString &itemName);
+    void scrollCurrentMapListToItem(const QString &itemName, bool expandItem = true);
     void showFileWatcherWarning();
     bool openProject(QString dir, bool initial = false);
     bool closeProject();
@@ -410,6 +410,7 @@ private:
 
     void rebuildMapList_Locations();
     void rebuildMapList_Layouts();
+    void setMapListSorted(MapTree *list, bool sort);
     void updateMapList();
     void openMapListItem(const QModelIndex &index);
     void onMapListTabChanged(int index);

--- a/include/project.h
+++ b/include/project.h
@@ -52,8 +52,6 @@ public:
     QStringList bgEventFacingDirections;
     QStringList trainerTypes;
     QStringList globalScriptLabels;
-    QStringList mapSectionIdNamesSaveOrder;
-    QStringList mapSectionIdNames;
     QMap<uint32_t, QString> encounterTypeToName;
     QMap<uint32_t, QString> terrainTypeToName;
     QMap<QString, QMap<QString, uint16_t>> metatileLabelsMap;
@@ -83,6 +81,7 @@ public:
     Map* loadMap(const QString &mapName);
 
     const QStringList& layoutIds() const { return this->alphabeticalLayoutIds; }
+    const QStringList& layoutIdsOrdered() const { return this->orderedLayoutIds; }
     bool isKnownLayout(const QString &layoutId) const { return this->mapLayouts.contains(layoutId); }
     bool isLoadedLayout(const QString &layoutId) const { return this->loadedLayoutIds.contains(layoutId); }
     bool isUnsavedLayout(const QString &layoutId) const;
@@ -92,6 +91,12 @@ public:
     // Note: This does not guarantee the layout is loaded.
     Layout* getLayout(const QString &layoutId) const { return this->mapLayouts.value(layoutId); }
     Layout* loadLayout(const QString &layoutId);
+
+    const QStringList& locationNames() const { return this->mapSectionIdNames; }
+    const QStringList& locationNamesOrdered() const { return this->mapSectionIdNamesSaveOrder; }
+
+    QString getLocationName(int locationValue) const { return this->mapSectionIdNamesSaveOrder.value(locationValue, getEmptyMapsecName()); }
+    int getLocationValue(const QString &locationName) const { return this->mapSectionIdNamesSaveOrder.indexOf(locationName); }
 
     void clearMaps();
     void clearTilesetCache();
@@ -284,6 +289,8 @@ private:
     QStringList orderedLayoutIdsMaster;
     QHash<QString, Layout*> mapLayouts;
     QHash<QString, Layout*> mapLayoutsMaster;
+    QStringList mapSectionIdNamesSaveOrder;
+    QStringList mapSectionIdNames;
 
     // Fields for preserving top-level JSON data that Porymap isn't expecting.
     QJsonObject customLayoutsData;

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -327,6 +327,8 @@ void PorymapConfig::reset() {
     this->mapListTab = 0;
     this->mapListEditGroupsEnabled = false;
     this->mapListHideEmptyEnabled.clear();
+    this->mapListLayoutsSorted = true;
+    this->mapListLocationsSorted = true;
     this->prettyCursors = true;
     this->mirrorConnectingMaps = true;
     this->showDiveEmergeMaps = false;
@@ -397,6 +399,10 @@ void PorymapConfig::parseConfigKeyValue(QString key, QString value) {
             return;
         }
         this->mapListHideEmptyEnabled.insert(tab, getConfigBool(key, value));
+    } else if (key == "map_list_layouts_sorted") {
+        this->mapListLayoutsSorted = getConfigBool(key, value);
+    } else if (key == "map_list_locations_sorted") {
+        this->mapListLocationsSorted = getConfigBool(key, value);
     } else if (key == "main_window_geometry") {
         this->mainWindowGeometry = bytesFromString(value);
     } else if (key == "main_window_state") {
@@ -579,6 +585,8 @@ QMap<QString, QString> PorymapConfig::getKeyValueMap() {
     for (auto i = this->mapListHideEmptyEnabled.constBegin(); i != this->mapListHideEmptyEnabled.constEnd(); i++) {
         map.insert(QStringLiteral("map_list_hide_empty_enabled/") + QString::number(i.key()), i.value() ? "1" : "0");
     }
+    map.insert("map_list_layouts_sorted", this->mapListLayoutsSorted ? "1" : "0");
+    map.insert("map_list_locations_sorted", this->mapListLocationsSorted ? "1" : "0");
     map.insert("main_window_geometry", stringFromByteArray(this->mainWindowGeometry));
     map.insert("main_window_state", stringFromByteArray(this->mainWindowState));
     map.insert("map_splitter_state", stringFromByteArray(this->mapSplitterState));

--- a/src/core/regionmap.cpp
+++ b/src/core/regionmap.cpp
@@ -156,7 +156,7 @@ bool RegionMap::loadLayout(poryjson::Json layoutJson) {
                 for (int x = 0; x < this->layout_width; x++) {
                     int bin_index = x + y * this->layout_width;
                     uint8_t square_section_id = mapBinData.at(bin_index);
-                    QString square_section_name = project->mapSectionIdNames.value(square_section_id, this->default_map_section);
+                    QString square_section_name = project->getLocationName(square_section_id);
 
                     LayoutSquare square;
                     square.map_section = square_section_name;
@@ -397,11 +397,11 @@ void RegionMap::saveLayout() {
         case LayoutFormat::Binary:
         {
             QByteArray data;
-            int defaultValue = this->project->mapSectionIdNames.indexOf(this->default_map_section);
+            int defaultValue = this->project->getLocationValue(this->default_map_section);
             for (int m = 0; m < this->layout_height; m++) {
                 for (int n = 0; n < this->layout_width; n++) {
                     int i = n + this->layout_width * m;
-                    int mapSectionValue = this->project->mapSectionIdNames.indexOf(this->layouts["main"][i].map_section);
+                    int mapSectionValue = this->project->getLocationValue(this->layouts["main"][i].map_section);
                     if (mapSectionValue < 0){
                         mapSectionValue = defaultValue;
                     }

--- a/src/scriptapi/apiutility.cpp
+++ b/src/scriptapi/apiutility.cpp
@@ -288,7 +288,7 @@ QList<QString> ScriptUtility::getSongNames() {
 QList<QString> ScriptUtility::getLocationNames() {
     if (!window || !window->editor || !window->editor->project)
         return QList<QString>();
-    return window->editor->project->mapSectionIdNames;
+    return window->editor->project->locationNames();
 }
 
 QList<QString> ScriptUtility::getWeatherNames() {

--- a/src/ui/mapheaderform.cpp
+++ b/src/ui/mapheaderform.cpp
@@ -67,7 +67,7 @@ void MapHeaderForm::setProject(Project * project, bool allowChanges) {
 
     const QSignalBlocker b_Locations(ui->comboBox_Location);
     ui->comboBox_Location->clear();
-    ui->comboBox_Location->addItems(m_project->mapSectionIdNames);
+    ui->comboBox_Location->addItems(m_project->locationNames());
 
     // Hide config-specific settings
 

--- a/src/ui/maplistmodels.cpp
+++ b/src/ui/maplistmodels.cpp
@@ -442,7 +442,7 @@ bool MapGroupModel::setData(const QModelIndex &index, const QVariant &value, int
 MapLocationModel::MapLocationModel(Project *project, QObject *parent) : MapListModel(project, parent) {
     this->folderTypeName = "map_section";
 
-    for (const auto &idName : this->project->mapSectionIdNames) {
+    for (const auto &idName : this->project->locationNamesOrdered()) {
         insertMapFolderItem(idName);
     }
     for (const auto &mapName : this->project->mapNames()) {
@@ -466,7 +466,7 @@ QStandardItem *MapLocationModel::createMapFolderItem(const QString &folderName, 
 LayoutTreeModel::LayoutTreeModel(Project *project, QObject *parent) : MapListModel(project, parent) {
     this->folderTypeName = "map_layout";
 
-    for (const auto &layoutId : this->project->layoutIds()) {
+    for (const auto &layoutId : this->project->layoutIdsOrdered()) {
         insertMapFolderItem(layoutId);
     }
     for (const auto &mapName : this->project->mapNames()) {

--- a/src/ui/regionmapeditor.cpp
+++ b/src/ui/regionmapeditor.cpp
@@ -648,7 +648,7 @@ void RegionMapEditor::displayRegionMapLayoutOptions() {
 
     const QSignalBlocker b(ui->comboBox_RM_ConnectedMap);
     this->ui->comboBox_RM_ConnectedMap->clear();
-    this->ui->comboBox_RM_ConnectedMap->addItems(this->project->mapSectionIdNames);
+    this->ui->comboBox_RM_ConnectedMap->addItems(this->project->locationNames());
 
     this->ui->frame_RM_Options->setEnabled(true);
 
@@ -711,7 +711,7 @@ void RegionMapEditor::displayRegionMapEntryOptions() {
     if (!this->region_map->layoutEnabled()) return;
 
     this->ui->comboBox_RM_Entry_MapSection->clear();
-    this->ui->comboBox_RM_Entry_MapSection->addItems(this->project->mapSectionIdNames);
+    this->ui->comboBox_RM_Entry_MapSection->addItems(this->project->locationNames());
     this->ui->spinBox_RM_Entry_x->setMaximum(128);
     this->ui->spinBox_RM_Entry_y->setMaximum(128);
     this->ui->spinBox_RM_Entry_width->setMinimum(1);
@@ -1103,10 +1103,10 @@ void RegionMapEditor::on_action_Swap_triggered() {
     QFormLayout form(&popup);
 
     QComboBox *oldSecBox = new QComboBox();
-    oldSecBox->addItems(this->project->mapSectionIdNames);
+    oldSecBox->addItems(this->project->locationNames());
     form.addRow(new QLabel("Map Section 1:"), oldSecBox);
     QComboBox *newSecBox = new QComboBox();
-    newSecBox->addItems(this->project->mapSectionIdNames);
+    newSecBox->addItems(this->project->locationNames());
     form.addRow(new QLabel("Map Section 2:"), newSecBox);
 
     QDialogButtonBox buttonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel, Qt::Horizontal, &popup);
@@ -1142,10 +1142,10 @@ void RegionMapEditor::on_action_Replace_triggered() {
     QFormLayout form(&popup);
 
     QComboBox *oldSecBox = new QComboBox();
-    oldSecBox->addItems(this->project->mapSectionIdNames);
+    oldSecBox->addItems(this->project->locationNames());
     form.addRow(new QLabel("Old Map Section:"), oldSecBox);
     QComboBox *newSecBox = new QComboBox();
-    newSecBox->addItems(this->project->mapSectionIdNames);
+    newSecBox->addItems(this->project->locationNames());
     form.addRow(new QLabel("New Map Section:"), newSecBox);
 
     QDialogButtonBox buttonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel, Qt::Horizontal, &popup);


### PR DESCRIPTION
Adds an option to change the sorting behavior of the `Locations` and `Layouts` list from alphabetical (current) to by-value, accessible by right-clicking on any folder in the list.