### PR TITLE
Widen INCBIN regex support

### DIFF
--- a/include/core/parseutil.h
+++ b/include/core/parseutil.h
@@ -140,6 +140,7 @@ private:
     static const QRegularExpression re_poryScriptLabel;
     static const QRegularExpression re_globalPoryScriptLabel;
     static const QRegularExpression re_poryRawSection;
+    static const QString incbinRegexText;
 };
 
 #endif // PARSEUTIL_H

--- a/src/project.cpp
+++ b/src/project.cpp
@@ -1522,8 +1522,9 @@ void Project::readTilesetPaths(Tileset* tileset) {
         
         const QString tilesImagePath = parser.readCIncbin(graphicsFile, tileset->tiles_label);
         const QStringList palettePaths = parser.readCIncbinArray(graphicsFile, tileset->palettes_label);
-        const QString metatilesPath = parser.readCIncbin(metatilesFile, tileset->metatiles_label);
-        const QString metatileAttrsPath = parser.readCIncbin(metatilesFile, tileset->metatile_attrs_label);
+        auto metatileIncbins = parser.readCIncbinMulti(metatilesFile);
+        const QString metatilesPath = metatileIncbins.value(tileset->metatiles_label);
+        const QString metatileAttrsPath = metatileIncbins.value(tileset->metatile_attrs_label);
 
         if (!tilesImagePath.isEmpty())
             tileset->tilesImagePath = this->fixGraphicPath(rootDir + tilesImagePath);


### PR DESCRIPTION
When parsing an `array[] = INCBIN_U32("path")` statement to extract `path`, Porymap will now successfully parse the following:
- `array[size] = INCBIN_U32("path")`
- `array[] = INCBIN_U32   ("path")`
- `array[] = INCBIN_U32("path", "path2")`