### PR TITLE
Redesign species distribution chart

### DIFF
--- a/forms/wildmonchart.ui
+++ b/forms/wildmonchart.ui
@@ -92,7 +92,7 @@
         <number>0</number>
        </property>
        <item>
-        <widget class="QChartView" name="chartView_SpeciesDistribution">
+        <widget class="SpeciesChartView" name="chartView_SpeciesDistribution">
          <property name="renderHints">
           <set>QPainter::Antialiasing</set>
          </property>
@@ -216,7 +216,7 @@
         </widget>
        </item>
        <item>
-        <widget class="QChartView" name="chartView_LevelDistribution">
+        <widget class="SpeciesChartView" name="chartView_LevelDistribution">
          <property name="renderHints">
           <set>QPainter::Antialiasing</set>
          </property>
@@ -230,9 +230,9 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>QChartView</class>
-   <extends>QGraphicsView</extends>
-   <header>QtCharts</header>
+   <class>SpeciesChartView</class>
+   <extends>QChartView</extends>
+   <header>specieschartview.h</header>
   </customwidget>
   <customwidget>
    <class>NoScrollComboBox</class>

--- a/forms/wildmonchart.ui
+++ b/forms/wildmonchart.ui
@@ -17,10 +17,10 @@
    <item>
     <widget class="QFrame" name="frame_TopBar">
      <property name="frameShape">
-      <enum>QFrame::NoFrame</enum>
+      <enum>QFrame::Shape::NoFrame</enum>
      </property>
      <property name="frameShadow">
-      <enum>QFrame::Plain</enum>
+      <enum>QFrame::Shadow::Plain</enum>
      </property>
      <layout class="QHBoxLayout" name="horizontalLayout_2">
       <property name="leftMargin">
@@ -48,7 +48,7 @@
       <item>
        <spacer name="horizontalSpacer_2">
         <property name="orientation">
-         <enum>Qt::Horizontal</enum>
+         <enum>Qt::Orientation::Horizontal</enum>
         </property>
         <property name="sizeHint" stdset="0">
          <size>
@@ -85,6 +85,9 @@
        <property name="leftMargin">
         <number>0</number>
        </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
        <property name="rightMargin">
         <number>0</number>
        </property>
@@ -92,11 +95,55 @@
         <number>0</number>
        </property>
        <item>
-        <widget class="SpeciesChartView" name="chartView_SpeciesDistribution">
-         <property name="renderHints">
-          <set>QPainter::Antialiasing</set>
+        <widget class="QFrame" name="frame_speciesDistribution">
+         <property name="frameShape">
+          <enum>QFrame::Shape::NoFrame</enum>
          </property>
+         <property name="frameShadow">
+          <enum>QFrame::Shadow::Plain</enum>
+         </property>
+         <layout class="QHBoxLayout" name="horizontalLayout_speciesDistribution">
+          <property name="topMargin">
+           <number>12</number>
+          </property>
+          <property name="bottomMargin">
+           <number>0</number>
+          </property>
+          <item>
+           <widget class="QLabel" name="label_speciesDistributionGroup">
+            <property name="text">
+             <string>Group</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="NoScrollComboBox" name="comboBox_speciesDistributionGroup">
+            <property name="sizeAdjustPolicy">
+             <enum>QComboBox::SizeAdjustPolicy::AdjustToMinimumContentsLengthWithIcon</enum>
+            </property>
+            <property name="minimumContentsLength">
+             <number>8</number>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <spacer name="horizontalSpacer_speciesDistribution">
+            <property name="orientation">
+             <enum>Qt::Orientation::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>40</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+         </layout>
         </widget>
+       </item>
+       <item>
+        <widget class="SpeciesChartView" name="chartView_SpeciesDistribution" native="true"/>
        </item>
       </layout>
      </widget>
@@ -120,10 +167,10 @@
        <item>
         <widget class="QFrame" name="frame">
          <property name="frameShape">
-          <enum>QFrame::NoFrame</enum>
+          <enum>QFrame::Shape::NoFrame</enum>
          </property>
          <property name="frameShadow">
-          <enum>QFrame::Plain</enum>
+          <enum>QFrame::Shadow::Plain</enum>
          </property>
          <layout class="QHBoxLayout" name="horizontalLayout">
           <property name="topMargin">
@@ -142,7 +189,7 @@
           <item>
            <widget class="NoScrollComboBox" name="comboBox_Group">
             <property name="sizeAdjustPolicy">
-             <enum>QComboBox::AdjustToMinimumContentsLengthWithIcon</enum>
+             <enum>QComboBox::SizeAdjustPolicy::AdjustToMinimumContentsLengthWithIcon</enum>
             </property>
             <property name="minimumContentsLength">
              <number>8</number>
@@ -152,7 +199,7 @@
           <item>
            <spacer name="horizontalSpacer">
             <property name="orientation">
-             <enum>Qt::Horizontal</enum>
+             <enum>Qt::Orientation::Horizontal</enum>
             </property>
             <property name="sizeHint" stdset="0">
              <size>
@@ -199,10 +246,10 @@
                 <bool>true</bool>
                </property>
                <property name="insertPolicy">
-                <enum>QComboBox::NoInsert</enum>
+                <enum>QComboBox::InsertPolicy::NoInsert</enum>
                </property>
                <property name="sizeAdjustPolicy">
-                <enum>QComboBox::AdjustToMinimumContentsLengthWithIcon</enum>
+                <enum>QComboBox::SizeAdjustPolicy::AdjustToMinimumContentsLengthWithIcon</enum>
                </property>
                <property name="minimumContentsLength">
                 <number>12</number>
@@ -230,14 +277,14 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>SpeciesChartView</class>
-   <extends>QChartView</extends>
-   <header>specieschartview.h</header>
-  </customwidget>
-  <customwidget>
    <class>NoScrollComboBox</class>
    <extends>QComboBox</extends>
    <header>noscrollwidgets.h</header>
+  </customwidget>
+  <customwidget>
+   <class>SpeciesChartView</class>
+   <extends>QWidget</extends>
+   <header>specieschartview.h</header>
   </customwidget>
  </customwidgets>
  <resources>

--- a/include/ui/specieschartview.h
+++ b/include/ui/specieschartview.h
@@ -3,6 +3,7 @@
 
 #if __has_include(<QtCharts>)
 #include <QtCharts/QChartView>
+QT_CHARTS_USE_NAMESPACE
 
 class Project;
 

--- a/include/ui/specieschartview.h
+++ b/include/ui/specieschartview.h
@@ -1,7 +1,7 @@
 #ifndef SPECIESCHARTVIEW_H
 #define SPECIESCHARTVIEW_H
 
-#if __has_include(<QtCharts>)
+#if QT_CHARTS_LIB
 #include <QtCharts/QChartView>
 QT_CHARTS_USE_NAMESPACE
 

--- a/include/ui/specieschartview.h
+++ b/include/ui/specieschartview.h
@@ -25,6 +25,7 @@ public:
     static constexpr int IconVerticalOffset = -2;
     static constexpr int Spacing = 6;
     static constexpr int Padding = 10;
+    static constexpr int MaxLabelWidth = 230;
     explicit SpeciesChartView(QWidget *parent = nullptr);
 
     void setSpecies(const QStringList &species);

--- a/include/ui/specieschartview.h
+++ b/include/ui/specieschartview.h
@@ -3,7 +3,10 @@
 
 #if QT_CHARTS_LIB
 #include <QtCharts/QChartView>
+
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
 QT_CHARTS_USE_NAMESPACE
+#endif
 
 class Project;
 

--- a/include/ui/specieschartview.h
+++ b/include/ui/specieschartview.h
@@ -1,6 +1,7 @@
 #ifndef SPECIESCHARTVIEW_H
 #define SPECIESCHARTVIEW_H
 
+#if __has_include(<QtCharts>)
 #include <QtCharts/QChartView>
 
 class Project;
@@ -34,4 +35,6 @@ private:
     int m_maxTextWidth = 0;
 };
 
-#endif
+#endif // __has_include(<QtCharts>)
+
+#endif // SPECIESCHARTVIEW_H

--- a/include/ui/specieschartview.h
+++ b/include/ui/specieschartview.h
@@ -1,0 +1,37 @@
+#ifndef SPECIESCHARTVIEW_H
+#define SPECIESCHARTVIEW_H
+
+#include <QtCharts/QChartView>
+
+class Project;
+
+struct SpeciesEntry
+{
+    QString name;
+    QPixmap icon;
+};
+
+class SpeciesChartView : public QChartView
+{
+    Q_OBJECT
+
+public:
+    static constexpr int IconSize = 32;
+    static constexpr int IconVerticalOffset = -2;
+    static constexpr int Spacing = 6;
+    static constexpr int Padding = 10;
+    explicit SpeciesChartView(QWidget *parent = nullptr);
+
+    void setSpecies(const QStringList &species);
+    void setProject(Project *project);
+
+protected:
+    void paintEvent(QPaintEvent *event) override;
+
+private:
+    QVector<SpeciesEntry> m_speciesEntries;
+    Project *m_project = nullptr;
+    int m_maxTextWidth = 0;
+};
+
+#endif

--- a/include/ui/wildmonchart.h
+++ b/include/ui/wildmonchart.h
@@ -77,11 +77,13 @@ private:
 
 #else
 
+class Project;
+
 class WildMonChart : public QWidget
 {
     Q_OBJECT
 public:
-    explicit WildMonChart(QWidget *, const EncounterTableModel *) {};
+    explicit WildMonChart(QWidget *, const EncounterTableModel *, Project *) {};
     ~WildMonChart() {};
 
 public slots:

--- a/include/ui/wildmonchart.h
+++ b/include/ui/wildmonchart.h
@@ -8,6 +8,8 @@
 #if __has_include(<QtCharts>)
 #include <QtCharts>
 
+class Project;
+
 namespace Ui {
 class WildMonChart;
 }
@@ -16,7 +18,7 @@ class WildMonChart : public QWidget
 {
     Q_OBJECT
 public:
-    explicit WildMonChart(QWidget *parent, const EncounterTableModel *table);
+    explicit WildMonChart(QWidget *parent, const EncounterTableModel *table, Project *project);
     ~WildMonChart();
 
 public slots:
@@ -27,6 +29,7 @@ public slots:
 private:
     Ui::WildMonChart *ui;
     const EncounterTableModel *table;
+    Project *project = nullptr;
 
     QStringList groupNames;
     QStringList groupNamesReversed;

--- a/include/ui/wildmonchart.h
+++ b/include/ui/wildmonchart.h
@@ -5,10 +5,10 @@
 
 #include <QWidget>
 
+class Project;
+
 #if __has_include(<QtCharts>)
 #include <QtCharts>
-
-class Project;
 
 namespace Ui {
 class WildMonChart;
@@ -49,8 +49,6 @@ private:
     typedef QMap<QString, Summary> GroupedData;
 
     QMap<QString, GroupedData> speciesToGroupedData;
-    QMap<QString, QColor> speciesToColor;
-
 
     QStringList getSpeciesNamesAlphabetical() const;
     double getSpeciesFrequency(const QString&, const QString&) const;
@@ -66,8 +64,6 @@ private:
     void refreshSpeciesDistributionChart();
     void refreshLevelDistributionChart();
 
-    void saveSpeciesColors(const QList<QBarSet*> &);
-    void applySpeciesColors(const QList<QBarSet*> &);
     QChart::ChartTheme currentTheme() const;
     void updateTheme();
     void limitChartAnimation();
@@ -76,8 +72,6 @@ private:
 };
 
 #else
-
-class Project;
 
 class WildMonChart : public QWidget
 {

--- a/porymap.pro
+++ b/porymap.pro
@@ -144,6 +144,7 @@ SOURCES += src/config/keyvalueconfigbase.cpp \
     src/ui/palettecolorsearch.cpp \
     src/ui/paletteeditor.cpp \
     src/ui/selectablepixmapitem.cpp \
+    src/ui/specieschartview.cpp \
     src/ui/tileseteditor.cpp \
     src/ui/tileseteditormetatileselector.cpp \
     src/ui/tileseteditortileselector.cpp \
@@ -275,6 +276,7 @@ HEADERS  += include/config/keyvalueconfigbase.h \
     include/ui/palettecolorsearch.h \
     include/ui/paletteeditor.h \
     include/ui/selectablepixmapitem.h \
+    include/ui/specieschartview.h \
     include/ui/tileseteditor.h \
     include/ui/tileseteditormetatileselector.h \
     include/ui/tileseteditortileselector.h \

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -2839,7 +2839,7 @@ void MainWindow::on_pushButton_DeleteWildMonGroup_clicked() {
 
 void MainWindow::on_pushButton_SummaryChart_clicked() {
     if (!this->wildMonChart) {
-        this->wildMonChart = new WildMonChart(this, this->editor->getCurrentWildMonTable());
+        this->wildMonChart = new WildMonChart(this, this->editor->getCurrentWildMonTable(), this->editor->project);
         connect(this->editor, &Editor::wildMonTableOpened, this->wildMonChart, &WildMonChart::setTable);
         connect(this->editor, &Editor::wildMonTableClosed, this->wildMonChart, &WildMonChart::clearTable);
         connect(this->editor, &Editor::wildMonTableEdited, this->wildMonChart, &WildMonChart::refresh);

--- a/src/ui/specieschartview.cpp
+++ b/src/ui/specieschartview.cpp
@@ -1,0 +1,100 @@
+#include "specieschartview.h"
+
+#include "project.h"
+
+#include <QPainter>
+
+SpeciesChartView::SpeciesChartView(QWidget *parent)
+    : QChartView(parent)
+{
+}
+
+
+void SpeciesChartView::setSpecies(const QStringList &species)
+{
+    m_speciesEntries.clear();
+
+    const QString speciesPrefix = projectConfig.getIdentifier(ProjectIdentifier::define_species_prefix);
+
+    QFontMetrics fm(font());
+
+    m_maxTextWidth = 0;
+    for (const QString &name : species)
+    {
+        m_maxTextWidth = std::max(m_maxTextWidth, fm.horizontalAdvance(name));
+
+        QPixmap icon = m_project->getSpeciesIcon(speciesPrefix + name);
+
+        m_speciesEntries.push_back({
+            name,
+            icon.scaled(
+                IconSize,
+                IconSize,
+                Qt::KeepAspectRatio,
+                Qt::SmoothTransformation)
+        });
+    }
+
+    viewport()->update();
+}
+
+void SpeciesChartView::setProject(Project *project)
+{
+    m_project = project;
+    viewport()->update();
+}
+
+void SpeciesChartView::paintEvent(QPaintEvent *event)
+{
+    QChartView::paintEvent(event);
+
+    if (!chart() || !m_project || m_speciesEntries.isEmpty())
+        return;
+
+    QPainter painter(viewport());
+    painter.setRenderHint(QPainter::TextAntialiasing);
+    painter.setPen(chart()->titleBrush().color());
+
+    const QRectF plot = chart()->plotArea();
+
+    if (plot.height() <= 0)
+        return;
+
+    const QFontMetrics fm(painter.font());
+
+    const double rowHeight = plot.height() / m_speciesEntries.size();
+    const int labelWidth = m_maxTextWidth + IconSize + Spacing;
+    const int textX = plot.left() - labelWidth - Padding;
+    const int iconX = textX + m_maxTextWidth + Spacing;
+
+    for (int i = 0; i < m_speciesEntries.size(); ++i)
+    {
+        const SpeciesEntry &entry = m_speciesEntries[i];
+
+        // Center text vertically
+        const double y = plot.top() + rowHeight * (i + 0.5);
+        const QRect textRect(
+            textX,
+            static_cast<int>(y - rowHeight / 2.0),
+            m_maxTextWidth,
+            static_cast<int>(rowHeight)
+        );
+
+        painter.drawText(
+            textRect,
+            Qt::AlignRight | Qt::AlignVCenter,
+            entry.name
+        );
+
+        // Align icon with text
+        const int iconY = textRect.center().y() - IconSize / 2.0 + IconVerticalOffset;
+        const QRect iconRect(
+            iconX,
+            iconY,
+            IconSize,
+            IconSize
+        );
+
+        painter.drawPixmap(iconRect, entry.icon);
+    }
+}

--- a/src/ui/specieschartview.cpp
+++ b/src/ui/specieschartview.cpp
@@ -23,7 +23,8 @@ void SpeciesChartView::setSpecies(const QStringList &species)
     {
         m_maxTextWidth = std::max(m_maxTextWidth, fm.horizontalAdvance(name));
 
-        QPixmap icon = m_project->getSpeciesIcon(speciesPrefix + name);
+        QPixmap icon;
+        if (m_project) icon = m_project->getSpeciesIcon(speciesPrefix + name);
 
         m_speciesEntries.push_back({
             name,
@@ -33,6 +34,10 @@ void SpeciesChartView::setSpecies(const QStringList &species)
                 Qt::KeepAspectRatio,
                 Qt::SmoothTransformation)
         });
+    }
+
+    if (m_maxTextWidth > MaxLabelWidth) {
+        m_maxTextWidth = MaxLabelWidth;
     }
 
     viewport()->update();

--- a/src/ui/specieschartview.cpp
+++ b/src/ui/specieschartview.cpp
@@ -1,7 +1,7 @@
+#ifdef QT_CHARTS_LIB
+
 #include "specieschartview.h"
-
 #include "project.h"
-
 #include <QPainter>
 
 SpeciesChartView::SpeciesChartView(QWidget *parent)
@@ -98,3 +98,5 @@ void SpeciesChartView::paintEvent(QPaintEvent *event)
         painter.drawPixmap(iconRect, entry.icon);
     }
 }
+
+#endif // QT_CHARTS_LIB

--- a/src/ui/wildmonchart.cpp
+++ b/src/ui/wildmonchart.cpp
@@ -19,9 +19,10 @@ static const QList<QPair<QString, QChart::ChartTheme>> themes = {
     {"Qt",            QChart::ChartThemeQt},
 };
 
-WildMonChart::WildMonChart(QWidget *parent, const EncounterTableModel *table) :
+WildMonChart::WildMonChart(QWidget *parent, const EncounterTableModel *table, Project *project) :
     QWidget(parent),
-    ui(new Ui::WildMonChart)
+    ui(new Ui::WildMonChart),
+    project(project)
 {
     ui->setupUi(this);
     setAttribute(Qt::WA_DeleteOnClose);
@@ -109,7 +110,7 @@ void WildMonChart::readTable() {
         this->groupNames.append(QString());
         this->groupNamesReversed.append(QString());
     }
-    
+
     // Read data from the table, combining data for duplicate entries
     const QVector<double> tableFrequencies = this->table->percentages();
     const QVector<WildPokemon> tablePokemon = this->table->encounterData().wildPokemon;
@@ -180,7 +181,11 @@ void WildMonChart::refresh() {
 void WildMonChart::refreshSpeciesDistributionChart() {
     if (ui->chartView_SpeciesDistribution->chart())
         ui->chartView_SpeciesDistribution->chart()->deleteLater();
-    ui->chartView_SpeciesDistribution->setChart(createSpeciesDistributionChart());
+
+    QChart *chart = createSpeciesDistributionChart();
+    ui->chartView_SpeciesDistribution->setChart(chart);
+    ui->chartView_SpeciesDistribution->setProject(this->project);
+    ui->chartView_SpeciesDistribution->setSpecies(this->speciesInLegendOrder);
     if (ui->tabWidget->currentWidget() == ui->tabSpecies)
         limitChartAnimation();
 }
@@ -223,64 +228,85 @@ bool WildMonChart::usesGroupLabels() const {
     return this->groupNames.length() > 1;
 }
 
+struct SpeciesFrequency
+{
+    QString name;
+    double frequency;
+};
+
 QChart* WildMonChart::createSpeciesDistributionChart() {
     QList<QBarSet*> barSets;
+    QStringList categories;
+    QList<SpeciesFrequency> speciesList;
+
     for (const auto &species : getSpeciesNamesAlphabetical()) {
-        // Add encounter chance data
-        auto set = new QBarSet(species);
-        for (auto groupName : this->groupNamesReversed)
-            set->append(getSpeciesFrequency(species, groupName) * 100);
-
-        // We order the bar sets from lowest to highest total, left-to-right.
-        for (int i = 0; i < barSets.length() + 1; i++){
-            if (i >= barSets.length() || barSets.at(i)->sum() > set->sum()) {
-                barSets.insert(i, set);
-                break;
-            }
+        for (auto groupName : this->groupNamesReversed) {
+            speciesList.append({species, getSpeciesFrequency(species, groupName) * 100.0});
         }
-
-        // Show species name and % when hovering over a bar set. This covers some shortfalls in our ability to control the chart design
-        // (i.e. bar segments may be too narrow to see the % label, or colors may be hard to match to the legend).
-        connect(set, &QBarSet::hovered, [set] (bool on, int i) {
-            QString text = on ? QString("%1 (%2%)").arg(set->label()).arg(set->at(i)) : "";
-            QToolTip::showText(QCursor::pos(), text);
-        });
     }
 
-    // Preserve the order we set earlier so that the legend isn't shuffling around for the other all-species charts.
-    this->speciesInLegendOrder.clear();
-    for (auto set : barSets)
-        this->speciesInLegendOrder.append(set->label());
+    std::sort(speciesList.begin(), speciesList.end(), [](const auto &a, const auto &b) {
+            return a.frequency < b.frequency;
+    });
+
+    auto *set = new QBarSet("Encounter Rates");
+    for (const auto &entry : speciesList) {
+        set->append(entry.frequency);
+        categories.append(entry.name);
+    }
+
+    barSets.append(set);
+
+    // Show species name and % when hovering over a bar set. This covers some shortfalls in our ability to control the chart design
+    // (i.e. bar segments may be too narrow to see the % label).
+    connect(set, &QBarSet::hovered, [set] (bool on, int i) {
+        QString text = on ? QString("%1 (%2%)").arg(set->label()).arg(set->at(i)) : "";
+        QToolTip::showText(QCursor::pos(), text);
+    });
+
+    // Reverse the order for specieschartview
+    this->speciesInLegendOrder = categories;
+    std::reverse(speciesInLegendOrder.begin(),
+                 speciesInLegendOrder.end());
 
     // Set up series
-    auto series = new QHorizontalPercentBarSeries();
+    auto series = new QHorizontalBarSeries();
     series->setLabelsVisible();
     series->append(barSets);
+    series->setBarWidth(0.8);
 
     // Set up chart
     auto chart = new QChart();
     chart->addSeries(series);
     chart->setTheme(currentTheme());
     chart->setAnimationOptions(QChart::SeriesAnimations);
-    chart->legend()->setVisible(true);
-    chart->legend()->setShowToolTips(true);
-    chart->legend()->setAlignment(Qt::AlignBottom);
-    saveSpeciesColors(barSets);
+    chart->legend()->hide();
+
+    QFontMetrics fm(chart->font());
+
+    int maxTextWidth = 0;
+    for (const QString &category : categories) {
+        maxTextWidth = std::max(maxTextWidth, fm.horizontalAdvance(category));
+    }
+
+    int labelWidth = maxTextWidth + SpeciesChartView::IconSize + SpeciesChartView::Spacing;
+    int leftMargin = labelWidth + 2 * SpeciesChartView::Padding;
+    chart->setMargins(QMargins(leftMargin, 20, 20, 20));
 
     // X-axis is the % frequency. We're already showing percentages on the bar, so we just display 0/50/100%
     auto axisX = new QValueAxis();
+    axisX->setRange(0, 100);
     axisX->setLabelFormat("%u%%");
-    axisX->setTickCount(3);
+    axisX->setTickCount(6);
     chart->addAxis(axisX, Qt::AlignBottom);
     series->attachAxis(axisX);
 
-    // Y-axis is the names of encounter groups (e.g. Old Rod, Good Rod...)
-    if (usesGroupLabels()) {
-        auto axisY = new QBarCategoryAxis();
-        axisY->setCategories(this->groupNamesReversed);
-        chart->addAxis(axisY, Qt::AlignLeft);
-        series->attachAxis(axisY);
-    }
+    // Y-axis is species names + icons
+    auto axisY = new QBarCategoryAxis();
+    axisY->setCategories(categories);
+    axisY->setLabelsVisible(false); // handled in specieschartview.c/h
+    chart->addAxis(axisY, Qt::AlignLeft);
+    series->attachAxis(axisY);
 
     return chart;
 }
@@ -351,7 +377,6 @@ QChart* WildMonChart::createLevelDistributionChart() {
     chart->legend()->setVisible(true);
     chart->legend()->setShowToolTips(true);
     chart->legend()->setAlignment(Qt::AlignBottom);
-    applySpeciesColors(barSets); // Has to happen after theme is set
 
     // X-axis is the level range.
     QBarCategoryAxis *axisX = new QBarCategoryAxis();
@@ -389,11 +414,12 @@ void WildMonChart::updateTheme() {
     if (!chart || chart->series().isEmpty())
         return;
     chart->setTheme(theme);
-    saveSpeciesColors(static_cast<QAbstractBarSeries*>(chart->series().at(0))->barSets());
 
     chart = ui->chartView_LevelDistribution->chart();
     if (!chart || chart->series().isEmpty())
         return;
+
+    saveSpeciesColors(static_cast<QAbstractBarSeries*>(chart->series().at(0))->barSets());
     chart->setTheme(theme);
     applySpeciesColors(static_cast<QAbstractBarSeries*>(chart->series().at(0))->barSets());
 }

--- a/src/ui/wildmonchart.cpp
+++ b/src/ui/wildmonchart.cpp
@@ -78,7 +78,6 @@ void WildMonChart::clearTableData() {
     this->tableIndexToGroupName.clear();
     this->groupedLevelRanges.clear();
     this->speciesToGroupedData.clear();
-    this->speciesToColor.clear();
     setWindowTitle(baseWindowTitle);
 
     const QSignalBlocker blocker1(ui->comboBox_Species);
@@ -303,13 +302,18 @@ QChart* WildMonChart::createSpeciesDistributionChart() {
     int maxTextWidth = 0;
     for (const QString &category : categories) {
         maxTextWidth = std::max(maxTextWidth, fm.horizontalAdvance(category));
+
+        if (maxTextWidth > SpeciesChartView::MaxLabelWidth) {
+            maxTextWidth = SpeciesChartView::MaxLabelWidth;
+            break;
+        }
     }
 
     int labelWidth = maxTextWidth + SpeciesChartView::IconSize + SpeciesChartView::Spacing;
     int leftMargin = labelWidth + 2 * SpeciesChartView::Padding;
     chart->setMargins(QMargins(leftMargin, 20, 20, 20));
 
-    // X-axis is the % frequency. We're already showing percentages on the bar, so we just display 0/50/100%
+    // X-axis is the % frequency.
     auto axisX = new QValueAxis();
     axisX->setRange(0, 100);
     axisX->setLabelFormat("%u%%");
@@ -435,20 +439,7 @@ void WildMonChart::updateTheme() {
     if (!chart || chart->series().isEmpty())
         return;
 
-    saveSpeciesColors(static_cast<QAbstractBarSeries*>(chart->series().at(0))->barSets());
     chart->setTheme(theme);
-    applySpeciesColors(static_cast<QAbstractBarSeries*>(chart->series().at(0))->barSets());
-}
-
-void WildMonChart::saveSpeciesColors(const QList<QBarSet*> &barSets) {
-    this->speciesToColor.clear();
-    for (auto set : barSets)
-        this->speciesToColor.insert(set->label(), set->color());
-}
-
-void WildMonChart::applySpeciesColors(const QList<QBarSet*> &barSets) {
-    for (auto set : barSets)
-        set->setColor(this->speciesToColor.value(set->label()));
 }
 
 // Turn off the chart animation once it's played, otherwise it replays any time the window changes size.

--- a/src/ui/wildmonchart.cpp
+++ b/src/ui/wildmonchart.cpp
@@ -35,6 +35,7 @@ WildMonChart::WildMonChart(QWidget *parent, const EncounterTableModel *table, Pr
     connect(ui->groupBox_Species, &QGroupBox::clicked, this, &WildMonChart::refreshLevelDistributionChart);
     connect(ui->comboBox_Species, &QComboBox::currentTextChanged, this, &WildMonChart::refreshLevelDistributionChart);
     connect(ui->comboBox_Group, &QComboBox::currentTextChanged, this, &WildMonChart::refreshLevelDistributionChart);
+    connect(ui->comboBox_speciesDistributionGroup, &QComboBox::currentTextChanged, this, &WildMonChart::refreshSpeciesDistributionChart);
 
     connect(ui->tabWidget, &QTabWidget::currentChanged, this, &WildMonChart::limitChartAnimation);
 
@@ -82,10 +83,14 @@ void WildMonChart::clearTableData() {
 
     const QSignalBlocker blocker1(ui->comboBox_Species);
     const QSignalBlocker blocker2(ui->comboBox_Group);
+    const QSignalBlocker blocker3(ui->comboBox_speciesDistributionGroup);
     ui->comboBox_Species->clear();
     ui->comboBox_Group->clear();
     ui->comboBox_Group->setEnabled(false);
+    ui->comboBox_speciesDistributionGroup->clear();
+    ui->comboBox_speciesDistributionGroup->setEnabled(false);
     ui->label_Group->setEnabled(false);
+    ui->label_speciesDistributionGroup->setEnabled(false);
 }
 
 // Extract all the data from the table that we need for the charts
@@ -150,20 +155,27 @@ void WildMonChart::readTable() {
     // Populate combo boxes
     const QSignalBlocker blocker1(ui->comboBox_Species);
     const QSignalBlocker blocker2(ui->comboBox_Group);
+    const QSignalBlocker blocker3(ui->comboBox_speciesDistributionGroup);
     ui->comboBox_Species->clear();
     ui->comboBox_Species->addItems(getSpeciesNamesAlphabetical());
     ui->comboBox_Group->clear();
     ui->comboBox_Group->addItems(this->groupNames);
+    ui->comboBox_speciesDistributionGroup->clear();
+    ui->comboBox_speciesDistributionGroup->addItems(this->groupNames);
     bool enableGroupSelection = usesGroupLabels();
     ui->comboBox_Group->setEnabled(enableGroupSelection);
+    ui->comboBox_speciesDistributionGroup->setEnabled(enableGroupSelection);
     ui->label_Group->setEnabled(enableGroupSelection);
+    ui->label_speciesDistributionGroup->setEnabled(enableGroupSelection);
 }
 
 void WildMonChart::refresh() {
     const QSignalBlocker blocker1(ui->comboBox_Species);
     const QSignalBlocker blocker2(ui->comboBox_Group);
+    const QSignalBlocker blocker3(ui->comboBox_speciesDistributionGroup);
     const QString oldSpecies = ui->comboBox_Species->currentText();
     const QString oldGroup = ui->comboBox_Group->currentText();
+    const QString oldSpeciesGroup = ui->comboBox_speciesDistributionGroup->currentText();
 
     readTable();
 
@@ -173,6 +185,9 @@ void WildMonChart::refresh() {
 
     index = ui->comboBox_Group->findText(oldGroup);
     if (index >= 0) ui->comboBox_Group->setCurrentIndex(index);
+
+    index = ui->comboBox_speciesDistributionGroup->findText(oldSpeciesGroup);
+    if (index >= 0) ui->comboBox_speciesDistributionGroup->setCurrentIndex(index);
 
     refreshSpeciesDistributionChart();
     refreshLevelDistributionChart();
@@ -235,14 +250,13 @@ struct SpeciesFrequency
 };
 
 QChart* WildMonChart::createSpeciesDistributionChart() {
+    const QString groupName = ui->comboBox_speciesDistributionGroup->currentText();
     QList<QBarSet*> barSets;
     QStringList categories;
     QList<SpeciesFrequency> speciesList;
 
     for (const auto &species : getSpeciesNamesAlphabetical()) {
-        for (auto groupName : this->groupNamesReversed) {
-            speciesList.append({species, getSpeciesFrequency(species, groupName) * 100.0});
-        }
+        speciesList.append({species, getSpeciesFrequency(species, groupName) * 100.0});
     }
 
     std::sort(speciesList.begin(), speciesList.end(), [](const auto &a, const auto &b) {
@@ -251,8 +265,10 @@ QChart* WildMonChart::createSpeciesDistributionChart() {
 
     auto *set = new QBarSet("Encounter Rates");
     for (const auto &entry : speciesList) {
-        set->append(entry.frequency);
-        categories.append(entry.name);
+        if (entry.frequency > 0.0) {
+            set->append(entry.frequency);
+            categories.append(entry.name);
+        }
     }
 
     barSets.append(set);
@@ -359,7 +375,7 @@ QChart* WildMonChart::createLevelDistributionChart() {
         levelRange = getLevelRange(species, groupName);
     } else {
         // Species box is inactive, we display data for all species in the table.
-        for (const auto &species : this->speciesInLegendOrder)
+        for (const auto &species : getSpeciesNamesAlphabetical())
             barSets.append(createLevelDistributionBarSet(species, groupName, false));
         levelRange = this->groupedLevelRanges.value(groupName);
     }


### PR DESCRIPTION
Redesigns the species distrubtion chart showing 1 horizontal bar per species. This allows for y-axis labels to include species + icon, making it visually easier to connect a species with its bar.
Example:  
<img width="767" height="468" alt="image" src="https://github.com/user-attachments/assets/0f7aae7d-bd67-45c4-8755-d1fe323f4426" />
