### PR TITLE
Separate duplicate map/layout, fix window disabling

### DIFF
--- a/forms/mainwindow.ui
+++ b/forms/mainwindow.ui
@@ -2867,7 +2867,8 @@
     <addaction name="action_NewMap"/>
     <addaction name="action_NewLayout"/>
     <addaction name="actionNew_Tileset"/>
-    <addaction name="actionDuplicate_Current_Map_Layout"/>
+    <addaction name="actionDuplicate_Current_Map"/>
+    <addaction name="actionDuplicate_Current_Layout"/>
     <addaction name="separator"/>
     <addaction name="actionImport_Map_from_Advance_Map_1_92"/>
     <addaction name="separator"/>
@@ -3244,9 +3245,17 @@
     <string>New Layout...</string>
    </property>
   </action>
-  <action name="actionDuplicate_Current_Map_Layout">
+  <action name="actionDuplicate_Current_Map">
    <property name="text">
-    <string>Duplicate Current Map/Layout...</string>
+    <string>Duplicate Current Map...</string>
+   </property>
+   <property name="enabled">
+    <bool>false</bool>
+   </property>
+  </action>
+  <action name="actionDuplicate_Current_Layout">
+   <property name="text">
+    <string>Duplicate Current Layout...</string>
    </property>
   </action>
   <action name="actionBack">

--- a/include/mainwindow.h
+++ b/include/mainwindow.h
@@ -366,6 +366,8 @@ private:
     bool tilesetNeedsRedraw = false;
     bool lockMapListAutoScroll = false;
 
+    QSet<QObject*> objectsDisabled;
+
     bool setLayout(const QString &layoutId);
     bool setMap(const QString &mapName);
     void unsetMap();
@@ -390,7 +392,6 @@ private:
     NewLayoutDialog* createNewLayoutDialog(const Layout *layoutToCopy = nullptr);
     void openNewLayoutDialog();
     void openDuplicateLayoutDialog(const QString &layoutId);
-    void openDuplicateMapOrLayoutDialog();
     void openNewMapGroupDialog();
     void openNewLocationDialog();
     void scrollMapList(MapTree *list, const QString &itemName, bool expandItem = true);


### PR DESCRIPTION
- Separates `Duplicate Current Map/Layout` into two separate menu actions so that a user can duplicate a layout while a map is open.
- Fixes `MainWindow::setWindowDisabled` blindly disabling, then re-enabling most actions in the menu bar, which was incorrectly enabling menu actions that should initially be disabled (at the moment, just `Edit > Undo` and the new `Duplicate Current Map`)
- Fixes `Help > Open Manual` being disabled when no project is open.