### PR TITLE
Add config option for region map sections json key

### DIFF
--- a/include/config/projectconfig.h
+++ b/include/config/projectconfig.h
@@ -66,6 +66,7 @@ enum ProjectIdentifier {
     regex_incbin,
     pals_output_extension,
     tiles_output_extension,
+    key_region_map_sections,
 };
 
 enum ProjectFilePath {

--- a/src/config/projectconfig.cpp
+++ b/src/config/projectconfig.cpp
@@ -71,6 +71,8 @@ const QMap<ProjectIdentifier, QString> ProjectConfig::defaultIdentifiers = {
     {ProjectIdentifier::regex_encounter_types,         "\\bTILE_ENCOUNTER_"},
     {ProjectIdentifier::regex_terrain_types,           "\\bTILE_TERRAIN_"},
     {ProjectIdentifier::regex_incbin,                  Regex::Pattern_INCBIN},
+    // JSON keys
+    {ProjectIdentifier::key_region_map_sections,       "map_sections"},
     // Other
     {ProjectIdentifier::pals_output_extension,         ".gbapal"},
     {ProjectIdentifier::tiles_output_extension,        ".4bpp.lz"},

--- a/src/project.cpp
+++ b/src/project.cpp
@@ -983,8 +983,10 @@ bool Project::saveRegionMapSections() {
         mapSectionArray.append(mapSectionObj);
     }
 
+    const QString mapSectionsKey = projectConfig.getIdentifier(ProjectIdentifier::key_region_map_sections);
+
     OrderedJson::object object;
-    object["map_sections"] = mapSectionArray;
+    object[mapSectionsKey] = mapSectionArray;
     OrderedJson::append(&object, this->customMapSectionsData);
 
     ignoreWatchedFileTemporarily(filepath);
@@ -2549,8 +2551,10 @@ bool Project::readRegionMapSections() {
     }
     watchFile(filepath);
 
+    const QString mapSectionsKey = projectConfig.getIdentifier(ProjectIdentifier::key_region_map_sections);
+
     QJsonObject mapSectionsGlobalObj = doc.object();
-    QJsonArray mapSections = mapSectionsGlobalObj.take("map_sections").toArray();
+    QJsonArray mapSections = mapSectionsGlobalObj.take(mapSectionsKey).toArray();
     for (int i = 0; i < mapSections.size(); i++) {
         QJsonObject mapSectionObj = mapSections.at(i).toObject();
 


### PR DESCRIPTION
Add a config option for  the key used in `region_map_sections.json` to allow for different map sections  for different build targets.